### PR TITLE
Fix GitHub Actions release build errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fastskill"
-version = "0.9.36"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/bin/fastskill.rs"
 
 [dependencies]
 # Async runtime
-tokio = { version = "1.0", features = ["rt-multi-thread", "net", "fs", "io-util", "macros"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "net", "fs", "io-util", "macros", "process"] }
 async-trait = "0.1"
 futures = "0.3"
 


### PR DESCRIPTION
This PR fixes the compilation errors that were occurring in the GitHub Actions release workflow.

## Changes Made

- **Added 'process' feature to tokio dependency** in Cargo.toml to enable  usage
- **Gated S3 blob storage code** behind the 'registry-publish' feature flag to prevent compilation errors when AWS dependencies are not available  
- **Conditionally imported tracing::info** macro for S3 logging only when the feature is enabled
- **Resolved type annotation issues** that were cascading from missing dependencies

## Problem Solved

The release workflow was failing because the cross-compilation for musl targets used  which excluded the AWS SDK dependencies, but the S3 code was still being compiled unconditionally.