### PR TITLE
fix: use GitHub App token for auto-deploy workflow

### DIFF
--- a/.github/workflows/auto-deploy-on-merge.yml
+++ b/.github/workflows/auto-deploy-on-merge.yml
@@ -11,10 +11,21 @@ jobs:
   trigger-deploy:
     name: Trigger Deployment on Merge
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.GH_APP_ID }}
+          private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Trigger Release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "Pull request merged to main - triggering deployment..."
           gh workflow run release.yml -f version=latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fastskill"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Summary
Fix the auto-deploy workflow to use GitHub App token authentication instead of individual user tokens.

## Problem
The auto-deploy workflow was failing with:
```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
Error: Process completed with exit code 4.
```

## Solution
- Add GitHub App token generation using `tibdex/github-app-token@v1` action
- Set `GH_TOKEN` environment variable for gh CLI authentication
- Add condition to only run when PR is actually merged (not just closed)
- Follow the same authentication pattern as used in `release.yml`

## Changes
- Updated `.github/workflows/auto-deploy-on-merge.yml`:
  - Added GitHub App token generation step
  - Set proper GH_TOKEN environment variable
  - Added merge condition check

## Test Plan
- [x] Pre-commit checks pass
- [x] Pre-push checks pass
- [x] All tests pass
- [ ] Workflow will be tested on merge to verify proper token generation

## References
- Uses same GitHub App credentials as `release.yml` workflow
- Requires `GH_APP_ID` and `GH_APP_PRIVATE_KEY` secrets to be configured

🤖 Generated with Claude Code