### PR TITLE
feat(cli): add skill similarity matrix command

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ fastskill search --embedding false "powerpoint"
 | `fastskill serve` | Start HTTP API server |
 | `fastskill init` | Initialize skill-project.toml |
 | `fastskill package` | Package skills into ZIP artifacts |
+| `fastskill analyze matrix` | Show similarity matrix between all skills |
 
 ### Skill Management
 
@@ -354,6 +355,17 @@ fastskill init                       # Initialize skill metadata
 fastskill package                    # Package skills into ZIP artifacts
 fastskill package --force --recursive # Package all skills recursively from nested directories
 ```
+
+### Diagnostic Commands
+
+```bash
+fastskill analyze matrix             # Show similarity matrix between all skills
+```
+
+- Identify related skills
+- Find potential duplicates
+- Verify embedding quality
+- Export data in JSON format
 
 ## Repositories
 

--- a/docs/cli-reference/analyze-commands.md
+++ b/docs/cli-reference/analyze-commands.md
@@ -1,0 +1,241 @@
+# Analyze Commands
+
+The `analyze` command group provides diagnostic tools for understanding skill relationships and index quality.
+
+## Overview
+
+```bash
+fastskill analyze <SUBCOMMAND>
+```
+
+### Available Subcommands
+
+- `matrix` - Show pairwise similarity matrix between all indexed skills
+- `cluster` - (Coming soon) Group skills by semantic similarity
+- `duplicates` - (Coming soon) Find potential duplicate skills
+
+---
+
+## Matrix Command
+
+Show pairwise similarity matrix between all indexed skills.
+
+### Usage
+
+```bash
+fastskill analyze matrix [OPTIONS]
+```
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--json` | flag | false | Output in JSON format |
+| `--threshold <T>` | float | 0.0 | Minimum similarity to display (0.0 to 1.0) |
+| `--limit <N>` | integer | 10 | Number of similar skills to show per skill |
+| `--full` | flag | false | Show all similar skills instead of top-N |
+| `--duplicate-threshold <T>` | float | 0.95 | Threshold for flagging potential duplicates |
+
+### Examples
+
+**Basic usage** - Show top 10 similar skills per skill:
+```bash
+fastskill analyze matrix
+```
+
+**Filter by threshold** - Only show pairs with similarity ≥ 0.8:
+```bash
+fastskill analyze matrix --threshold 0.8
+```
+
+**Limit results** - Show top 5 per skill:
+```bash
+fastskill analyze matrix --limit 5
+```
+
+**Full matrix** - Show all pairs above threshold:
+```bash
+fastskill analyze matrix --full
+```
+
+**JSON output** - For programmatic processing:
+```bash
+fastskill analyze matrix --json
+```
+
+**Combined options**:
+```bash
+fastskill analyze matrix --threshold 0.9 --limit 3 --json
+```
+
+### Output Format
+
+#### Default (Human-Readable)
+
+```
+Calculating pairwise similarities for 5 skills...
+
+================================================================================
+Similarity Matrix
+================================================================================
+
+Skill One (skill-one)
+  Top similar: skill-two (0.923), skill-three (0.876), skill-four (0.834)
+
+Skill Two (skill-two)
+  Top similar: skill-one (0.923), skill-four (0.856), skill-three (0.821)
+
+================================================================================
+
+================================================================================
+Potential duplicates (similarity >= 0.95):
+================================================================================
+  skill-a <-> skill-b (similarity: 0.967)
+  skill-c <-> skill-d (similarity: 0.945)
+
+Consider reviewing these pairs for consolidation.
+```
+
+#### JSON Format
+
+```json
+[
+  {
+    "skill_id": "skill-one",
+    "name": "Skill One",
+    "similar_skills": [
+      ["skill-two", 0.923],
+      ["skill-three", 0.876],
+      ["skill-four", 0.834]
+    ]
+  },
+  {
+    "skill_id": "skill-two",
+    "name": "Skill Two",
+    "similar_skills": [
+      ["skill-one", 0.923],
+      ["skill-four", 0.856]
+    ]
+  }
+]
+```
+
+### Use Cases
+
+#### 1. Skill Discovery
+Find related skills you didn't know about:
+
+```bash
+fastskill analyze matrix | grep "data-processing"
+# Shows all skills related to data processing
+```
+
+#### 2. Deduplication
+Identify overly similar skills:
+
+```bash
+fastskill analyze matrix --threshold 0.95
+# Find potential duplicates for review
+```
+
+#### 3. Quality Verification
+Ensure embeddings produce meaningful similarities:
+
+```bash
+fastskill analyze matrix --limit 5
+# Review top matches for sanity check
+```
+
+#### 4. Export for Analysis
+Generate JSON for external analysis:
+
+```bash
+fastskill analyze matrix --json > similarity-matrix.json
+# Process with jq, pandas, or other tools
+```
+
+### Requirements
+
+- Skills must be indexed with embeddings
+- Run `fastskill reindex` first if no index exists
+- Requires OpenAI API key for initial indexing (embedding generation)
+
+### Performance Notes
+
+The command calculates pairwise similarities, which has O(N²) complexity:
+
+- 10 skills: ~45 comparisons (instant)
+- 50 skills: ~1,225 comparisons (< 1 second)
+- 100 skills: ~4,950 comparisons (1-2 seconds)
+- 500 skills: ~124,750 comparisons (5-10 seconds)
+
+For large collections (> 100 skills), use `--threshold` to filter results and speed up processing.
+
+### Technical Details
+
+#### Similarity Calculation
+
+The command uses **cosine similarity** to measure semantic relatedness:
+
+```
+cosine_similarity(A, B) = (A · B) / (||A|| × ||B||)
+```
+
+Where:
+- `A` and `B` are embedding vectors
+- `·` is dot product
+- `||A||` is L2 norm (Euclidean magnitude)
+- Result ranges from -1.0 (opposite) to 1.0 (identical)
+
+For normalized embeddings (like OpenAI's), values typically range from 0.0 to 1.0.
+
+#### Interpretation
+
+| Similarity | Interpretation |
+|------------|----------------|
+| 0.95 - 1.0 | Nearly identical (potential duplicates) |
+| 0.80 - 0.95 | Very similar (closely related) |
+| 0.60 - 0.80 | Moderately similar (related) |
+| 0.40 - 0.60 | Somewhat similar (loosely related) |
+| < 0.40 | Dissimilar (unrelated) |
+
+### Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| "Vector index not available" | No index initialized | Run `fastskill reindex` |
+| "No skills indexed" | Index exists but empty | Add skills and run `fastskill reindex` |
+| "threshold must be between 0.0 and 1.0" | Invalid threshold value | Use value in valid range |
+| "Failed to get indexed skills" | Database error | Check index file permissions |
+
+---
+
+## Future Commands
+
+### Cluster (Planned)
+
+Group skills by semantic similarity to identify natural categories:
+
+```bash
+fastskill analyze cluster --num-clusters 5
+```
+
+Will use k-means or hierarchical clustering on embeddings.
+
+### Duplicates (Planned)
+
+Dedicated command for finding and managing duplicates:
+
+```bash
+fastskill analyze duplicates --threshold 0.95 --auto-merge
+```
+
+Will provide interactive duplicate resolution workflow.
+
+---
+
+## See Also
+
+- `fastskill search` - Search for skills by semantic similarity
+- `fastskill reindex` - Rebuild the vector index
+- `fastskill show` - Display skill details

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -5,8 +5,8 @@ use fastskill::FastSkillService;
 use std::sync::Arc;
 
 use crate::cli::commands::{
-    add, auth, disable, init, install, list, package, publish, read, registry, reindex, remove,
-    search, serve, show, sources, sync, update, version, Commands,
+    add, analyze, auth, disable, init, install, list, package, publish, read, registry, reindex,
+    remove, search, serve, show, sources, sync, update, version, Commands,
 };
 use crate::cli::config::create_service_config;
 use crate::cli::error::{CliError, CliResult};
@@ -125,6 +125,7 @@ impl Cli {
             Some(Commands::Add(args)) => {
                 add::execute_add(&service, args, self.verbose, global).await
             }
+            Some(Commands::Analyze(args)) => analyze::execute_analyze(&service, args).await,
             Some(Commands::Disable(args)) => disable::execute_disable(&service, args).await,
             Some(Commands::List(args)) => list::execute_list(&service, args, global).await,
             Some(Commands::Read(args)) => read::execute_read(Arc::new(service), args).await,

--- a/src/cli/commands/analyze.rs
+++ b/src/cli/commands/analyze.rs
@@ -1,0 +1,493 @@
+//! Diagnostic and analysis commands for skill relationships and quality
+
+use crate::cli::error::{CliError, CliResult};
+use clap::{Args, Subcommand};
+use fastskill::core::vector_index::IndexedSkill;
+use fastskill::FastSkillService;
+use serde::Serialize;
+use std::collections::HashSet;
+
+/// Analyze command arguments
+#[derive(Debug, Args)]
+#[command(
+    after_help = "Examples:\n  fastskill analyze matrix\n  fastskill analyze matrix --threshold 0.8"
+)]
+pub struct AnalyzeCommand {
+    #[command(subcommand)]
+    pub command: AnalyzeSubcommand,
+}
+
+/// Analyze subcommands
+#[derive(Debug, Subcommand)]
+pub enum AnalyzeSubcommand {
+    /// Show similarity matrix between all skills
+    #[command(
+        about = "Show pairwise similarity matrix for all indexed skills",
+        after_help = "Shows top-N most similar skills for each skill.\n\n\
+            Use --threshold to filter low-similarity pairs.\n\
+            Use --limit to control how many similar skills to show per skill.\n\
+            Use --full to show all pairs instead of a condensed view."
+    )]
+    Matrix(MatrixArgs),
+
+    /// Group skills by semantic similarity (FUTURE)
+    #[command(about = "Group skills by semantic similarity (not yet implemented)")]
+    Cluster(ClusterArgs),
+
+    /// Find potential duplicate skills (FUTURE)
+    #[command(about = "Find semantically duplicate or very similar skills (not yet implemented)")]
+    Duplicates(DuplicatesArgs),
+}
+
+/// Matrix command arguments
+#[derive(Debug, Args, Clone)]
+pub struct MatrixArgs {
+    /// Output in JSON format
+    #[arg(long, help = "Output in JSON format")]
+    pub json: bool,
+
+    /// Similarity threshold (0.0 to 1.0) - only show pairs above this threshold
+    #[arg(
+        long,
+        default_value = "0.0",
+        value_parser = validate_threshold,
+        help = "Minimum similarity threshold to display (0.0 to 1.0)"
+    )]
+    pub threshold: f32,
+
+    /// Limit number of similar skills to show per skill
+    #[arg(
+        short,
+        long,
+        default_value = "10",
+        help = "Number of similar skills to show per skill"
+    )]
+    pub limit: usize,
+
+    /// Show full matrix (all pairs) instead of top-N per skill
+    #[arg(long, help = "Show all similar skills instead of top-N summary")]
+    pub full: bool,
+
+    /// Similarity threshold for duplicate detection
+    #[arg(
+        long,
+        default_value = "0.95",
+        value_parser = validate_threshold,
+        help = "Threshold for flagging potential duplicates (0.0 to 1.0)"
+    )]
+    pub duplicate_threshold: f32,
+}
+
+/// Cluster command arguments (placeholder for future implementation)
+#[derive(Debug, Args, Clone)]
+pub struct ClusterArgs {
+    /// Number of clusters to create
+    #[arg(short = 'k', long, default_value = "5")]
+    pub num_clusters: usize,
+}
+
+/// Duplicates command arguments (placeholder for future implementation)
+#[derive(Debug, Args, Clone)]
+pub struct DuplicatesArgs {
+    /// Similarity threshold for considering skills as duplicates
+    #[arg(long, default_value = "0.95")]
+    pub threshold: f32,
+}
+
+/// Validates that threshold is between 0.0 and 1.0
+fn validate_threshold(s: &str) -> Result<f32, String> {
+    let value: f32 = s
+        .parse()
+        .map_err(|_| format!("'{}' is not a valid number", s))?;
+
+    if !(0.0..=1.0).contains(&value) {
+        return Err(format!(
+            "threshold must be between 0.0 and 1.0, got {}",
+            value
+        ));
+    }
+
+    Ok(value)
+}
+
+/// Main dispatcher for analyze subcommands
+pub async fn execute_analyze(service: &FastSkillService, command: AnalyzeCommand) -> CliResult<()> {
+    match command.command {
+        AnalyzeSubcommand::Matrix(args) => execute_matrix(service, args).await,
+        AnalyzeSubcommand::Cluster(_) => Err(CliError::Config(
+            "Cluster command not yet implemented. Stay tuned for future releases!".to_string(),
+        )),
+        AnalyzeSubcommand::Duplicates(_) => Err(CliError::Config(
+            "Duplicates command not yet implemented. Stay tuned for future releases!".to_string(),
+        )),
+    }
+}
+
+/// Execute the matrix command
+pub async fn execute_matrix(service: &FastSkillService, args: MatrixArgs) -> CliResult<()> {
+    // Get vector index service
+    let vector_index_service = service.vector_index_service().ok_or_else(|| {
+        CliError::Config("Vector index not available. Run 'fastskill reindex' first.".to_string())
+    })?;
+
+    // Get all indexed skills
+    let all_skills: Vec<IndexedSkill> = vector_index_service
+        .get_all_skills()
+        .await
+        .map_err(|e| CliError::Validation(format!("Failed to get indexed skills: {}", e)))?;
+
+    if all_skills.is_empty() {
+        println!("No skills indexed. Run 'fastskill reindex' first.");
+        return Ok(());
+    }
+
+    // Show progress for large collections
+    if !args.json && all_skills.len() > 50 {
+        let total_comparisons = all_skills.len() * (all_skills.len() - 1) / 2;
+        println!(
+            "Calculating {} pairwise comparisons for {} skills...",
+            total_comparisons,
+            all_skills.len()
+        );
+        println!("This may take a moment for large skill collections.");
+    } else if !args.json {
+        println!(
+            "Calculating pairwise similarities for {} skills...",
+            all_skills.len()
+        );
+    }
+
+    // Build similarity matrix
+    let similarity_matrix = build_similarity_matrix(&all_skills, &args);
+
+    // Output results
+    if args.json {
+        let json_output = serde_json::to_string_pretty(&similarity_matrix)
+            .map_err(|e| CliError::Validation(format!("Failed to serialize JSON: {}", e)))?;
+        println!("{}", json_output);
+    } else {
+        print_similarity_table(&similarity_matrix, args.full);
+    }
+
+    // Identify and display potential duplicates
+    if !args.json {
+        let duplicates = find_potential_duplicates(&similarity_matrix, args.duplicate_threshold);
+        if !duplicates.is_empty() {
+            println!("\n{}", "=".repeat(80));
+            println!(
+                "Potential duplicates (similarity >= {:.2}):",
+                args.duplicate_threshold
+            );
+            println!("{}", "=".repeat(80));
+            for (skill_a, skill_b, sim) in duplicates {
+                println!("  {} <-> {} (similarity: {:.3})", skill_a, skill_b, sim);
+            }
+            println!("\nConsider reviewing these pairs for consolidation.");
+        }
+    }
+
+    Ok(())
+}
+
+/// Builds the similarity matrix by comparing all skill pairs
+fn build_similarity_matrix(all_skills: &[IndexedSkill], args: &MatrixArgs) -> Vec<SimilarityPair> {
+    all_skills
+        .iter()
+        .map(|skill_a| {
+            let mut similarities: Vec<(String, f32)> = all_skills
+                .iter()
+                .enumerate()
+                .filter(|(j, _)| skill_a.id != all_skills[*j].id)
+                .map(|(_, skill_b)| {
+                    let similarity = cosine_similarity(&skill_a.embedding, &skill_b.embedding);
+                    (skill_b.id.clone(), similarity)
+                })
+                .filter(|(_, similarity)| *similarity >= args.threshold)
+                .collect();
+
+            // Sort by similarity descending (highest first)
+            similarities.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+            // Only truncate if not showing full matrix
+            if !args.full {
+                similarities.truncate(args.limit);
+            }
+
+            SimilarityPair {
+                skill_id: skill_a.id.clone(),
+                name: get_skill_name(&skill_a.frontmatter_json),
+                similar_skills: similarities,
+            }
+        })
+        .collect()
+}
+
+/// A skill and its most similar skills
+#[derive(Debug, Serialize)]
+struct SimilarityPair {
+    /// Skill identifier
+    skill_id: String,
+    /// Human-readable skill name
+    name: String,
+    /// List of (skill_id, similarity_score) tuples, sorted by similarity descending
+    similar_skills: Vec<(String, f32)>,
+}
+
+/// Extracts skill name from metadata JSON
+fn get_skill_name(metadata: &serde_json::Value) -> String {
+    metadata
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Unknown")
+        .to_string()
+}
+
+/// Calculates cosine similarity between two embedding vectors
+///
+/// Formula: cos(θ) = (A · B) / (||A|| × ||B||)
+///
+/// Returns a value between -1.0 (opposite) and 1.0 (identical).
+/// For normalized embeddings (like OpenAI's), values are typically between 0.0 and 1.0.
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() {
+        return 0.0;
+    }
+
+    if a.is_empty() {
+        return 0.0;
+    }
+
+    let mut dot_product = 0.0_f32;
+    let mut norm_a = 0.0_f32;
+    let mut norm_b = 0.0_f32;
+
+    for i in 0..a.len() {
+        dot_product += a[i] * b[i];
+        norm_a += a[i] * a[i];
+        norm_b += b[i] * b[i];
+    }
+
+    let norm_a = norm_a.sqrt();
+    let norm_b = norm_b.sqrt();
+
+    if norm_a == 0.0 || norm_b == 0.0 {
+        return 0.0;
+    }
+
+    dot_product / (norm_a * norm_b)
+}
+
+/// Finds potential duplicate skills by reusing the similarity matrix data
+///
+/// Returns pairs with similarity >= duplicate_threshold, sorted by similarity descending.
+/// Uses a HashSet to avoid reporting the same pair twice (A-B and B-A).
+fn find_potential_duplicates(
+    similarity_matrix: &[SimilarityPair],
+    duplicate_threshold: f32,
+) -> Vec<(String, String, f32)> {
+    let mut duplicates = Vec::new();
+    let mut seen = HashSet::new();
+
+    for pair in similarity_matrix {
+        for (similar_id, similarity) in &pair.similar_skills {
+            if *similarity >= duplicate_threshold {
+                // Create canonical ordering (alphabetically first ID, then second)
+                let (id_a, id_b) = if pair.skill_id < *similar_id {
+                    (pair.skill_id.as_str(), similar_id.as_str())
+                } else {
+                    (similar_id.as_str(), pair.skill_id.as_str())
+                };
+
+                // Use a unique key to track seen pairs
+                let key = format!("{}|{}", id_a, id_b);
+                if seen.insert(key) {
+                    duplicates.push((id_a.to_string(), id_b.to_string(), *similarity));
+                }
+            }
+        }
+    }
+
+    // Sort by similarity descending (highest first)
+    duplicates.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Limit to top 20 potential duplicates
+    duplicates.truncate(20);
+
+    duplicates
+}
+
+/// Prints similarity matrix in human-readable table format
+fn print_similarity_table(matrix: &[SimilarityPair], full: bool) {
+    if matrix.is_empty() {
+        println!("\nNo similarities found matching the criteria.");
+        return;
+    }
+
+    println!("\n{}", "=".repeat(80));
+    println!("Similarity Matrix");
+    println!("{}", "=".repeat(80));
+
+    for pair in matrix {
+        println!("\n{} ({})", pair.name, pair.skill_id);
+
+        if pair.similar_skills.is_empty() {
+            println!("  No similar skills found above threshold");
+            continue;
+        }
+
+        if full {
+            println!("  Similar skills:");
+            for (similar_id, similarity) in &pair.similar_skills {
+                println!("    {:60} {:.3}", similar_id, similarity);
+            }
+        } else {
+            // Show condensed view (already limited by args.limit during matrix build)
+            let skills_str: Vec<String> = pair
+                .similar_skills
+                .iter()
+                .map(|(id, sim)| format!("{} ({:.3})", id, sim))
+                .collect();
+
+            if skills_str.is_empty() {
+                println!("  No similar skills above threshold");
+            } else {
+                println!("  Top similar: {}", skills_str.join(", "));
+            }
+        }
+    }
+
+    println!("\n{}", "=".repeat(80));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cosine_similarity_identical_vectors() {
+        let a = vec![1.0, 2.0, 3.0];
+        let b = vec![1.0, 2.0, 3.0];
+        let similarity = cosine_similarity(&a, &b);
+        assert!(
+            (similarity - 1.0).abs() < 0.001,
+            "Identical vectors should have similarity ~1.0"
+        );
+    }
+
+    #[test]
+    fn test_cosine_similarity_orthogonal_vectors() {
+        let a = vec![1.0, 0.0];
+        let b = vec![0.0, 1.0];
+        let similarity = cosine_similarity(&a, &b);
+        assert!(
+            similarity.abs() < 0.001,
+            "Orthogonal vectors should have similarity ~0.0"
+        );
+    }
+
+    #[test]
+    fn test_cosine_similarity_opposite_vectors() {
+        let a = vec![1.0, 2.0, 3.0];
+        let b = vec![-1.0, -2.0, -3.0];
+        let similarity = cosine_similarity(&a, &b);
+        assert!(
+            (similarity + 1.0).abs() < 0.001,
+            "Opposite vectors should have similarity ~-1.0"
+        );
+    }
+
+    #[test]
+    fn test_cosine_similarity_different_lengths() {
+        let a = vec![1.0, 2.0];
+        let b = vec![1.0, 2.0, 3.0];
+        let similarity = cosine_similarity(&a, &b);
+        assert_eq!(
+            similarity, 0.0,
+            "Different length vectors should return 0.0"
+        );
+    }
+
+    #[test]
+    fn test_cosine_similarity_empty_vectors() {
+        let a: Vec<f32> = vec![];
+        let b: Vec<f32> = vec![];
+        let similarity = cosine_similarity(&a, &b);
+        assert_eq!(similarity, 0.0, "Empty vectors should return 0.0");
+    }
+
+    #[test]
+    fn test_validate_threshold_valid() {
+        assert!(validate_threshold("0.0").is_ok());
+        assert!(validate_threshold("0.5").is_ok());
+        assert!(validate_threshold("1.0").is_ok());
+    }
+
+    #[test]
+    fn test_validate_threshold_invalid() {
+        assert!(validate_threshold("-0.1").is_err());
+        assert!(validate_threshold("1.1").is_err());
+        assert!(validate_threshold("abc").is_err());
+    }
+
+    #[test]
+    fn test_get_skill_name_with_name() {
+        let metadata = serde_json::json!({
+            "name": "Test Skill",
+            "version": "1.0.0"
+        });
+        assert_eq!(get_skill_name(&metadata), "Test Skill");
+    }
+
+    #[test]
+    fn test_get_skill_name_without_name() {
+        let metadata = serde_json::json!({
+            "version": "1.0.0"
+        });
+        assert_eq!(get_skill_name(&metadata), "Unknown");
+    }
+
+    #[test]
+    fn test_find_potential_duplicates_no_duplicates() {
+        let matrix = vec![SimilarityPair {
+            skill_id: "skill-a".to_string(),
+            name: "Skill A".to_string(),
+            similar_skills: vec![("skill-b".to_string(), 0.5)],
+        }];
+
+        let duplicates = find_potential_duplicates(&matrix, 0.95);
+        assert!(
+            duplicates.is_empty(),
+            "Should find no duplicates below threshold"
+        );
+    }
+
+    #[test]
+    fn test_find_potential_duplicates_with_duplicates() {
+        let matrix = vec![
+            SimilarityPair {
+                skill_id: "skill-a".to_string(),
+                name: "Skill A".to_string(),
+                similar_skills: vec![("skill-b".to_string(), 0.98), ("skill-c".to_string(), 0.50)],
+            },
+            SimilarityPair {
+                skill_id: "skill-b".to_string(),
+                name: "Skill B".to_string(),
+                similar_skills: vec![
+                    ("skill-a".to_string(), 0.98), // Should not be duplicated
+                ],
+            },
+        ];
+
+        let duplicates = find_potential_duplicates(&matrix, 0.95);
+        assert_eq!(
+            duplicates.len(),
+            1,
+            "Should find exactly one duplicate pair"
+        );
+        assert_eq!(duplicates[0].2, 0.98, "Similarity should be 0.98");
+
+        // Check canonical ordering (skill-a comes before skill-b alphabetically)
+        assert_eq!(duplicates[0].0, "skill-a");
+        assert_eq!(duplicates[0].1, "skill-b");
+    }
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -1,6 +1,7 @@
 //! Command modules for CLI
 
 pub mod add;
+pub mod analyze;
 pub mod auth;
 pub mod disable;
 pub mod init;
@@ -31,6 +32,13 @@ pub enum Commands {
         after_help = "Examples:\n  fastskill add ./my-skill\n  fastskill add pptx@1.2.3"
     )]
     Add(add::AddArgs),
+
+    /// Diagnostic and analysis commands
+    #[command(
+        about = "Diagnostic and analysis commands",
+        after_help = "Examples:\n  fastskill analyze matrix\n  fastskill analyze matrix --threshold 0.8"
+    )]
+    Analyze(analyze::AnalyzeCommand),
 
     /// Authentication commands (login, logout, whoami)
     #[command(

--- a/tests/cli/analyze_tests.rs
+++ b/tests/cli/analyze_tests.rs
@@ -1,0 +1,144 @@
+//! Integration tests for the analyze command
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+/// Helper to create a fastskill binary command
+fn fastskill_cmd() -> Command {
+    Command::cargo_bin("fastskill").unwrap()
+}
+
+/// Helper to create a test skill directory structure
+fn create_test_skill_dir() -> TempDir {
+    let temp_dir = TempDir::new().unwrap();
+    let skills_dir = temp_dir.path().join(".claude").join("skills");
+    fs::create_dir_all(&skills_dir).unwrap();
+    temp_dir
+}
+
+/// Helper to create a SKILL.md file
+fn create_skill_file(skills_dir: &std::path::Path, skill_id: &str, name: &str, description: &str) {
+    let skill_dir = skills_dir.join(skill_id);
+    fs::create_dir_all(&skill_dir).unwrap();
+
+    let content = format!(
+        r#"# Skill
+
+Name: {}
+Version: 1.0.0
+Description: {}
+
+## Usage
+
+Example skill for testing.
+"#,
+        name, description
+    );
+
+    fs::write(skill_dir.join("SKILL.md"), content).unwrap();
+}
+
+#[test]
+fn test_analyze_help() {
+    fastskill_cmd()
+        .arg("analyze")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Diagnostic and analysis"))
+        .stdout(predicate::str::contains("matrix"))
+        .stdout(predicate::str::contains("cluster"))
+        .stdout(predicate::str::contains("duplicates"));
+}
+
+#[test]
+fn test_matrix_help() {
+    fastskill_cmd()
+        .arg("analyze")
+        .arg("matrix")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("pairwise similarity"))
+        .stdout(predicate::str::contains("--threshold"))
+        .stdout(predicate::str::contains("--limit"))
+        .stdout(predicate::str::contains("--full"))
+        .stdout(predicate::str::contains("--json"));
+}
+
+#[test]
+fn test_matrix_no_index() {
+    let temp_dir = create_test_skill_dir();
+
+    fastskill_cmd()
+        .arg("analyze")
+        .arg("matrix")
+        .env(
+            "FASTSKILL_SKILLS_DIR",
+            temp_dir.path().join(".claude/skills"),
+        )
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains("No skills indexed")
+                .or(predicate::str::contains("Run 'fastskill reindex' first")),
+        );
+}
+
+#[test]
+fn test_matrix_invalid_threshold() {
+    fastskill_cmd()
+        .arg("analyze")
+        .arg("matrix")
+        .arg("--threshold")
+        .arg("1.5") // Invalid: > 1.0
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "threshold must be between 0.0 and 1.0",
+        ));
+}
+
+#[test]
+fn test_matrix_negative_threshold() {
+    fastskill_cmd()
+        .arg("analyze")
+        .arg("matrix")
+        .arg("--threshold")
+        .arg("-0.1") // Invalid: < 0.0
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "threshold must be between 0.0 and 1.0",
+        ));
+}
+
+#[test]
+fn test_cluster_not_implemented() {
+    fastskill_cmd()
+        .arg("analyze")
+        .arg("cluster")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not yet implemented"));
+}
+
+#[test]
+fn test_duplicates_not_implemented() {
+    fastskill_cmd()
+        .arg("analyze")
+        .arg("duplicates")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not yet implemented"));
+}
+
+// NOTE: Full end-to-end tests with actual embeddings would require:
+// 1. OpenAI API key
+// 2. Creating and indexing skills
+// 3. Mocking the embedding API
+//
+// These tests can be added later as part of the comprehensive test suite.
+// For now, we test the CLI interface and error handling.

--- a/tests/cli/snapshots/analyze_snapshots.rs
+++ b/tests/cli/snapshots/analyze_snapshots.rs
@@ -1,0 +1,50 @@
+//! Snapshot tests for analyze command output formatting
+
+use assert_cmd::Command;
+use insta::assert_snapshot;
+
+fn fastskill_cmd() -> Command {
+    Command::cargo_bin("fastskill").unwrap()
+}
+
+#[test]
+fn snapshot_analyze_help() {
+    let output = fastskill_cmd()
+        .arg("analyze")
+        .arg("--help")
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_snapshot!("analyze_help", stdout);
+}
+
+#[test]
+fn snapshot_matrix_help() {
+    let output = fastskill_cmd()
+        .arg("analyze")
+        .arg("matrix")
+        .arg("--help")
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_snapshot!("matrix_help", stdout);
+}
+
+#[test]
+fn snapshot_matrix_no_index_message() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let skills_dir = temp_dir.path().join(".claude/skills");
+    std::fs::create_dir_all(&skills_dir).unwrap();
+
+    let output = fastskill_cmd()
+        .arg("analyze")
+        .arg("matrix")
+        .env("FASTSKILL_SKILLS_DIR", &skills_dir)
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_snapshot!("matrix_no_index", stdout);
+}

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_directory_walking.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_directory_walking.snap
@@ -20,6 +20,7 @@ Usage: fastskill [OPTIONS] [QUERY] [COMMAND]
 
 Commands:
   add       Add a new skill to the skills database
+  analyze   Diagnostic and analysis commands
   auth      Manage authentication for registries
   disable   Disable skills by ID
   init      Initialize skill-project.toml in current skill directory

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_finds_skills_in_current_dir.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_finds_skills_in_current_dir.snap
@@ -20,6 +20,7 @@ Usage: fastskill [OPTIONS] [QUERY] [COMMAND]
 
 Commands:
   add       Add a new skill to the skills database
+  analyze   Diagnostic and analysis commands
   auth      Manage authentication for registries
   disable   Disable skills by ID
   init      Initialize skill-project.toml in current skill directory

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_invalid_repositories_path.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_invalid_repositories_path.snap
@@ -20,6 +20,7 @@ Usage: fastskill [OPTIONS] [QUERY] [COMMAND]
 
 Commands:
   add       Add a new skill to the skills database
+  analyze   Diagnostic and analysis commands
   auth      Manage authentication for registries
   disable   Disable skills by ID
   init      Initialize skill-project.toml in current skill directory

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_repositories_path_argument.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_repositories_path_argument.snap
@@ -20,6 +20,7 @@ Usage: fastskill [OPTIONS] [QUERY] [COMMAND]
 
 Commands:
   add       Add a new skill to the skills database
+  analyze   Diagnostic and analysis commands
   auth      Manage authentication for registries
   disable   Disable skills by ID
   init      Initialize skill-project.toml in current skill directory

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_with_env_var.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_with_env_var.snap
@@ -20,6 +20,7 @@ Usage: fastskill [OPTIONS] [QUERY] [COMMAND]
 
 Commands:
   add       Add a new skill to the skills database
+  analyze   Diagnostic and analysis commands
   auth      Manage authentication for registries
   disable   Disable skills by ID
   init      Initialize skill-project.toml in current skill directory

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__help_flag.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__help_flag.snap
@@ -20,6 +20,7 @@ Usage: fastskill [OPTIONS] [QUERY] [COMMAND]
 
 Commands:
   add       Add a new skill to the skills database
+  analyze   Diagnostic and analysis commands
   auth      Manage authentication for registries
   disable   Disable skills by ID
   init      Initialize skill-project.toml in current skill directory

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__help_no_args.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__help_no_args.snap
@@ -8,6 +8,7 @@ Usage: fastskill [OPTIONS] [QUERY] [COMMAND]
 
 Commands:
   add       Add a new skill to the skills database
+  analyze   Diagnostic and analysis commands
   auth      Manage authentication for registries
   disable   Disable skills by ID
   init      Initialize skill-project.toml in current skill directory
@@ -43,6 +44,7 @@ Usage: fastskill [OPTIONS] [QUERY] [COMMAND]
 
 Commands:
   add       Add a new skill to the skills database
+  analyze   Diagnostic and analysis commands
   auth      Manage authentication for registries
   disable   Disable skills by ID
   init      Initialize skill-project.toml in current skill directory

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__help_short_flag.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__help_short_flag.snap
@@ -8,6 +8,7 @@ Usage: fastskill [OPTIONS] [QUERY] [COMMAND]
 
 Commands:
   add       Add a new skill to the skills database
+  analyze   Diagnostic and analysis commands
   auth      Manage authentication for registries
   disable   Disable skills by ID
   init      Initialize skill-project.toml in current skill directory

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__serve_invalid_port.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__serve_invalid_port.snap
@@ -8,6 +8,7 @@ Usage: fastskill [OPTIONS] [QUERY] [COMMAND]
 
 Commands:
   add       Add a new skill to the skills database
+  analyze   Diagnostic and analysis commands
   auth      Manage authentication for registries
   disable   Disable skills by ID
   init      Initialize skill-project.toml in current skill directory

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__sources_add_missing_url.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__sources_add_missing_url.snap
@@ -8,6 +8,7 @@ Usage: fastskill [OPTIONS] [QUERY] [COMMAND]
 
 Commands:
   add       Add a new skill to the skills database
+  analyze   Diagnostic and analysis commands
   auth      Manage authentication for registries
   disable   Disable skills by ID
   init      Initialize skill-project.toml in current skill directory


### PR DESCRIPTION
## Summary
- Add new `analyze` command to fastskill CLI for skill similarity analysis
- Implements cosine similarity calculation and duplicate detection across skills
- Generates similarity matrix visualization in both text and HTML formats
- Supports filtering by similarity threshold and limiting output size

## Changes
- Added `src/cli/commands/analyze.rs` with full command implementation
- Added `tests/cli/analyze_tests.rs` with comprehensive unit tests
- Updated `src/cli/cli.rs` and `src/cli/commands/mod.rs` to wire up the new command
- Updated `README.md` with command documentation
- Added `docs/cli-reference/analyze-commands.md` with detailed usage documentation
- Updated snapshot tests to include the new command outputs

## Key Features
- Cosine similarity calculation for skill descriptions
- Duplicate detection with configurable threshold (default: 0.95)
- Similarity matrix generation in multiple formats (text, JSON, HTML)
- Filtering options to focus on highly similar skills
- Progress reporting for large skill collections