### PR TITLE
feat: migrate cli-framework pin to 6d198a2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,21 +168,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anthropic-sdk"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0e11a7c14d8af2206c110597bf7f2919ea0c1dc5011c017d2d4dc9d033f5363"
-dependencies = [
- "anyhow",
- "dotenv",
- "futures",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "tokio",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,40 +234,6 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-convert"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
-dependencies = [
- "async-trait",
-]
-
-[[package]]
-name = "async-openai"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e97f9c5e0ee3260caee9700ba1bb61a6fdc34d2b6786a31e018c5de5198491"
-dependencies = [
- "async-convert",
- "backoff",
- "base64 0.22.1",
- "bytes",
- "derive_builder",
- "futures",
- "rand 0.8.6",
- "reqwest 0.12.28",
- "reqwest-eventsource",
- "secrecy",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -859,20 +810,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "futures-core",
- "getrandom 0.2.17",
- "instant",
- "pin-project-lite",
- "rand 0.8.6",
- "tokio",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,12 +1042,10 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "cli-framework"
 version = "0.4.2"
-source = "git+https://github.com/aroff/cli-framework?rev=772811504a412d31648b541d80ed77c5e02fb900#772811504a412d31648b541d80ed77c5e02fb900"
+source = "git+https://github.com/aroff/cli-framework?rev=6d198a219bae68a228bc4661715cf758c9230626#6d198a219bae68a228bc4661715cf758c9230626"
 dependencies = [
  "ailoop-core",
- "anthropic-sdk",
  "anyhow",
- "async-openai",
  "async-trait",
  "axum",
  "chrono",
@@ -1596,37 +1531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn",
-]
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,12 +1620,6 @@ checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
 ]
-
-[[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dunce"
@@ -1820,17 +1718,6 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "eventsource-stream"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
-dependencies = [
- "futures-core",
- "nom",
- "pin-project-lite",
-]
 
 [[package]]
 name = "fallible-iterator"
@@ -3117,12 +3004,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,16 +3078,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -3952,7 +3823,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.38",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3971,22 +3841,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "reqwest-eventsource"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632c55746dbb44275691640e7b40c907c16a2dc1a5842aa98aaec90da6ec6bde"
-dependencies = [
- "eventsource-stream",
- "futures-core",
- "futures-timer",
- "mime",
- "nom",
- "pin-project-lite",
- "reqwest 0.12.28",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4317,16 +4171,6 @@ dependencies = [
  "generic-array",
  "pkcs8",
  "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
-dependencies = [
- "serde",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ tower = { version = "0.5", features = ["util", "timeout", "limit"] }
 tower-http = { version = "0.6", features = ["cors", "trace", "compression-gzip", "fs"] }
 
 # CLI framework for versioned API server hosting
-cli-framework = { git = "https://github.com/aroff/cli-framework", rev = "772811504a412d31648b541d80ed77c5e02fb900", default-features = false, features = ["api-server"] }
+cli-framework = { git = "https://github.com/aroff/cli-framework", rev = "6d198a219bae68a228bc4661715cf758c9230626", default-features = false, features = ["api-server"] }
 
 # Request validation
 validator = { version = "0.20", features = ["derive"] }

--- a/crates/fastskill-cli/src/context.rs
+++ b/crates/fastskill-cli/src/context.rs
@@ -1,16 +1,24 @@
 //! Application context for the fastskill CLI.
 //!
-//! `FsCtx` is the single shared context passed to every command.  It owns the
-//! lazily-initialised `FastSkillService` (via an async `OnceCell`) and the
-//! pre-parsed global flags extracted by `strip_global_flags` in `main.rs`.
+//! `FsCtx` is a trivial empty struct that satisfies the `AppContext` trait bound.
+//! All shared state lives in `FsState`, which is captured via `Arc<FsState>` in
+//! each command closure at registration time — no `Any`-downcasting needed.
 
 use cli_framework::prelude::AppContext;
 use fastskill_core::FastSkillService;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-/// Main application context.
-pub struct FsCtx {
+/// Trivial application context — satisfies `AppContext: Send + Sync`.
+/// All operational state is captured via `Arc<FsState>` in command closures.
+pub struct FsCtx;
+
+impl AppContext for FsCtx {}
+
+/// Shared application state captured by each command closure.
+///
+/// Created once in `main()` and cloned via `Arc` into every registered command.
+pub struct FsState {
     /// Shared cell for lazy service initialisation.
     service_cell: Arc<tokio::sync::OnceCell<Arc<FastSkillService>>>,
 
@@ -29,17 +37,7 @@ pub struct FsCtx {
     pub raw_remaining_args: Vec<String>,
 }
 
-impl AppContext for FsCtx {
-    fn as_any(&self) -> Option<&dyn std::any::Any> {
-        Some(self)
-    }
-
-    fn as_any_mut(&mut self) -> Option<&mut dyn std::any::Any> {
-        Some(self)
-    }
-}
-
-impl FsCtx {
+impl FsState {
     pub fn new(
         skills_dir_override: Option<PathBuf>,
         global: bool,
@@ -55,37 +53,12 @@ impl FsCtx {
         }
     }
 
-    /// Return a lightweight, clone-friendly handle for service initialisation.
-    ///
-    /// Cloning the handle is cheap (Arc clone). The underlying OnceCell is
-    /// shared, so `handle.get().await` initialises the service exactly once
-    /// regardless of how many handles exist.
-    pub fn service_handle(&self) -> ServiceHandle {
-        ServiceHandle {
-            cell: self.service_cell.clone(),
-            skills_dir: self.skills_dir_override.clone(),
-            global: self.global,
-        }
-    }
-}
-
-/// Sendable handle to the shared service OnceCell.
-///
-/// Bridge closures clone this handle before any `.await` to avoid holding a
-/// borrow of `ctx: &mut dyn AppContext` across await points.
-pub struct ServiceHandle {
-    cell: Arc<tokio::sync::OnceCell<Arc<FastSkillService>>>,
-    skills_dir: Option<PathBuf>,
-    global: bool,
-}
-
-impl ServiceHandle {
     /// Initialise (or reuse) the `FastSkillService` and return an `Arc` to it.
-    pub async fn get(&self) -> crate::error::CliResult<Arc<FastSkillService>> {
+    pub async fn service(&self) -> crate::error::CliResult<Arc<FastSkillService>> {
         use crate::error::CliError;
         let global = self.global;
-        let skills_dir = self.skills_dir.clone();
-        self.cell
+        let skills_dir = self.skills_dir_override.clone();
+        self.service_cell
             .get_or_try_init(|| async move {
                 let cfg = crate::config::create_service_config(global, skills_dir, None)?;
                 let mut s = FastSkillService::new(cfg)
@@ -96,28 +69,5 @@ impl ServiceHandle {
             })
             .await
             .cloned()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_ctx_downcast_roundtrip() {
-        let ctx = FsCtx::new(None, false, false, vec!["fastskill".to_string()]);
-        let any = ctx.as_any();
-        assert!(any.is_some());
-        let back = any.and_then(|a| a.downcast_ref::<FsCtx>());
-        assert!(back.is_some());
-    }
-
-    #[test]
-    fn test_ctx_downcast_mut_roundtrip() {
-        let mut ctx = FsCtx::new(None, false, false, vec!["fastskill".to_string()]);
-        let any = ctx.as_any_mut();
-        assert!(any.is_some());
-        let back = any.and_then(|a| a.downcast_mut::<FsCtx>());
-        assert!(back.is_some());
     }
 }

--- a/crates/fastskill-cli/src/main.rs
+++ b/crates/fastskill-cli/src/main.rs
@@ -2,9 +2,12 @@
 //!
 //! Stage 1: all 21 active (non-deprecated, non-framework) commands are
 //! registered as bridged commands (`spec: None`).  Each bridge closure
-//! reconstructs the original typed `Args` struct from `FsCtx.raw_remaining_args`
+//! reconstructs the original typed `Args` struct from `FsState.raw_remaining_args`
 //! and delegates to the existing `execute_*` functions, preserving all
 //! existing behaviour.
+//!
+//! `Arc<FsState>` is captured at registration time by each command closure —
+//! no `Any`-downcasting of `AppContext` is needed.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -18,7 +21,7 @@ mod error;
 mod utils;
 
 use cli_framework::prelude::AppBuilder;
-use context::FsCtx;
+use context::{FsCtx, FsState};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -27,22 +30,6 @@ use commands::{
     reindex, remove, repos, resolve, search, serve, show, sync, update,
 };
 
-/// Pre-parse and strip global flags from argv before handing to the framework.
-///
-/// Handles:
-/// - `--skills-dir=<path>` (equals form)
-/// - `--skills-dir <path>` (space form)
-/// - `--global`
-/// - `--verbose` / `-v`
-/// - `--repositories-path <path>` / `--repositories-path=<path>` (unused but
-///   present in legacy help; silently dropped)
-///
-/// Returns `(skills_dir, global, verbose, remaining_args)` where
-/// `remaining_args[0]` is the binary name.
-///
-/// # Errors
-///
-/// Exits the process if `--skills-dir` appears without a following value.
 pub fn strip_global_flags(args: Vec<String>) -> (Option<PathBuf>, bool, bool, Vec<String>) {
     let mut skills_dir: Option<PathBuf> = None;
     let mut global = false;
@@ -54,26 +41,22 @@ pub fn strip_global_flags(args: Vec<String>) -> (Option<PathBuf>, bool, bool, Ve
         let arg = &args[i];
 
         if arg == "--skills-dir" {
-            // Space form: --skills-dir <path>
             if i + 1 < args.len() && !args[i + 1].starts_with('-') {
                 skills_dir = Some(PathBuf::from(&args[i + 1]));
                 i += 2;
             } else if i + 1 < args.len() {
-                // Next arg starts with '-' — treat as SKILLS_DIR_STRIP_AMBIGUOUS
                 eprintln!(
                     "Error: --skills-dir requires a path value (got '{}' which looks like a flag)",
                     args[i + 1]
                 );
                 std::process::exit(1);
             } else {
-                // End of args — SKILLS_DIR_STRIP_AMBIGUOUS
                 eprintln!(
                     "Error: --skills-dir requires a path value but appears at end of arguments"
                 );
                 std::process::exit(1);
             }
         } else if let Some(path) = arg.strip_prefix("--skills-dir=") {
-            // Equals form: --skills-dir=<path>
             skills_dir = Some(PathBuf::from(path));
             i += 1;
         } else if arg == "--global" {
@@ -83,7 +66,6 @@ pub fn strip_global_flags(args: Vec<String>) -> (Option<PathBuf>, bool, bool, Ve
             verbose = true;
             i += 1;
         } else if arg == "--repositories-path" {
-            // Silently consume the flag and its value (flag is unused post-migration)
             if i + 1 < args.len() {
                 i += 2;
             } else {
@@ -100,14 +82,7 @@ pub fn strip_global_flags(args: Vec<String>) -> (Option<PathBuf>, bool, bool, Ve
     (skills_dir, global, verbose, remaining)
 }
 
-/// Parse a clap `Args` struct from a raw arg slice.
-///
-/// `raw[0]` is used as the "binary name" by clap (it is typically the
-/// subcommand name, e.g. `"install"`).  All elements of `raw` are passed to
-/// clap's `try_get_matches_from`.
 fn parse_from_args<T: clap::Args>(raw: &[String]) -> anyhow::Result<T> {
-    // Use a static placeholder as the binary name — clap uses it only in
-    // error/help output, so the actual value doesn't matter for the bridge.
     let cmd = T::augment_args(clap::Command::new("fastskill"));
     let matches = cmd
         .try_get_matches_from(raw.iter().map(|s| s.as_str()))
@@ -115,29 +90,22 @@ fn parse_from_args<T: clap::Args>(raw: &[String]) -> anyhow::Result<T> {
     T::from_arg_matches(&matches).map_err(|e| anyhow::anyhow!("{}", e))
 }
 
-/// Downcast `ctx` to `&FsCtx`.  Returns an error if the context is not an
-/// `FsCtx` (i.e. `AppContext::as_any` was not overridden — CTX_DOWNCAST_FAILED).
-fn downcast_fctx(ctx: &mut dyn cli_framework::prelude::AppContext) -> anyhow::Result<&FsCtx> {
-    ctx.as_any()
-        .and_then(|a| a.downcast_ref::<FsCtx>())
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "CTX_DOWNCAST_FAILED: context is not FsCtx (as_any() returned None or wrong type)"
-            )
-        })
-}
-
 #[tokio::main]
 async fn main() {
     let raw: Vec<String> = std::env::args().collect();
     let (skills_dir, global, verbose, remaining_args) = strip_global_flags(raw);
 
-    // Initialise logging (honours RUST_LOG; verbose enables debug-level fastskill output)
     fastskill_core::init_logging_with_verbose(verbose);
 
-    let ctx = FsCtx::new(skills_dir, global, verbose, remaining_args.clone());
+    let state = Arc::new(FsState::new(
+        skills_dir,
+        global,
+        verbose,
+        remaining_args.clone(),
+    ));
+    let ctx = FsCtx;
 
-    let builder = match build_app(AppBuilder::new()) {
+    let builder = match build_app(AppBuilder::new(), Arc::clone(&state)) {
         Ok(b) => b,
         Err(e) => {
             eprintln!("Error building app: {}", e);
@@ -166,406 +134,464 @@ async fn main() {
     }
 }
 
-/// Register all bridged commands on the `AppBuilder`.
-fn build_app(builder: AppBuilder) -> anyhow::Result<AppBuilder> {
+fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuilder> {
     use cli_framework::prelude::Command;
 
     let builder = builder
         // ── No-service commands ──────────────────────────────────────────────
-        .register_command(Command {
-            id: "init",
-            summary: "Initialize skill-project.toml in current skill directory",
-            syntax: Some("init [OPTIONS]"),
-            category: Some("project"),
-            spec: None,
-            validator: None,
-            expose_mcp: false,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let raw = downcast_fctx(ctx)?.raw_remaining_args.clone();
-                    let args = parse_from_args::<init::InitArgs>(&raw[1..])?;
-                    init::execute_init(args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "init",
+                summary: "Initialize skill-project.toml in current skill directory",
+                syntax: Some("init [OPTIONS]"),
+                category: Some("project"),
+                spec: None,
+                validator: None,
+                expose_mcp: false,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<init::InitArgs>(&raw[1..])?;
+                        init::execute_init(args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "install",
-            summary: "Apply manifest: install skills from skill-project.toml [dependencies]",
-            syntax: Some("install [OPTIONS]"),
-            category: Some("packages"),
-            spec: None,
-            validator: None,
-            expose_mcp: false,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let raw = downcast_fctx(ctx)?.raw_remaining_args.clone();
-                    let args = parse_from_args::<install::InstallArgs>(&raw[1..])?;
-                    install::execute_install(args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "install",
+                summary: "Apply manifest: install skills from skill-project.toml [dependencies]",
+                syntax: Some("install [OPTIONS]"),
+                category: Some("packages"),
+                spec: None,
+                validator: None,
+                expose_mcp: false,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<install::InstallArgs>(&raw[1..])?;
+                        install::execute_install(args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "update",
-            summary: "Update skills to latest versions",
-            syntax: Some("update [SKILL_ID] [OPTIONS]"),
-            category: Some("packages"),
-            spec: None,
-            validator: None,
-            expose_mcp: false,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let fctx = downcast_fctx(ctx)?;
-                    let (global, raw) = (fctx.global, fctx.raw_remaining_args.clone());
-                    let args = parse_from_args::<update::UpdateArgs>(&raw[1..])?;
-                    update::execute_update(args, global).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "update",
+                summary: "Update skills to latest versions",
+                syntax: Some("update [SKILL_ID] [OPTIONS]"),
+                category: Some("packages"),
+                spec: None,
+                validator: None,
+                expose_mcp: false,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<update::UpdateArgs>(&raw[1..])?;
+                        update::execute_update(args, state.global).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "show",
-            summary: "Show metadata for one or all installed skills",
-            syntax: Some("show [SKILL_ID] [OPTIONS]"),
-            category: Some("discovery"),
-            spec: None,
-            validator: None,
-            expose_mcp: true,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let fctx = downcast_fctx(ctx)?;
-                    let (global, raw) = (fctx.global, fctx.raw_remaining_args.clone());
-                    let args = parse_from_args::<show::ShowArgs>(&raw[1..])?;
-                    show::execute_show(args, global).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "show",
+                summary: "Show metadata for one or all installed skills",
+                syntax: Some("show [SKILL_ID] [OPTIONS]"),
+                category: Some("discovery"),
+                spec: None,
+                validator: None,
+                expose_mcp: true,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<show::ShowArgs>(&raw[1..])?;
+                        show::execute_show(args, state.global).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "package",
-            summary: "Package skills into ZIP artifacts with versioning",
-            syntax: Some("package [OPTIONS]"),
-            category: Some("publishing"),
-            spec: None,
-            validator: None,
-            expose_mcp: false,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let raw = downcast_fctx(ctx)?.raw_remaining_args.clone();
-                    let args = parse_from_args::<package::PackageArgs>(&raw[1..])?;
-                    package::execute_package(args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "package",
+                summary: "Package skills into ZIP artifacts with versioning",
+                syntax: Some("package [OPTIONS]"),
+                category: Some("publishing"),
+                spec: None,
+                validator: None,
+                expose_mcp: false,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<package::PackageArgs>(&raw[1..])?;
+                        package::execute_package(args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "publish",
-            summary: "Publish artifacts to remote API or local folder",
-            syntax: Some("publish [OPTIONS]"),
-            category: Some("publishing"),
-            spec: None,
-            validator: None,
-            expose_mcp: false,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let raw = downcast_fctx(ctx)?.raw_remaining_args.clone();
-                    let args = parse_from_args::<publish::PublishArgs>(&raw[1..])?;
-                    publish::execute_publish(args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "publish",
+                summary: "Publish artifacts to remote API or local folder",
+                syntax: Some("publish [OPTIONS]"),
+                category: Some("publishing"),
+                spec: None,
+                validator: None,
+                expose_mcp: false,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<publish::PublishArgs>(&raw[1..])?;
+                        publish::execute_publish(args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
         // ── Subcommand-tree commands (no service) ───────────────────────────
-        .register_command(Command {
-            id: "repos",
-            summary: "Manage repository list and browse remote skill catalog",
-            syntax: Some("repos <SUBCOMMAND>"),
-            category: Some("repositories"),
-            spec: None,
-            validator: None,
-            expose_mcp: true,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let raw = downcast_fctx(ctx)?.raw_remaining_args.clone();
-                    let args = parse_from_args::<repos::ReposArgs>(&raw[1..])?;
-                    repos::execute_repos(args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "repos",
+                summary: "Manage repository list and browse remote skill catalog",
+                syntax: Some("repos <SUBCOMMAND>"),
+                category: Some("repositories"),
+                spec: None,
+                validator: None,
+                expose_mcp: true,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<repos::ReposArgs>(&raw[1..])?;
+                        repos::execute_repos(args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "marketplace",
-            summary: "Create and manage skill marketplace artifacts",
-            syntax: Some("marketplace <SUBCOMMAND>"),
-            category: Some("publishing"),
-            spec: None,
-            validator: None,
-            expose_mcp: true,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let raw = downcast_fctx(ctx)?.raw_remaining_args.clone();
-                    let args = parse_from_args::<marketplace::MarketplaceArgs>(&raw[1..])?;
-                    marketplace::execute_marketplace(args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "marketplace",
+                summary: "Create and manage skill marketplace artifacts",
+                syntax: Some("marketplace <SUBCOMMAND>"),
+                category: Some("publishing"),
+                spec: None,
+                validator: None,
+                expose_mcp: true,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<marketplace::MarketplaceArgs>(&raw[1..])?;
+                        marketplace::execute_marketplace(args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "auth",
-            summary: "Manage authentication for registries",
-            syntax: Some("auth <login|logout|whoami>"),
-            category: Some("auth"),
-            spec: None,
-            validator: None,
-            expose_mcp: false,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let raw = downcast_fctx(ctx)?.raw_remaining_args.clone();
-                    let args = parse_from_args::<auth::AuthArgs>(&raw[1..])?;
-                    auth::execute_auth(args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "auth",
+                summary: "Manage authentication for registries",
+                syntax: Some("auth <login|logout|whoami>"),
+                category: Some("auth"),
+                spec: None,
+                validator: None,
+                expose_mcp: false,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<auth::AuthArgs>(&raw[1..])?;
+                        auth::execute_auth(args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "eval",
-            summary: "Evaluation commands for skill quality assurance",
-            syntax: Some("eval <run|validate>"),
-            category: Some("quality"),
-            spec: None,
-            validator: None,
-            expose_mcp: true,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let raw = downcast_fctx(ctx)?.raw_remaining_args.clone();
-                    let args = parse_from_args::<eval::EvalCommand>(&raw[1..])?;
-                    eval::execute_eval(args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "eval",
+                summary: "Evaluation commands for skill quality assurance",
+                syntax: Some("eval <run|validate>"),
+                category: Some("quality"),
+                spec: None,
+                validator: None,
+                expose_mcp: true,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<eval::EvalCommand>(&raw[1..])?;
+                        eval::execute_eval(args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
         // ── Service commands ─────────────────────────────────────────────────
-        .register_command(Command {
-            id: "add",
-            summary: "Add a skill (from local path, zip, git URL, or registry ID)",
-            syntax: Some("add <SOURCE> [OPTIONS]"),
-            category: Some("packages"),
-            spec: None,
-            validator: None,
-            expose_mcp: false,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let fctx = downcast_fctx(ctx)?;
-                    let (handle, global, raw) = (
-                        fctx.service_handle(),
-                        fctx.global,
-                        fctx.raw_remaining_args.clone(),
-                    );
-                    let svc = handle.get().await?;
-                    let args = parse_from_args::<add::AddArgs>(&raw[1..])?;
-                    add::execute_add(&svc, args, global).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "add",
+                summary: "Add a skill (from local path, zip, git URL, or registry ID)",
+                syntax: Some("add <SOURCE> [OPTIONS]"),
+                category: Some("packages"),
+                spec: None,
+                validator: None,
+                expose_mcp: false,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let svc = state.service().await?;
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<add::AddArgs>(&raw[1..])?;
+                        add::execute_add(&svc, args, state.global).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "analyze",
-            summary: "Diagnostic and analysis commands",
-            syntax: Some("analyze <matrix|duplicates|cluster>"),
-            category: Some("analysis"),
-            spec: None,
-            validator: None,
-            expose_mcp: true,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let fctx = downcast_fctx(ctx)?;
-                    let (handle, raw) = (fctx.service_handle(), fctx.raw_remaining_args.clone());
-                    let svc = handle.get().await?;
-                    let args = parse_from_args::<analyze::AnalyzeCommand>(&raw[1..])?;
-                    analyze::execute_analyze(&svc, args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "analyze",
+                summary: "Diagnostic and analysis commands",
+                syntax: Some("analyze <matrix|duplicates|cluster>"),
+                category: Some("analysis"),
+                spec: None,
+                validator: None,
+                expose_mcp: true,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let svc = state.service().await?;
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<analyze::AnalyzeCommand>(&raw[1..])?;
+                        analyze::execute_analyze(&svc, args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "disable",
-            summary: "Disable skills by ID",
-            syntax: Some("disable <SKILL_ID>..."),
-            category: Some("packages"),
-            spec: None,
-            validator: None,
-            expose_mcp: false,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let fctx = downcast_fctx(ctx)?;
-                    let (handle, raw) = (fctx.service_handle(), fctx.raw_remaining_args.clone());
-                    let svc = handle.get().await?;
-                    let args = parse_from_args::<disable::DisableArgs>(&raw[1..])?;
-                    disable::execute_disable(&svc, args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "disable",
+                summary: "Disable skills by ID",
+                syntax: Some("disable <SKILL_ID>..."),
+                category: Some("packages"),
+                spec: None,
+                validator: None,
+                expose_mcp: false,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let svc = state.service().await?;
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<disable::DisableArgs>(&raw[1..])?;
+                        disable::execute_disable(&svc, args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "list",
-            summary: "List installed skills and reconcile with skill-project.toml",
-            syntax: Some("list [OPTIONS]"),
-            category: Some("discovery"),
-            spec: None,
-            validator: None,
-            expose_mcp: true,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let fctx = downcast_fctx(ctx)?;
-                    let (handle, global, raw) = (
-                        fctx.service_handle(),
-                        fctx.global,
-                        fctx.raw_remaining_args.clone(),
-                    );
-                    let svc = handle.get().await?;
-                    let args = parse_from_args::<list::ListArgs>(&raw[1..])?;
-                    list::execute_list(&svc, args, global).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "list",
+                summary: "List installed skills and reconcile with skill-project.toml",
+                syntax: Some("list [OPTIONS]"),
+                category: Some("discovery"),
+                spec: None,
+                validator: None,
+                expose_mcp: true,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let svc = state.service().await?;
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<list::ListArgs>(&raw[1..])?;
+                        list::execute_list(&svc, args, state.global).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "read",
-            summary: "Stream skill documentation (SKILL.md content) to stdout",
-            syntax: Some("read <SKILL_ID>"),
-            category: Some("discovery"),
-            spec: None,
-            validator: None,
-            expose_mcp: true,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let fctx = downcast_fctx(ctx)?;
-                    let (handle, raw) = (fctx.service_handle(), fctx.raw_remaining_args.clone());
-                    let svc = handle.get().await?;
-                    let args = parse_from_args::<read::ReadArgs>(&raw[1..])?;
-                    read::execute_read(svc, args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "read",
+                summary: "Stream skill documentation (SKILL.md content) to stdout",
+                syntax: Some("read <SKILL_ID>"),
+                category: Some("discovery"),
+                spec: None,
+                validator: None,
+                expose_mcp: true,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let svc = state.service().await?;
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<read::ReadArgs>(&raw[1..])?;
+                        read::execute_read(svc, args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "sync",
-            summary: "Sync installed skills to the agent's metadata file",
-            syntax: Some("sync [OPTIONS]"),
-            category: Some("packages"),
-            spec: None,
-            validator: None,
-            expose_mcp: false,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let fctx = downcast_fctx(ctx)?;
-                    let (handle, raw) = (fctx.service_handle(), fctx.raw_remaining_args.clone());
-                    let svc = handle.get().await?;
-                    let args = parse_from_args::<sync::SyncArgs>(&raw[1..])?;
-                    sync::execute_sync(&svc, args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "sync",
+                summary: "Sync installed skills to the agent's metadata file",
+                syntax: Some("sync [OPTIONS]"),
+                category: Some("packages"),
+                spec: None,
+                validator: None,
+                expose_mcp: false,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let svc = state.service().await?;
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<sync::SyncArgs>(&raw[1..])?;
+                        sync::execute_sync(&svc, args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "reindex",
-            summary: "Reindex the vector index for semantic search",
-            syntax: Some("reindex [OPTIONS]"),
-            category: Some("packages"),
-            spec: None,
-            validator: None,
-            expose_mcp: false,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let fctx = downcast_fctx(ctx)?;
-                    let (handle, raw) = (fctx.service_handle(), fctx.raw_remaining_args.clone());
-                    let svc = handle.get().await?;
-                    let args = parse_from_args::<reindex::ReindexArgs>(&raw[1..])?;
-                    reindex::execute_reindex(&svc, args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "reindex",
+                summary: "Reindex the vector index for semantic search",
+                syntax: Some("reindex [OPTIONS]"),
+                category: Some("packages"),
+                spec: None,
+                validator: None,
+                expose_mcp: false,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let svc = state.service().await?;
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<reindex::ReindexArgs>(&raw[1..])?;
+                        reindex::execute_reindex(&svc, args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "remove",
-            summary: "Uninstall skills (removes from manifest and local installation)",
-            syntax: Some("remove <SKILL_ID>... [OPTIONS]"),
-            category: Some("packages"),
-            spec: None,
-            validator: None,
-            expose_mcp: false,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let fctx = downcast_fctx(ctx)?;
-                    let (handle, global, raw) = (
-                        fctx.service_handle(),
-                        fctx.global,
-                        fctx.raw_remaining_args.clone(),
-                    );
-                    let svc = handle.get().await?;
-                    let args = parse_from_args::<remove::RemoveArgs>(&raw[1..])?;
-                    remove::execute_remove(&svc, args, global).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "remove",
+                summary: "Uninstall skills (removes from manifest and local installation)",
+                syntax: Some("remove <SKILL_ID>... [OPTIONS]"),
+                category: Some("packages"),
+                spec: None,
+                validator: None,
+                expose_mcp: false,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let svc = state.service().await?;
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<remove::RemoveArgs>(&raw[1..])?;
+                        remove::execute_remove(&svc, args, state.global).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "resolve",
-            summary: "Resolve skills as machine-readable JSON with canonical paths",
-            syntax: Some("resolve <QUERY> [OPTIONS]"),
-            category: Some("discovery"),
-            spec: None,
-            validator: None,
-            expose_mcp: true,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let fctx = downcast_fctx(ctx)?;
-                    let (handle, raw) = (fctx.service_handle(), fctx.raw_remaining_args.clone());
-                    let svc = handle.get().await?;
-                    let args = parse_from_args::<resolve::ResolveArgs>(&raw[1..])?;
-                    resolve::execute_resolve(&svc, args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "resolve",
+                summary: "Resolve skills as machine-readable JSON with canonical paths",
+                syntax: Some("resolve <QUERY> [OPTIONS]"),
+                category: Some("discovery"),
+                spec: None,
+                validator: None,
+                expose_mcp: true,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let svc = state.service().await?;
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<resolve::ResolveArgs>(&raw[1..])?;
+                        resolve::execute_resolve(&svc, args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "search",
-            summary: "Search skills by query with explicit scope flags",
-            syntax: Some("search <QUERY> [--local|--remote] [OPTIONS]"),
-            category: Some("discovery"),
-            spec: None,
-            validator: None,
-            expose_mcp: true,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let fctx = downcast_fctx(ctx)?;
-                    let (handle, raw) = (fctx.service_handle(), fctx.raw_remaining_args.clone());
-                    let svc = handle.get().await?;
-                    let args = parse_from_args::<search::SearchArgs>(&raw[1..])?;
-                    search::execute_search(&svc, args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "search",
+                summary: "Search skills by query with explicit scope flags",
+                syntax: Some("search <QUERY> [--local|--remote] [OPTIONS]"),
+                category: Some("discovery"),
+                spec: None,
+                validator: None,
+                expose_mcp: true,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let svc = state.service().await?;
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<search::SearchArgs>(&raw[1..])?;
+                        search::execute_search(&svc, args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?
-        .register_command(Command {
-            id: "serve",
-            summary: "Start the FastSkill HTTP API server",
-            syntax: Some("serve [OPTIONS]"),
-            category: Some("server"),
-            spec: None,
-            validator: None,
-            expose_mcp: false,
-            execute: Arc::new(|ctx, _args| {
-                Box::pin(async move {
-                    let fctx = downcast_fctx(ctx)?;
-                    let (handle, raw) = (fctx.service_handle(), fctx.raw_remaining_args.clone());
-                    let svc = handle.get().await?;
-                    let args = parse_from_args::<serve::ServeArgs>(&raw[1..])?;
-                    serve::execute_serve(svc, args).await?;
-                    Ok(())
-                })
-            }),
+        .register_command({
+            let state = Arc::clone(&state);
+            Command {
+                id: "serve",
+                summary: "Start the FastSkill HTTP API server",
+                syntax: Some("serve [OPTIONS]"),
+                category: Some("server"),
+                spec: None,
+                validator: None,
+                expose_mcp: false,
+                execute: Arc::new(move |_ctx, _args| {
+                    let state = Arc::clone(&state);
+                    Box::pin(async move {
+                        let svc = state.service().await?;
+                        let raw = state.raw_remaining_args.clone();
+                        let args = parse_from_args::<serve::ServeArgs>(&raw[1..])?;
+                        serve::execute_serve(svc, args).await?;
+                        Ok(())
+                    })
+                }),
+            }
         })?;
 
     Ok(builder)
@@ -649,5 +675,28 @@ mod tests {
         let (_skills_dir, _global, verbose, remaining) = strip_global_flags(args);
         assert!(verbose);
         assert_eq!(remaining, vec!["fastskill", "list"]);
+    }
+
+    #[test]
+    fn test_fsstate_new_stores_fields() {
+        let state = FsState::new(
+            Some(PathBuf::from("/tmp/skills")),
+            true,
+            true,
+            vec!["fastskill".to_string(), "list".to_string()],
+        );
+        assert_eq!(
+            state.skills_dir_override,
+            Some(PathBuf::from("/tmp/skills"))
+        );
+        assert!(state.global);
+        assert!(state.verbose);
+        assert_eq!(state.raw_remaining_args, vec!["fastskill", "list"]);
+    }
+
+    #[test]
+    fn test_fsctx_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<FsCtx>();
     }
 }


### PR DESCRIPTION
## Summary

Closes #168

- Bumps cli-framework dependency from `7728115` to `6d198a2` (latest HEAD)
- Replaces `Any`-downcast pattern (`as_any()`/`as_any_mut()`) with `Arc<FsState>` closure capture across all 21 command registrations
- Introduces `FsState` struct (Arc-shared state) and simplifies `FsCtx` to a trivial empty struct satisfying `AppContext: Send + Sync`
- Removes `ServiceHandle` intermediary; `FsState::service()` now handles lazy init directly
- Removes obsolete `downcast_fctx()` function and downcast roundtrip tests
- Drops `chat` default feature via `default-features = false` on workspace entry (avoids pulling `aikit-agent`)

## Files Changed

| File | Change |
|------|--------|
| `Cargo.toml` (workspace) | Bump cli-framework rev to `6d198a2` |
| `Cargo.lock` | Updated lockfile (removes unused transitive deps like `anthropic-sdk`, `async-openai`) |
| `crates/fastskill-cli/src/context.rs` | Replace `FsCtx` with empty struct + `FsState` with `Arc`-shared state |
| `crates/fastskill-cli/src/main.rs` | Rewrite `build_app` to capture `Arc<FsState>`, remove `downcast_fctx`, update `main()` |

## Testing

- All 349 tests pass (`cargo nextest run --workspace`)
- Clippy clean (`cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`)
- Formatted (`cargo fmt --all -- --check`)