### PR TITLE
refactor: rename git-registry to http-registry with flat index layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fastskill"
-version = "0.7.9"
+version = "0.7.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1338,21 +1338,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1791,19 +1776,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -2327,23 +2299,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,32 +2381,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "openssl-probe"
@@ -2897,16 +2826,16 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-tls",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.12",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2914,7 +2843,7 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -2922,6 +2851,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -3636,16 +3566,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4117,6 +4037,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -60,7 +60,8 @@ pub async fn execute_install(args: InstallArgs) -> CliResult<()> {
     service.initialize().await.map_err(CliError::Service)?;
 
     // Load repositories and create sources manager for marketplace-based repos
-    let repos_path = PathBuf::from(".claude/repositories.toml");
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = RepositoryManager::new(repos_path);
     repo_manager
         .load()
@@ -367,8 +368,8 @@ fn create_sources_manager_from_repositories(
                     None
                 }
             }
-            RepositoryType::GitRegistry => {
-                // Git-registry repos don't work with SourcesManager, skip them
+            RepositoryType::HttpRegistry => {
+                // Http-registry repos don't work with SourcesManager, skip them
                 None
             }
         };

--- a/src/cli/commands/registry.rs
+++ b/src/cli/commands/registry.rs
@@ -38,10 +38,10 @@ pub enum RegistryCommand {
     Add {
         /// Repository name
         name: String,
-        /// Repository type: git-marketplace, git-registry, zip-url, or local
+        /// Repository type: git-marketplace, http-registry, zip-url, or local
         #[arg(long)]
         repo_type: String,
-        /// URL for git-marketplace or git-registry, base_url for zip-url, or path for local
+        /// URL for git-marketplace or http-registry, base_url for zip-url, or path for local
         url_or_path: String,
         /// Priority (lower number = higher priority, default: 0)
         #[arg(long)]
@@ -241,7 +241,8 @@ pub async fn execute_registry(args: RegistryArgs) -> CliResult<()> {
 // Repository management functions
 
 async fn execute_list() -> CliResult<()> {
-    let repos_path = PathBuf::from(".claude/repositories.toml");
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = RepositoryManager::new(repos_path);
     repo_manager
         .load()
@@ -255,7 +256,7 @@ async fn execute_list() -> CliResult<()> {
         for repo in repos {
             let repo_type_str = match repo.repo_type {
                 RepositoryType::GitMarketplace => "git-marketplace",
-                RepositoryType::GitRegistry => "git-registry",
+                RepositoryType::HttpRegistry => "http-registry",
                 RepositoryType::ZipUrl => "zip-url",
                 RepositoryType::Local => "local",
             };
@@ -280,7 +281,8 @@ async fn execute_add(
     auth_key_path: Option<PathBuf>,
     auth_username: Option<String>,
 ) -> CliResult<()> {
-    let repos_path = PathBuf::from(".claude/repositories.toml");
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = RepositoryManager::new(repos_path);
     repo_manager
         .load()
@@ -289,12 +291,12 @@ async fn execute_add(
     // Parse repository type
     let repo_type_enum = match repo_type.as_str() {
         "git-marketplace" => RepositoryType::GitMarketplace,
-        "git-registry" => RepositoryType::GitRegistry,
+        "http-registry" => RepositoryType::HttpRegistry,
         "zip-url" => RepositoryType::ZipUrl,
         "local" => RepositoryType::Local,
         _ => {
             return Err(CliError::Config(format!(
-            "Invalid repository type: {}. Use: git-marketplace, git-registry, zip-url, or local",
+            "Invalid repository type: {}. Use: git-marketplace, http-registry, zip-url, or local",
             repo_type
         )))
         }
@@ -307,7 +309,7 @@ async fn execute_add(
             branch,
             tag,
         },
-        RepositoryType::GitRegistry => RepositoryConfig::GitRegistry {
+        RepositoryType::HttpRegistry => RepositoryConfig::HttpRegistry {
             index_url: url_or_path,
         },
         RepositoryType::ZipUrl => RepositoryConfig::ZipUrl {
@@ -389,7 +391,8 @@ async fn execute_add(
 }
 
 async fn execute_remove(name: String) -> CliResult<()> {
-    let repos_path = PathBuf::from(".claude/repositories.toml");
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = RepositoryManager::new(repos_path);
     repo_manager
         .load()
@@ -407,7 +410,8 @@ async fn execute_remove(name: String) -> CliResult<()> {
 }
 
 async fn execute_show(name: String) -> CliResult<()> {
-    let repos_path = PathBuf::from(".claude/repositories.toml");
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = RepositoryManager::new(repos_path);
     repo_manager
         .load()
@@ -419,7 +423,7 @@ async fn execute_show(name: String) -> CliResult<()> {
 
     let repo_type_str = match repo.repo_type {
         RepositoryType::GitMarketplace => "git-marketplace",
-        RepositoryType::GitRegistry => "git-registry",
+        RepositoryType::HttpRegistry => "http-registry",
         RepositoryType::ZipUrl => "zip-url",
         RepositoryType::Local => "local",
     };
@@ -438,7 +442,7 @@ async fn execute_show(name: String) -> CliResult<()> {
                 println!("  Tag: {}", t);
             }
         }
-        RepositoryConfig::GitRegistry { index_url } => {
+        RepositoryConfig::HttpRegistry { index_url } => {
             println!("  Index URL: {}", index_url);
         }
         RepositoryConfig::ZipUrl { base_url } => {
@@ -465,7 +469,8 @@ async fn execute_update(
     branch: Option<String>,
     priority: Option<u32>,
 ) -> CliResult<()> {
-    let repos_path = PathBuf::from(".claude/repositories.toml");
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = RepositoryManager::new(repos_path);
     repo_manager
         .load()
@@ -523,7 +528,8 @@ async fn execute_update(
 }
 
 async fn execute_test(name: String) -> CliResult<()> {
-    let repos_path = PathBuf::from(".claude/repositories.toml");
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = RepositoryManager::new(repos_path);
     repo_manager
         .load()
@@ -586,7 +592,8 @@ async fn execute_refresh(name: Option<String>) -> CliResult<()> {
 // Skill browsing functions
 
 async fn execute_list_skills(repository: Option<String>) -> CliResult<()> {
-    let repos_path = PathBuf::from(".claude/repositories.toml");
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = RepositoryManager::new(repos_path);
     repo_manager
         .load()
@@ -646,7 +653,8 @@ async fn execute_list_skills(repository: Option<String>) -> CliResult<()> {
 }
 
 async fn execute_show_skill(skill_id: String, repository: Option<String>) -> CliResult<()> {
-    let repos_path = PathBuf::from(".claude/repositories.toml");
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = RepositoryManager::new(repos_path);
     repo_manager
         .load()
@@ -707,7 +715,8 @@ async fn execute_show_skill(skill_id: String, repository: Option<String>) -> Cli
 }
 
 async fn execute_versions(skill_id: String, repository: Option<String>) -> CliResult<()> {
-    let repos_path = PathBuf::from(".claude/repositories.toml");
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = RepositoryManager::new(repos_path);
     repo_manager
         .load()
@@ -760,7 +769,8 @@ async fn execute_versions(skill_id: String, repository: Option<String>) -> CliRe
 }
 
 async fn execute_search(query: String, repository: Option<String>) -> CliResult<()> {
-    let repos_path = PathBuf::from(".claude/repositories.toml");
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = RepositoryManager::new(repos_path);
     repo_manager
         .load()

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -112,7 +112,8 @@ pub async fn execute_update(args: UpdateArgs) -> CliResult<()> {
     };
 
     // Load repositories and create sources manager for marketplace-based repos
-    let repos_path = PathBuf::from(".claude/repositories.toml");
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = RepositoryManager::new(repos_path);
     repo_manager
         .load()
@@ -169,7 +170,8 @@ pub async fn execute_update(args: UpdateArgs) -> CliResult<()> {
     service.initialize().await.map_err(CliError::Service)?;
 
     // Load repositories and create sources manager for marketplace-based repos
-    let repos_path = PathBuf::from(".claude/repositories.toml");
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = RepositoryManager::new(repos_path);
     repo_manager
         .load()
@@ -495,8 +497,8 @@ fn create_sources_manager_from_repositories(
                     None
                 }
             }
-            RepositoryType::GitRegistry => {
-                // Git-registry repos don't work with SourcesManager, skip them
+            RepositoryType::HttpRegistry => {
+                // Http-registry repos don't work with SourcesManager, skip them
                 None
             }
         };

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -17,20 +17,24 @@ pub struct GitUrlInfo {
     pub subdir: Option<PathBuf>,
 }
 
-/// Detect if input is a skill ID (format: skillid@version or skillid)
+/// Detect if input is a skill ID (format: skillid@version, skillid, or scope/skillid@version)
 pub fn is_skill_id(input: &str) -> bool {
     // Skill ID format: alphanumeric with dashes/underscores, optionally followed by @version
-    // Examples: pptx@1.2.3, web-scraper, my_skill@2.0.0
-    // Must not contain path separators or be a URL
-    if input.contains('/') || input.contains('\\') || input.contains(':') {
+    // Can also be scoped: scope/skillid or scope/skillid@version
+    // Examples: pptx@1.2.3, web-scraper, my_skill@2.0.0, dev-user/test-skill, org/my-skill@1.0.0
+    // Must not contain backslashes or colons (URL schemes)
+    if input.contains('\\') || input.contains(':') {
         return false;
     }
 
     // Check if it looks like a skill ID (not a file path)
+    // Supports both unscoped (skillid) and scoped (scope/skillid) formats
     // This regex is a compile-time constant pattern, so it should never fail
     #[allow(clippy::expect_used)]
-    let skill_id_pattern = regex::Regex::new(r"^[a-zA-Z0-9_-]+(@[0-9]+\.[0-9]+(\.[0-9]+)?.*)?$")
-        .expect("Invalid regex pattern");
+    let skill_id_pattern = regex::Regex::new(
+        r"^[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)?(@[0-9]+\.[0-9]+(\.[0-9]+)?.*)?$"
+    )
+    .expect("Invalid regex pattern");
     skill_id_pattern.is_match(input)
 }
 

--- a/src/cli/utils/install_utils.rs
+++ b/src/cli/utils/install_utils.rs
@@ -250,8 +250,9 @@ async fn install_from_source(
     use fastskill::core::version::VersionConstraint;
     use std::sync::Arc;
 
-    // Create resolver - load from repositories.toml
-    let repos_path = std::path::PathBuf::from(".claude/repositories.toml");
+    // Create resolver - load from repositories.toml (searches up directory tree)
+    let repos_path = crate::cli::config::get_repositories_toml_path()
+        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
     let mut repo_manager = fastskill::core::repository::RepositoryManager::new(repos_path);
     repo_manager
         .load()
@@ -393,8 +394,8 @@ fn create_sources_manager_from_repositories(
                     None
                 }
             }
-            RepositoryType::GitRegistry => {
-                // Git-registry repos don't work with SourcesManager, skip them
+            RepositoryType::HttpRegistry => {
+                // Http-registry repos don't work with SourcesManager, skip them
                 None
             }
         };

--- a/src/core/registry/client.rs
+++ b/src/core/registry/client.rs
@@ -69,55 +69,11 @@ impl RegistryClient {
         })
     }
 
-    /// Get the index URL for a skill (crates.io format: single file per skill)
+    /// Get the index URL for a skill (flat layout: scope/skill-name)
     fn get_index_url(&self, skill_id: &str) -> String {
-        // Use crates.io directory structure: 1/{name}, 2/{name}, 3/{first}/{name}, or {first2}/{second2}/{name}
-        let chars: Vec<char> = skill_id.chars().collect();
-
-        let path = match chars.len() {
-            1 => format!("1/{}", skill_id),
-            2 => format!("2/{}", skill_id),
-            3 => {
-                let first: String = chars[0..1].iter().collect();
-                format!("3/{}/{}", first, skill_id)
-            }
-            _ => {
-                let first_two: String = chars[0..2].iter().collect();
-                let next_two: String = chars[2..4].iter().collect();
-                format!("{}/{}/{}", first_two, next_two, skill_id)
-            }
-        };
-
-        // Construct URL based on registry type
-        if self.config.index_url.contains("github.com") {
-            // GitHub raw content URL
-            let repo_path = self
-                .config
-                .index_url
-                .trim_start_matches("https://github.com/")
-                .trim_end_matches(".git");
-            format!(
-                "https://raw.githubusercontent.com/{}/main/{}",
-                repo_path, path
-            )
-        } else if self.config.index_url.starts_with("sparse+") {
-            // Sparse registry format: sparse+https://api.example.com/index/
-            // We've already verified it starts with "sparse+", so strip_prefix will always succeed
-            let base_url = self
-                .config
-                .index_url
-                .strip_prefix("sparse+")
-                .unwrap_or_else(|| {
-                    // This should never happen since we checked starts_with above
-                    &self.config.index_url
-                });
-            format!("{}/{}", base_url.trim_end_matches('/'), path)
-        } else {
-            // Custom registry URL (HTTP-based or other)
-            // index_url should be the base URL for the index (e.g., https://api.fastskill.io/index)
-            // We just append the path
-            format!("{}/{}", self.config.index_url.trim_end_matches('/'), path)
-        }
+        // Flat layout: use skill_id directly (e.g., "dev-user/test-skill")
+        // index_url should be the base URL for the index (e.g., http://159.69.182.11:8080/index)
+        format!("{}/{}", self.config.index_url.trim_end_matches('/'), skill_id)
     }
 
     /// Get skill information from registry

--- a/src/core/repository.rs
+++ b/src/core/repository.rs
@@ -47,8 +47,8 @@ fn default_priority() -> u32 {
 pub enum RepositoryType {
     /// Git repository with marketplace.json
     GitMarketplace,
-    /// Git repository with crates.io-style index
-    GitRegistry,
+    /// HTTP-based registry with flat index layout
+    HttpRegistry,
     /// ZIP URL base with marketplace.json
     ZipUrl,
     /// Local directory
@@ -67,8 +67,8 @@ pub enum RepositoryConfig {
         #[serde(default)]
         tag: Option<String>,
     },
-    /// Git registry configuration
-    GitRegistry { index_url: String },
+    /// HTTP registry configuration
+    HttpRegistry { index_url: String },
     /// ZIP URL configuration
     ZipUrl { base_url: String },
     /// Local path configuration

--- a/src/core/repository/client.rs
+++ b/src/core/repository/client.rs
@@ -49,7 +49,7 @@ pub async fn create_client(
         RepositoryType::GitMarketplace | RepositoryType::ZipUrl | RepositoryType::Local => {
             Ok(Arc::new(MarketplaceRepositoryClient::new(repo)?))
         }
-        RepositoryType::GitRegistry => Ok(Arc::new(CratesRegistryClient::new(repo)?)),
+        RepositoryType::HttpRegistry => Ok(Arc::new(CratesRegistryClient::new(repo)?)),
     }
 }
 
@@ -116,9 +116,9 @@ impl MarketplaceRepositoryClient {
                 }
             }
             RepositoryConfig::Local { path } => SourceConfig::Local { path: path.clone() },
-            RepositoryConfig::GitRegistry { .. } => {
+            RepositoryConfig::HttpRegistry { .. } => {
                 return Err(ServiceError::Custom(
-                    "GitRegistry should use CratesRegistryClient".to_string(),
+                    "HttpRegistry should use CratesRegistryClient".to_string(),
                 ));
             }
         };
@@ -225,7 +225,7 @@ impl RepositoryClient for MarketplaceRepositoryClient {
     }
 }
 
-/// Crates.io-style registry client (wraps RegistryClient logic)
+/// HTTP registry client (wraps RegistryClient logic)
 pub struct CratesRegistryClient {
     registry_client: RegistryClient,
 }
@@ -233,10 +233,10 @@ pub struct CratesRegistryClient {
 impl CratesRegistryClient {
     pub fn new(repo: &RepositoryDefinition) -> Result<Self, ServiceError> {
         let index_url = match &repo.config {
-            RepositoryConfig::GitRegistry { index_url } => index_url.clone(),
+            RepositoryConfig::HttpRegistry { index_url } => index_url.clone(),
             _ => {
                 return Err(ServiceError::Custom(
-                    "GitRegistry requires index_url".to_string(),
+                    "HttpRegistry requires index_url".to_string(),
                 ))
             }
         };
@@ -295,7 +295,7 @@ impl CratesRegistryClient {
 #[async_trait::async_trait]
 impl RepositoryClient for CratesRegistryClient {
     async fn list_skills(&self) -> Result<Vec<SkillMetadata>, RepositoryClientError> {
-        // Crates.io-style registries don't have a simple "list all" - would need to scan index
+        // HTTP registries don't have a simple "list all" - would need to scan index
         Err(RepositoryClientError::NotImplemented)
     }
 

--- a/src/core/sources.rs
+++ b/src/core/sources.rs
@@ -26,7 +26,7 @@ pub struct SourceDefinition {
 impl SourceDefinition {
     /// Check if this source supports listing skills
     /// Returns true for git-marketplace, zip-url, and local sources
-    /// Returns false for crates.io-style registries (git-registry)
+    /// Returns false for HTTP registries (http-registry)
     pub fn supports_listing(&self) -> bool {
         matches!(
             &self.source,

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -478,6 +478,8 @@ impl FastSkillServer {
                 .fallback_service(ServeDir::new(static_dir.clone()));
 
             router = router
+                // Registry index file serving (flat layout: /index/{scope}/{skill-name})
+                .route("/index/*skill_id", get(registry::serve_index_file))
                 // Registry API endpoints
                 .route("/api/registry/sources", get(registry::list_sources))
                 .route("/api/registry/skills", get(registry::list_all_skills))


### PR DESCRIPTION
- Rename GitRegistry to HttpRegistry throughout codebase
- Remove crates.io sparse layout logic
- Implement flat index layout: {scope}/{skill-name}
- Add HTTP endpoint /index/*skill_id to serve index files
- Update all CLI commands and handlers
- Update repositories.toml format (git-registry -> http-registry)

Breaking: Repository type changed from git-registry to http-registry