### PR TITLE
refactor: consolidate configuration to skill-project.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -322,3 +322,4 @@ commondir
 gitdir
 index
 .newton
+CLAUDE.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fastskill"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/cli/commands/add.rs
+++ b/src/cli/commands/add.rs
@@ -543,13 +543,9 @@ async fn add_from_registry(
         )));
     };
 
-    // Load repository configuration from repositories.toml (searches up directory tree)
-    let repos_path = crate::cli::config::get_repositories_toml_path()
-        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
-    let mut repo_manager = RepositoryManager::new(repos_path);
-    repo_manager
-        .load()
-        .map_err(|e| CliError::Config(format!("Failed to load repositories: {}", e)))?;
+    // Load repository configuration from skill-project.toml [tool.fastskill.repositories]
+    let repositories = crate::cli::config::load_repositories_from_project()?;
+    let repo_manager = RepositoryManager::from_definitions(repositories);
 
     // Get default repository (prefer http-registry type, fallback to any)
     let default_repo = repo_manager.get_default_repository().ok_or_else(|| {

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -87,21 +87,13 @@ pub async fn execute_install(args: InstallArgs) -> CliResult<()> {
             }
         }
 
-        // Fall back to old repositories.toml path
-        let repos_path = crate::cli::config::get_repositories_toml_path()
-            .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
-        let mut rm = RepositoryManager::new(repos_path);
-        rm.load()
-            .map_err(|e| CliError::Config(format!("Failed to load repositories: {}", e)))?;
-        rm
+        // Load from skill-project.toml [tool.fastskill.repositories]
+        let repositories = crate::cli::config::load_repositories_from_project()?;
+        RepositoryManager::from_definitions(repositories)
     } else {
-        // No skill-project.toml, use old repositories.toml
-        let repos_path = crate::cli::config::get_repositories_toml_path()
-            .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
-        let mut rm = RepositoryManager::new(repos_path);
-        rm.load()
-            .map_err(|e| CliError::Config(format!("Failed to load repositories: {}", e)))?;
-        rm
+        // No skill-project.toml, load from skill-project.toml if available
+        let repositories = crate::cli::config::load_repositories_from_project()?;
+        RepositoryManager::from_definitions(repositories)
     };
 
     // Create SourcesManager from marketplace-based repositories for PackageResolver

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -1,7 +1,7 @@
 //! List locally installed skills command
 //!
 //! Similar to `pip list` or `uv list`, this command lists all locally installed skills
-//! and reconciles them against skills-project.toml and skills-lock.toml
+//! and reconciles them against skill-project.toml and skills.lock
 
 use crate::cli::error::{CliError, CliResult};
 use crate::cli::utils::messages;
@@ -74,53 +74,53 @@ pub async fn execute_list(service: &FastSkillService, args: ListArgs) -> CliResu
     Ok(())
 }
 
-/// Resolve skills-project.toml path
+/// Resolve skill-project.toml path
 fn resolve_project_file(skills_dir: &Path) -> PathBuf {
-    // Try .claude/skills-project.toml first (common location)
+    // Try .claude/skill-project.toml first (common location)
     if let Some(parent) = skills_dir.parent() {
-        let project_file = parent.join("skills-project.toml");
+        let project_file = parent.join("skill-project.toml");
         if project_file.exists() {
             return project_file;
         }
     }
 
     // Try current directory
-    let project_file = PathBuf::from("skills-project.toml");
+    let project_file = PathBuf::from("skill-project.toml");
     if project_file.exists() {
         return project_file;
     }
 
-    // Default to .claude/skills-project.toml
+    // Default to .claude/skill-project.toml
     skills_dir
         .parent()
         .unwrap_or_else(|| Path::new("."))
-        .join("skills-project.toml")
+        .join("skill-project.toml")
 }
 
-/// Resolve skills-lock.toml path
+/// Resolve skills.lock path
 fn resolve_lock_file(skills_dir: &Path) -> PathBuf {
-    // Try .claude/skills-lock.toml first (common location)
+    // Try .claude/skills.lock first (common location)
     if let Some(parent) = skills_dir.parent() {
-        let lock_file = parent.join("skills-lock.toml");
+        let lock_file = parent.join("skills.lock");
         if lock_file.exists() {
             return lock_file;
         }
     }
 
     // Try current directory
-    let lock_file = PathBuf::from("skills-lock.toml");
+    let lock_file = PathBuf::from("skills.lock");
     if lock_file.exists() {
         return lock_file;
     }
 
-    // Default to .claude/skills-lock.toml
+    // Default to .claude/skills.lock
     skills_dir
         .parent()
         .unwrap_or_else(|| Path::new("."))
-        .join("skills-lock.toml")
+        .join("skills.lock")
 }
 
-/// Load dependencies from skills-project.toml
+/// Load dependencies from skill-project.toml
 fn load_project_file(path: &Path) -> Result<HashMap<String, Option<String>>, CliError> {
     if !path.exists() {
         return Ok(HashMap::new());
@@ -145,7 +145,7 @@ fn load_project_file(path: &Path) -> Result<HashMap<String, Option<String>>, Cli
     Ok(deps)
 }
 
-/// Load locked versions from skills-lock.toml
+/// Load locked versions from skills.lock
 fn load_lock_file(path: &Path) -> Result<HashMap<String, String>, CliError> {
     if !path.exists() {
         return Ok(HashMap::new());
@@ -237,7 +237,7 @@ fn format_list_grid(report: &ReconciliationReport) -> CliResult<()> {
     if !report.missing.is_empty() {
         println!(
             "\n{}",
-            messages::warning("Missing Dependencies (in skills-project.toml but not installed):")
+            messages::warning("Missing Dependencies (in skill-project.toml but not installed):")
         );
         for entry in &report.missing {
             println!("  • {} (not installed)", entry.id);
@@ -248,7 +248,7 @@ fn format_list_grid(report: &ReconciliationReport) -> CliResult<()> {
     if !report.extraneous.is_empty() {
         println!(
             "\n{}",
-            messages::warning("Extraneous Packages (installed but not in skills-project.toml):")
+            messages::warning("Extraneous Packages (installed but not in skill-project.toml):")
         );
         for skill in &report.extraneous {
             println!("  • {} v{}", skill.id, skill.version);
@@ -259,9 +259,7 @@ fn format_list_grid(report: &ReconciliationReport) -> CliResult<()> {
     if !report.version_mismatches.is_empty() {
         println!(
             "\n{}",
-            messages::warning(
-                "Version Mismatches (installed version differs from skills-lock.toml):"
-            )
+            messages::warning("Version Mismatches (installed version differs from skills.lock):")
         );
         for mismatch in &report.version_mismatches {
             println!(

--- a/src/cli/commands/publish.rs
+++ b/src/cli/commands/publish.rs
@@ -52,13 +52,9 @@ pub async fn execute_publish(args: PublishArgs) -> CliResult<()> {
 
     // Determine target (API URL or local path)
     let target = if let Some(registry_name) = &args.registry {
-        // Load from repositories.toml (searches up directory tree)
-        let repos_path = crate::cli::config::get_repositories_toml_path()
-            .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
-        let mut repo_manager = RepositoryManager::new(repos_path);
-        repo_manager
-            .load()
-            .map_err(|e| CliError::Config(format!("Failed to load repositories: {}", e)))?;
+        // Load from skill-project.toml [tool.fastskill.repositories]
+        let repositories = crate::cli::config::load_repositories_from_project()?;
+        let repo_manager = RepositoryManager::from_definitions(repositories);
 
         let repo = repo_manager.get_repository(registry_name).ok_or_else(|| {
             CliError::Config(format!(

--- a/src/cli/commands/registry/helpers.rs
+++ b/src/cli/commands/registry/helpers.rs
@@ -5,13 +5,8 @@ use fastskill::core::repository::{
 use std::path::PathBuf;
 
 pub async fn load_repo_manager() -> CliResult<RepositoryManager> {
-    let repos_path = crate::cli::config::get_repositories_toml_path()
-        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
-    let mut repo_manager = RepositoryManager::new(repos_path);
-    repo_manager
-        .load()
-        .map_err(|e| CliError::Config(format!("Failed to load repositories: {}", e)))?;
-    Ok(repo_manager)
+    let repositories = crate::cli::config::load_repositories_from_project()?;
+    Ok(RepositoryManager::from_definitions(repositories))
 }
 
 pub fn resolve_repository_name(

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -130,12 +130,8 @@ pub async fn execute_update(args: UpdateArgs) -> CliResult<()> {
     };
 
     // Load repositories and create sources manager for marketplace-based repos
-    let repos_path = crate::cli::config::get_repositories_toml_path()
-        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
-    let mut repo_manager = RepositoryManager::new(repos_path);
-    repo_manager
-        .load()
-        .map_err(|e| CliError::Config(format!("Failed to load repositories: {}", e)))?;
+    let repositories = crate::cli::config::load_repositories_from_project()?;
+    let repo_manager = RepositoryManager::from_definitions(repositories);
 
     // Create SourcesManager from marketplace-based repositories for PackageResolver
     let sources_manager = create_sources_manager_from_repositories(&repo_manager)?;
@@ -188,12 +184,8 @@ pub async fn execute_update(args: UpdateArgs) -> CliResult<()> {
     service.initialize().await.map_err(CliError::Service)?;
 
     // Load repositories and create sources manager for marketplace-based repos
-    let repos_path = crate::cli::config::get_repositories_toml_path()
-        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
-    let mut repo_manager = RepositoryManager::new(repos_path);
-    repo_manager
-        .load()
-        .map_err(|e| CliError::Config(format!("Failed to load repositories: {}", e)))?;
+    let repositories = crate::cli::config::load_repositories_from_project()?;
+    let repo_manager = RepositoryManager::from_definitions(repositories);
 
     // Create SourcesManager from marketplace-based repositories for PackageResolver
     let sources_manager = create_sources_manager_from_repositories(&repo_manager)?;

--- a/src/cli/utils/install_utils.rs
+++ b/src/cli/utils/install_utils.rs
@@ -244,13 +244,10 @@ async fn install_from_source(
     use fastskill::core::version::VersionConstraint;
     use std::sync::Arc;
 
-    // Create resolver - load from repositories.toml (searches up directory tree)
-    let repos_path = crate::cli::config::get_repositories_toml_path()
-        .map_err(|e| CliError::Config(format!("Failed to find repositories.toml: {}", e)))?;
-    let mut repo_manager = fastskill::core::repository::RepositoryManager::new(repos_path);
-    repo_manager
-        .load()
-        .map_err(|e| CliError::Config(format!("Failed to load repositories: {}", e)))?;
+    // Create resolver - load from skill-project.toml [tool.fastskill.repositories]
+    let repositories = crate::cli::config::load_repositories_from_project()?;
+    let repo_manager =
+        fastskill::core::repository::RepositoryManager::from_definitions(repositories);
 
     // Create SourcesManager from marketplace-based repositories
     let sources_mgr = if let Some(sources_manager) =

--- a/src/cli/utils/manifest_utils.rs
+++ b/src/cli/utils/manifest_utils.rs
@@ -1,11 +1,11 @@
-//! Utilities for managing skills.toml and skills.lock
+//! Utilities for managing skill-project.toml and skills.lock
 
 use chrono::Utc;
 use fastskill::core::{
     lock::SkillsLock,
     manifest::{
-        DependenciesSection, DependencySource, DependencySpec, SkillEntry, SkillProjectToml,
-        SkillSource, SkillsManifest, SourceSpecificFields,
+        DependenciesSection, DependencySource, DependencySpec, SkillProjectToml,
+        SourceSpecificFields,
     },
     project::resolve_project_file,
     skill_manager::SkillDefinition,
@@ -13,87 +13,6 @@ use fastskill::core::{
 use std::collections::HashMap;
 use std::env;
 use std::path::Path;
-
-/// Update skills.toml with a new skill entry
-/// NOTE: This function is kept for backward compatibility but is deprecated.
-/// Use `add_skill_to_project_toml` instead for the unified format.
-#[allow(dead_code)] // Kept for backward compatibility
-pub fn add_skill_to_manifest(
-    manifest_path: &Path,
-    skill: &SkillDefinition,
-    groups: Vec<String>,
-    editable: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    // Ensure .claude directory exists
-    if let Some(parent) = manifest_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    // Load existing manifest or create new
-    let mut manifest = if manifest_path.exists() {
-        SkillsManifest::load_from_file(manifest_path)
-            .map_err(|e| format!("Failed to load manifest: {}", e))?
-    } else {
-        SkillsManifest {
-            metadata: fastskill::core::manifest::ManifestMetadata {
-                version: "1.0.0".to_string(),
-            },
-            skills: Vec::new(),
-        }
-    };
-
-    // Convert SkillDefinition to SkillSource
-    let source = if let Some(source_type) = &skill.source_type {
-        match source_type {
-            fastskill::core::skill_manager::SourceType::GitUrl => SkillSource::Git {
-                url: skill.source_url.clone().unwrap_or_default(),
-                branch: skill.source_branch.clone(),
-                tag: skill.source_tag.clone(),
-                subdir: skill.source_subdir.clone(),
-            },
-            fastskill::core::skill_manager::SourceType::LocalPath => SkillSource::Local {
-                path: skill.source_subdir.clone().unwrap_or_else(|| {
-                    std::path::PathBuf::from(skill.source_url.clone().unwrap_or_default())
-                }),
-                editable,
-            },
-            fastskill::core::skill_manager::SourceType::ZipFile => SkillSource::ZipUrl {
-                base_url: skill.source_url.clone().unwrap_or_default(),
-                version: Some(skill.version.clone()),
-            },
-            fastskill::core::skill_manager::SourceType::Source => SkillSource::Source {
-                name: skill.installed_from.clone().unwrap_or_default(),
-                skill: skill.id.to_string(),
-                version: Some(skill.version.clone()),
-            },
-        }
-    } else {
-        // Default to local path if source type unknown
-        SkillSource::Local {
-            path: std::path::PathBuf::from(skill.id.as_str()),
-            editable,
-        }
-    };
-
-    let entry = SkillEntry {
-        id: skill.id.to_string(),
-        source,
-        version: Some(skill.version.clone()),
-        groups,
-        editable,
-    };
-
-    // Remove existing entry if present
-    manifest.remove_skill(skill.id.as_str());
-    manifest.add_skill(entry);
-
-    // Save manifest
-    manifest
-        .save_to_file(manifest_path)
-        .map_err(|e| format!("Failed to save manifest: {}", e))?;
-
-    Ok(())
-}
 
 /// Update skills.lock with installed skill state
 pub fn update_lock_file(
@@ -132,37 +51,6 @@ pub fn update_lock_file(
     // Save lock
     lock.save_to_file(lock_path)
         .map_err(|e| format!("Failed to save lock file: {}", e))?;
-
-    Ok(())
-}
-
-/// Remove skill from both manifest and lock files
-/// NOTE: This function is kept for backward compatibility but is deprecated.
-/// Use `remove_skill_from_project_toml` instead for the unified format.
-#[allow(dead_code)] // Kept for backward compatibility
-pub fn remove_skill_from_manifest(
-    manifest_path: &Path,
-    lock_path: &Path,
-    skill_id: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    // Remove from manifest
-    if manifest_path.exists() {
-        let mut manifest = SkillsManifest::load_from_file(manifest_path)
-            .map_err(|e| format!("Failed to load manifest: {}", e))?;
-        manifest.remove_skill(skill_id);
-        manifest
-            .save_to_file(manifest_path)
-            .map_err(|e| format!("Failed to save manifest: {}", e))?;
-    }
-
-    // Remove from lock
-    if lock_path.exists() {
-        let mut lock = SkillsLock::load_from_file(lock_path)
-            .map_err(|e| format!("Failed to load lock file: {}", e))?;
-        lock.remove_skill(skill_id);
-        lock.save_to_file(lock_path)
-            .map_err(|e| format!("Failed to save lock file: {}", e))?;
-    }
 
     Ok(())
 }

--- a/src/core/manifest.rs
+++ b/src/core/manifest.rs
@@ -259,9 +259,21 @@ pub struct FastSkillToolConfig {
     /// Optional skills storage directory override
     #[serde(default)]
     pub skills_directory: Option<PathBuf>,
+    /// Optional embedding configuration
+    #[serde(default)]
+    pub embedding: Option<EmbeddingConfigToml>,
     /// Optional repository configuration
     #[serde(default)]
     pub repositories: Option<Vec<RepositoryDefinition>>,
+}
+
+/// Embedding configuration in TOML format
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingConfigToml {
+    pub openai_base_url: String,
+    pub embedding_model: String,
+    #[serde(default)]
+    pub index_path: Option<PathBuf>,
 }
 
 /// Repository definition with name, type, priority, authentication, and connection details

--- a/src/core/repository.rs
+++ b/src/core/repository.rs
@@ -128,6 +128,24 @@ impl RepositoryManager {
         }
     }
 
+    /// Create a repository manager from a list of repository definitions
+    /// Used when loading from skill-project.toml instead of repositories.toml
+    pub fn from_definitions(definitions: Vec<RepositoryDefinition>) -> Self {
+        let mut repo_map: HashMap<String, RepositoryDefinition> = HashMap::new();
+        let mut sorted_repos = definitions;
+        sorted_repos.sort_by_key(|r| r.priority);
+
+        for repo in sorted_repos {
+            repo_map.entry(repo.name.clone()).or_insert(repo);
+        }
+
+        Self {
+            config_path: PathBuf::new(), // Not used when loading from definitions
+            repositories: repo_map,
+            clients: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
     /// Load repositories from TOML file
     /// Loads from repositories.toml only
     pub fn load(&mut self) -> Result<(), ServiceError> {

--- a/src/http/handlers/status.rs
+++ b/src/http/handlers/status.rs
@@ -12,7 +12,7 @@ use std::time::SystemTime;
 pub struct AppState {
     pub service: Arc<FastSkillService>,
     pub start_time: SystemTime,
-    pub skills_toml_path: std::path::PathBuf,
+    pub project_file_path: std::path::PathBuf,
     pub auto_generate_mdc: bool,
 }
 
@@ -21,13 +21,13 @@ impl AppState {
         Self {
             service,
             start_time: SystemTime::now(),
-            skills_toml_path: std::path::PathBuf::from(".claude/skills.toml"),
+            project_file_path: std::path::PathBuf::from("skill-project.toml"),
             auto_generate_mdc: false,
         }
     }
 
-    pub fn with_skills_toml_path(mut self, path: std::path::PathBuf) -> Self {
-        self.skills_toml_path = path;
+    pub fn with_project_file_path(mut self, path: std::path::PathBuf) -> Self {
+        self.project_file_path = path;
         self
     }
 

--- a/tests/cli/repository_tests.rs
+++ b/tests/cli/repository_tests.rs
@@ -80,6 +80,7 @@ web-scraper = "1.0.0"
         .get_or_insert_with(|| ToolSection { fastskill: None });
     let fastskill_config = tool.fastskill.get_or_insert_with(|| FastSkillToolConfig {
         skills_directory: None,
+        embedding: None,
         repositories: Some(Vec::new()),
     });
     let repos = fastskill_config.repositories.get_or_insert_with(Vec::new);


### PR DESCRIPTION
## Summary

This PR consolidates all configuration into `skill-project.toml` using the `[tool.fastskill]` section, removing the need for separate configuration files.

## Changes

### Configuration Consolidation
- ✅ Remove `.fastskill.yaml` and `.fastskill/config.yaml` support
- ✅ Remove `.claude/skills.toml` and `.claude/repositories.toml`  
- ✅ Consolidate embedding config, skills_directory, and repositories into `[tool.fastskill]`
- ✅ Update all CLI commands and HTTP handlers to use new format

### File Naming Fixes
- ✅ Fix incorrect naming: `skills-project.toml` → `skill-project.toml`
- ✅ Fix incorrect naming: `skills-lock.toml` → `skills.lock`

### Developer Experience
- ✅ Init command now generates commented `[tool.fastskill]` section with examples
- ✅ All configuration in one place for easier management

## Breaking Changes

**This is a breaking change that requires users to migrate their configuration:**

1. Configuration must now be in `skill-project.toml [tool.fastskill]`
2. Repositories must be defined in `[tool.fastskill.repositories]`
3. Legacy `.fastskill.yaml` and `.claude/repositories.toml` are no longer supported

### Migration Example

**Before (multiple files):**
```yaml
# .fastskill.yaml
embedding:
  openai_base_url: "https://api.openai.com/v1"
  embedding_model: "text-embedding-3-small"
skills_directory: ".claude/skills"
```

```toml
# .claude/repositories.toml
[[repositories]]
name = "default"
type = "http-registry"
url = "https://registry.fastskill.dev"
```

**After (single file):**
```toml
# skill-project.toml
[tool.fastskill]
skills_directory = ".claude/skills"

[tool.fastskill.embedding]
openai_base_url = "https://api.openai.com/v1"
embedding_model = "text-embedding-3-small"

[[tool.fastskill.repositories]]
name = "default"
type = "http-registry"
index_url = "https://registry.fastskill.dev"
priority = 0
```

## Testing

- ✅ All 280 tests passing, 7 skipped
- ✅ Unit tests passed
- ✅ Integration tests passed  
- ✅ Pre-commit hooks passed (formatting, clippy, tests)
- ✅ Pre-push hooks passed (full test suite, documentation build)

## Implementation Details

### Core Changes

1. **Schema** (`src/core/manifest.rs`)
   - Added `EmbeddingConfigToml` and `embedding` field to `FastSkillToolConfig`
   - Repositories now part of `[tool.fastskill]`

2. **Config Loading** (`src/cli/config_file.rs`, `src/cli/config.rs`)
   - Removed all YAML config loading
   - Implemented `load_config_from_skill_project()` 
   - Updated `resolve_skills_storage_directory()`

3. **Repository System** (`src/core/repository.rs`)
   - Added `RepositoryManager::from_definitions()` for in-memory loading
   - All commands updated to load from `skill-project.toml`

4. **HTTP Handlers** (`src/http/handlers/`)
   - Converted manifest handlers to use `SkillProjectToml`
   - Updated repository loading in HTTP context

5. **CLI Commands**
   - Updated all commands: add, install, publish, update, list
   - Init command generates example `[tool.fastskill]` section

### Files Modified
- 20 files changed, 683 insertions(+), 703 deletions(-)

## Next Steps

After this PR is merged, documentation should be updated:
- [ ] Update README.md with new configuration format
- [ ] Update CLAUDE.md configuration section  
- [ ] Update webdocs to remove references to legacy files
- [ ] Add migration guide for users

🤖 Generated with [Claude Code](https://claude.com/claude-code)