### PR TITLE
docs: comprehensive alignment of README + webdocs with the actual CLI (0.9.152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,117 +1,176 @@
 # FastSkill
 
-Package manager and operational toolkit for Agent AI Skills.
+**Package manager and operational toolkit for AI agent skills.**
 
 [![CI](https://github.com/gofastskill/fastskill/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/gofastskill/fastskill/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/gofastskill/fastskill/branch/main/graph/badge.svg)](https://codecov.io/gh/gofastskill/fastskill)
 
-## Why FastSkill
+FastSkill brings package management to AI agent skills. It follows the Claude Code `SKILL.md`
+layout and adds a manifest (`skill-project.toml`), a lockfile (`skills.lock`), semantic search,
+quality evals, and a local HTTP/MCP server — so you can **install, organize, discover, and operate
+skills reproducibly**, alone or across a team. Think `npm`/`uv`, but for the skills your agents load.
 
-FastSkill helps you manage AI skills with a clean, repeatable workflow:
+Skills are read directly from your skills directory by Claude Code, Cursor, and other compatible
+agents — there is no metadata-file sync step. FastSkill manages the files; your agent reads them.
 
-- Install skills from local folders, git repositories, or registries
-- Keep installs reproducible with `skill-project.toml` and `skills.lock`
-- Discover skills with remote and local search
-- Validate and evaluate skill quality before sharing
-- Diagnose your environment with `fastskill doctor`
+---
+
+## Who it's for
+
+| You are… | FastSkill gives you… |
+|----------|----------------------|
+| **A developer** using Claude Code / Cursor | One command to install a skill from git, a folder, a zip, or a registry — and `list`/`read`/`search` to see exactly what your agent will load. |
+| **A team** sharing an agent setup | A committed `skill-project.toml` + `skills.lock` so every teammate and CI gets the identical skill set, with groups to split dev-only from production skills. |
+| **An organization** operating skills at scale | Private repositories, reproducible locked installs, duplicate/cluster analysis across large skill collections, and a local API/MCP surface for integration. |
+| **A skill author** | `init` to scaffold a manifest, `eval` to test that your skill triggers on the cases you care about, `optimize` to refine it automatically, and `marketplace create` to publish a catalog. |
+
+## What you can do
+
+- **Install skills** from a local folder, a git repo (branch/tag/subdirectory), a zip URL, or a registry ID.
+- **Keep installs reproducible** with `skill-project.toml` + `skills.lock`; split optional vs production skills into groups.
+- **Discover skills** by meaning with semantic search (remote catalogs by default, `--local` for installed skills).
+- **Test skill quality** with eval suites (`fastskill eval`) before you ship.
+- **Improve skills automatically** with the text-gradient optimizer (`fastskill optimize`).
+- **Analyze a collection** for near-duplicates, clusters, and similarity (`fastskill analyze`).
+- **Serve locally** — a read-only-by-default HTTP API and web UI (`fastskill serve`), plus an MCP server that exposes every command to your agent (`fastskill mcp`).
+- **Diagnose** your setup at any time with `fastskill doctor`.
+
+## Install
+
+Pick one (see the [installation guide](webdocs/installation.mdx) for all options and platform notes):
+
+```bash
+# macOS & Linux (Homebrew)
+brew install gofastskill/cli/fastskill
+
+# Windows (Scoop)
+scoop bucket add gofastskill https://github.com/gofastskill/scoop-bucket
+scoop install fastskill
+
+# Linux & macOS (install script)
+curl -fsSL https://raw.githubusercontent.com/gofastskill/fastskill/main/scripts/install.sh | bash
+```
+
+Verify:
+
+```bash
+fastskill -V
+```
 
 ## Quick start
 
 ```bash
-fastskill -V
-fastskill init
-fastskill add ./skills/my-skill -e --group dev
-fastskill install
-fastskill list
+fastskill init                              # scaffold skill-project.toml
+fastskill add ./skills/my-skill -e --group dev   # add a local skill (editable), in the dev group
+fastskill install                           # apply the manifest, write skills.lock
+fastskill list                              # see installed skills + reconciliation status
 ```
 
-Optional local search flow:
+Optional semantic search (needs an embedding provider — set `OPENAI_API_KEY`):
 
 ```bash
-fastskill reindex
-fastskill search "text processing" --local
+fastskill reindex                           # build the local vector index
+fastskill search "text processing" --local  # find installed skills by meaning
 ```
 
-## skill-project.toml (project manifest)
+## Common scenarios
 
-`skill-project.toml` is the project manifest for skill dependencies.
-It keeps installs reproducible across teammates and CI together with `skills.lock`.
+**Add a skill from anywhere**
 
-Minimal example:
+```bash
+fastskill add ./skills/pptx-helper -e             # local folder, editable (symlink)
+fastskill add ./skills -r --group dev             # every SKILL.md under a folder
+fastskill add https://github.com/org/skill.git --branch main
+fastskill add "https://github.com/org/repo/tree/main/path/to/skill"   # git subdirectory
+fastskill add scope/pptx@1.0.0                    # a pinned registry skill
+```
+
+**Reproducible install in CI**
+
+```bash
+fastskill install --lock          # install exact versions from skills.lock
+fastskill install --without dev   # skip the dev group for production
+```
+
+**Use a shared catalog (repository)**
+
+```bash
+fastskill repos add team-skills --repo-type git-marketplace https://github.com/org/team-skills.git
+fastskill repos list
+fastskill search "web scraping"   # remote catalogs by default
+```
+
+**Test and refine a skill you're authoring**
+
+```bash
+fastskill eval validate           # check your eval config
+fastskill eval run --all --output-dir ./eval-runs
+fastskill optimize run --config optimize.toml     # auto-improve the skill document
+```
+
+**Integrate with your agent**
+
+```bash
+fastskill mcp install --agent claude --scope project   # expose fastskill as MCP tools
+fastskill serve                                        # local HTTP API + web UI (read-only)
+```
+
+## Command reference
+
+| Command | What it does |
+|---------|--------------|
+| `fastskill init` | Scaffold `skill-project.toml` in the current project or skill |
+| `fastskill add <source>` | Add a skill from a local path, zip, git URL, or registry ID |
+| `fastskill install` | Apply the manifest (`--lock`, `--only`, `--without`) |
+| `fastskill update [id]` | Move installed skills forward from their source (`--check`, `--dry-run`) |
+| `fastskill remove <id>…` | Uninstall skills and update the manifest + lock |
+| `fastskill list` | List installed skills with reconciliation status (`--format`, `--json`) |
+| `fastskill read <id>` | Print a skill's `SKILL.md` (`--meta`, `--tree`) |
+| `fastskill search <query>` | Search remote catalogs (default) or installed skills (`--local`) |
+| `fastskill reindex` | Rebuild the local semantic search index |
+| `fastskill repos <cmd>` | Manage repositories & browse catalogs (`list/add/remove/info/update/test/refresh/skills/show/versions`) |
+| `fastskill marketplace create` | Generate a `marketplace.json` catalog from a folder of skills |
+| `fastskill eval <cmd>` | Skill quality evals (`validate/run/report/score`) |
+| `fastskill optimize <cmd>` | Text-gradient skill optimization (`run/resume/status/inspect/export`) |
+| `fastskill analyze <cmd>` | Similarity `matrix`, `cluster`, and `duplicates` across skills |
+| `fastskill serve` | Local HTTP API + web UI (read-only by default; `--enable-write` to mutate) |
+| `fastskill mcp <cmd>` | Run/install the MCP server (`serve/install/list`) for agents |
+| `fastskill doctor` | Diagnose configuration and environment readiness |
+
+Every command supports `--help`. Run `fastskill <skill-id>` as a shorthand for `fastskill read <skill-id>`.
+
+## Configuration
+
+All project configuration lives in **`skill-project.toml`** at your project root (FastSkill walks up
+to find it). A minimal manifest:
 
 ```toml
 [dependencies]
 demo-skill = { source = "local", path = "./skills/demo-skill", editable = true, groups = ["dev"] }
+
+# Only needed for semantic search (reindex / search --local):
+[tool.fastskill.embedding]
+openai_base_url = "https://api.openai.com/v1"
+embedding_model = "text-embedding-3-small"
 ```
 
-Typical workflow:
-
-```bash
-fastskill add ./skills/demo-skill -e --group dev
-fastskill install
-fastskill list
-```
-
-## Usage examples
-
-### Add from local folder (editable)
-
-```bash
-fastskill add ./skills/pptx-helper -e --group dev
-fastskill install
-```
-
-### Add from git
-
-```bash
-fastskill add https://github.com/org/skill.git --branch main
-fastskill install
-```
-
-### Add from registry
-
-```bash
-fastskill add scope/pptx@1.0.0
-fastskill install --lock
-```
-
-## Core commands
-
-| Command | What it does |
-|---------|--------------|
-| `fastskill add <source>` | Add a skill dependency from local, git, zip, or registry |
-| `fastskill install` | Apply dependencies from `skill-project.toml` |
-| `fastskill list` | List installed skills |
-| `fastskill read <id>` | Print a skill's full `SKILL.md` (add `--meta` for metadata, `--tree` for its dependency tree) |
-| `fastskill search "<query>"` | Search remote catalog (default) |
-| `fastskill search "<query>" --local` | Search installed skills |
-| `fastskill eval validate` | Validate eval configuration and checks |
-| `fastskill doctor` | Diagnose configuration and environment (e.g. whether semantic search is available) |
+Set `OPENAI_API_KEY` in your environment to enable embedding-based search. See the
+[configuration guide](webdocs/configuration/init-command.mdx) for the full schema (repositories,
+groups, server, eval).
 
 ## Documentation
 
-- [Welcome](webdocs/welcome.mdx)
-- [Quick Start](webdocs/quickstart.mdx)
-- [Installation](webdocs/installation.mdx)
+- [Welcome](webdocs/welcome.mdx) — the full story and use cases
+- [Quick Start](webdocs/quickstart.mdx) · [Installation](webdocs/installation.mdx) · [Cheatsheet](webdocs/cheatsheet.mdx)
 - [CLI Reference](webdocs/cli-reference/overview.mdx)
-- [Registry Guide](webdocs/registry/overview.mdx)
+- [Registry & repositories](webdocs/registry/overview.mdx)
+- [Evals & quality](webdocs/evals-quality/overview.mdx) · [Optimization](webdocs/optimize/overview.mdx)
+- [Integrations: Claude Code](webdocs/integration/claude-code-integration.mdx) · [Cursor](webdocs/integration/cursor-integration.mdx)
 
-## Crates
+## Contributing
 
-This repository is a Rust workspace with three primary crates:
-
-- [`crates/fastskill-cli`](crates/fastskill-cli): CLI binary and command routing.
-- [`crates/fastskill-core`](crates/fastskill-core): reusable service/library layer.
-- [`crates/fastskill-evals`](crates/fastskill-evals): standalone evaluation engine primitives.
-
-Each crate has its own docs:
-
-- `crates/fastskill-cli/README.md`
-- `crates/fastskill-cli/CONTRIBUTING.md`
-- `crates/fastskill-core/README.md`
-- `crates/fastskill-core/CONTRIBUTING.md`
-- `crates/fastskill-evals/README.md`
-- `crates/fastskill-evals/CONTRIBUTING.md`
+FastSkill is a Rust workspace (`fastskill-cli`, `fastskill-core`, `fastskill-evals`). To build from
+source, run the test suite, or contribute, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 

--- a/webdocs/cli-reference/discovery-commands.mdx
+++ b/webdocs/cli-reference/discovery-commands.mdx
@@ -65,7 +65,7 @@ fastskill search "process text" --repository my-repo
 Rebuild the vector search index by scanning all installed skills. Updates embeddings and similarity database.
 
 <Callout type="info">
-See [reindex Command](/cli-reference/reindex-command) for complete documentation with concurrency options.
+See [reindex Command](/cli-reference/reindex-command) for complete documentation.
 </Callout>
 
 ```bash
@@ -74,9 +74,6 @@ fastskill reindex
 
 # Force reindex (ignore file hash cache)
 fastskill reindex --force
-
-# Control concurrent embedding requests (default 5)
-fastskill reindex --max-concurrent 5
 
 # Optional explicit skills directory
 fastskill reindex --skills-dir ./.claude/skills
@@ -92,8 +89,9 @@ fastskill reindex --skills-dir ./.claude/skills
 **Options**:
 - `--skills-dir <PATH>`: Override skills directory for this run
 - `--force`: Rebuild all embeddings (ignore hash cache)
-- `--max-concurrent <N>`: Concurrent embedding requests (default: 5)
+- `--max-concurrent <N>`: Accepted for compatibility but currently a **no-op** — reindex embeds skills sequentially (default value: 5)
 - `--progress` / `--no-progress`: Control progress UI
+- `-v, --verbose`: Show per-skill processing details
 
 **When to use**:
 - After installing new skills
@@ -148,9 +146,9 @@ type = "git-marketplace"
 url = "https://github.com/team/skills.git"
 priority = 0
 branch = "main"
-# Optional authentication
-auth_type = "pat"
-auth_value = "token-value"
+# Optional authentication — the token is read from the named environment variable,
+# never stored inline in the file.
+auth = { type = "pat", env_var = "GITHUB_TOKEN" }
 ```
 
 **HTTP Registry**:
@@ -160,9 +158,8 @@ name = "public-registry"
 type = "http-registry"
 index_url = "https://registry.fastskill.dev/index"
 priority = 0
-# Optional authentication
-auth_type = "api-key"
-auth_value = "key-value"
+# Optional authentication — the key is read from the named environment variable.
+auth = { type = "api_key", env_var = "FASTSKILL_API_KEY" }
 ```
 
 **ZIP URL**:
@@ -183,22 +180,18 @@ path = "./local-skills"
 priority = 0
 ```
 
-**Authentication Types**:
-- `pat`: Personal Access Token (for git repositories)
-- `ssh-key`: SSH key path
-- `ssh`: SSH connection
-- `basic`: Basic authentication (username/password)
-- `api-key`: API key (for HTTP registries)
+**Authentication Types** (the `type` value in the `auth` table):
+- `pat`: Personal Access Token (for git repositories) — `{ type = "pat", env_var = "..." }`
+- `ssh-key`: SSH key path — `{ type = "ssh-key", path = "..." }`
+- `ssh`: SSH connection — `{ type = "ssh", key_path = "..." }`
+- `basic`: Basic authentication — `{ type = "basic", username = "...", password_env = "..." }`
+- `api_key`: API key (for HTTP registries) — `{ type = "api_key", env_var = "..." }`
 
 **Priority Resolution**:
 When skills are available in multiple repositories, priority determines the order:
 - Lower priority numbers are checked first
 - Default priority: 0
 - Higher priority values are checked later
-
-<Callout type="warn">
-**Legacy commands**: `sources` (alias `source`) and `registry` are hidden from `fastskill --help` but still exist for compatibility. Prefer `fastskill repos` for repository and catalog operations.
-</Callout>
 
 ## Search and Reindex Workflow
 
@@ -251,10 +244,8 @@ fastskill search "skill name or description"
 - Use `--force` to bypass hash cache
 
 **Concurrency**:
-- Embedding API requests are concurrent (default: 10)
-- Use `--max-concurrent` to control API rate limiting
-- Lower values reduce API rate limit errors
-- Higher values speed up reindexing
+- Reindex embeds skills **sequentially** (one at a time)
+- `--max-concurrent` is accepted for compatibility but is currently a **no-op** — it does not change indexing speed or the number of concurrent API requests
 
 ### Searching
 
@@ -295,7 +286,7 @@ fastskill search "skill name or description"
   </Callout>
 
   <Callout type="info">
-  **API rate limit errors**: Reduce concurrent requests with `--max-concurrent 3`.
+  **API rate limit errors**: Reindex already runs sequentially — wait and retry.
   </Callout>
 
   <Callout type="info">
@@ -336,9 +327,9 @@ Set lower priority numbers for primary repositories to ensure preferred skills a
 
 Use `fastskill repos test <name>` to verify repositories are accessible before using them.
 
-### 5. Control API concurrency for reindexing
+### 5. Reindex incrementally
 
-Use `--max-concurrent` to balance speed and API rate limits. Start with default and adjust based on rate limit errors.
+Reindex skips unchanged skills by default (via the file-hash cache), so routine reindexing is cheap. Use `--force` only when you need to rebuild every embedding.
 
 ## See Also
 

--- a/webdocs/cli-reference/eval-command.mdx
+++ b/webdocs/cli-reference/eval-command.mdx
@@ -30,7 +30,7 @@ fastskill eval validate --json
 | Option | Description |
 |--------|-------------|
 | `--agent <AGENT>` | Verify the given agent is available |
-| `--format <FORMAT>` | `table`, `json`, `grid`, or `xml` |
+| `--format <FORMAT>` | `table` or `json` only (eval does not support `grid`/`xml`) |
 | `--json` | Shorthand for `--format json` |
 
 ## eval run
@@ -51,7 +51,7 @@ fastskill eval run --agent codex --output-dir ./evals --json --no-fail
 | `--model <MODEL>` | Optional model override passed to the agent |
 | `--case <ID>` | Run only this case id |
 | `--tag <TAG>` | Run only cases with this tag |
-| `--format <FORMAT>` | Output format |
+| `--format <FORMAT>` | `table` or `json` only |
 | `--json` | Shorthand for `--format json` |
 | `--no-fail` | Exit zero even when the suite fails |
 
@@ -67,7 +67,7 @@ fastskill eval report --run-dir /tmp/evals/latest --json
 | Option | Description |
 |--------|-------------|
 | `--run-dir <DIR>` | **Required.** Run directory to summarize |
-| `--format <FORMAT>` | Output format |
+| `--format <FORMAT>` | `table` or `json` only |
 | `--json` | Shorthand for `--format json` |
 
 ## eval score
@@ -82,7 +82,7 @@ fastskill eval score --run-dir /tmp/evals/run-1 --no-fail
 | Option | Description |
 |--------|-------------|
 | `--run-dir <DIR>` | **Required.** Run directory |
-| `--format <FORMAT>` | Output format |
+| `--format <FORMAT>` | `table` or `json` only |
 | `--json` | Shorthand for `--format json` |
 | `--no-fail` | Exit zero on suite failure |
 

--- a/webdocs/cli-reference/overview.mdx
+++ b/webdocs/cli-reference/overview.mdx
@@ -47,8 +47,8 @@ fastskill list --help         # Help for list command
 |--------|-------------|---------|
 | `-V, --version` | Print the `fastskill` binary version and exit | `fastskill -V` |
 | `--verbose`, `-v` | Enable verbose logging | `fastskill -v list` |
-| `--repositories-path` | Override path to `repositories.toml` | `fastskill --repositories-path ./repositories.toml list` |
-| `--global` | Use the user-level global skills directory | `fastskill --global list` |
+| `--skills-dir <PATH>` | Override the skills directory path | `fastskill --skills-dir ./skills list` |
+| `--global` | Use the user-level global skills directory (`~/.config/fastskill/skills`) | `fastskill --global list` |
 | Positional `SKILL_ID` | Shorthand for `fastskill read <id>` when no subcommand is given | `fastskill pptx` |
 | `--help`, `-h` | Help | `fastskill --help` |
 
@@ -148,24 +148,19 @@ fastskill 0.9.3
 
 ### Configuration Files
 
-The CLI uses `.fastskill/config.yaml` for service-level configuration:
-
-```yaml .fastskill/config.yaml
-embedding:
-  openai_base_url: "https://api.openai.com/v1"
-  embedding_model: "text-embedding-3-small"
-
-# Optional: Custom skills directory
-skills_directory: ".claude/skills"
-```
-
-Project-level configuration (skill dependencies and repositories) is stored in `skill-project.toml` at your project root:
+All configuration lives in `skill-project.toml` at your project root. Skill dependencies go under `[dependencies]`; embedding, skills directory, and repositories go under the `[tool.fastskill]` tables:
 
 ```toml skill-project.toml
 [dependencies]
 web-scraper = { source = "git", url = "https://github.com/org/web-scraper.git" }
 
-[tool.fastskill.repositories]
+[tool.fastskill]
+skills_directory = ".claude/skills"
+
+[tool.fastskill.embedding]
+openai_base_url = "https://api.openai.com/v1"
+embedding_model = "text-embedding-3-small"
+
 [[tool.fastskill.repositories]]
 name = "public-registry"
 type = "http-registry"

--- a/webdocs/cli-reference/reindex-command.mdx
+++ b/webdocs/cli-reference/reindex-command.mdx
@@ -47,26 +47,22 @@ fastskill reindex --skills-dir .claude/skills/ --force
 
 ### --max-concurrent `&lt;NUMBER&gt;`
 
-Control the number of concurrent embedding API requests (default: 5).
-
-```bash
-# Increase concurrency for faster indexing
-fastskill reindex --skills-dir .claude/skills/ --max-concurrent 10
-
-# Reduce concurrency to avoid rate limits
-fastskill reindex --skills-dir .claude/skills/ --max-concurrent 2
-```
+<Callout type="warning">
+This flag is currently a **no-op**. It is accepted for compatibility but has no effect:
+`reindex` embeds skills **sequentially**, one at a time. Passing a value does not change
+indexing speed or the number of concurrent API requests.
+</Callout>
 
 ## Configuration Requirements
 
-### 1. FastSkill Configuration
+### 1. Embedding Configuration
 
-Create `.fastskill/config.yaml` with embedding settings:
+Add embedding settings to `skill-project.toml` under `[tool.fastskill.embedding]`:
 
-```yaml
-embedding:
-  openai_base_url: "https://api.openai.com/v1"
-  embedding_model: "text-embedding-3-small"
+```toml
+[tool.fastskill.embedding]
+openai_base_url = "https://api.openai.com/v1"
+embedding_model = "text-embedding-3-small"
 ```
 
 ### 2. OpenAI API Key
@@ -115,9 +111,9 @@ For each SKILL.md file:
 
 ### 4. Index Building
 
-- Creates/updates SQLite database
-- Stores metadata, embeddings, and file hashes
-- Creates optimized indexes for fast search
+- Creates/updates the SQLite vector index (`.fastskill/index.db`)
+- Stores metadata and embeddings for fast semantic search
+- Records file hashes in the change-detection cache (`.fastskill/build-cache.json`)
 
 ### 5. Cleanup
 
@@ -129,11 +125,11 @@ For each SKILL.md file:
 
 ### Output Levels
 
-The reindex command supports three output levels:
+The reindex command has these output controls:
 
-- **Default**: Shows progress bar with completion percentage
+- **Default**: Shows a live progress bar with completion percentage (when stdout is a TTY)
 - **Verbose (`-v, --verbose`)**: Shows per-skill processing details
-- **Quiet (`-q, --quiet`)**: Suppresses progress, shows only final summary
+- **`--progress` / `--no-progress`**: Force the progress bar on, or suppress it and show only the final summary
 
 ### Progress Bar
 
@@ -173,12 +169,12 @@ Reindex completed
   Total time: 45.23s
 ```
 
-### Quiet Mode
+### No-Progress Mode
 
-Use `-q` or `--quiet` to suppress all progress output:
+Use `--no-progress` to suppress the progress bar and show only the final summary:
 
 ```bash
-fastskill reindex --quiet
+fastskill reindex --no-progress
 
 Reindex completed
   Total skills: 50
@@ -230,8 +226,8 @@ fastskill reindex --skills-dir .claude/skills/ | grep "error"
 # No progress bar (redirected to file)
 fastskill reindex --skills-dir .claude/skills/ > output.log
 
-# Force quiet mode explicitly
-fastskill reindex --quiet
+# Suppress the progress bar explicitly
+fastskill reindex --no-progress
 ```
 
 ## Output and Progress
@@ -270,28 +266,34 @@ Reindex completed
 error: Reindex completed with 2 errors
 ```
 
-In quiet or default mode, only the summary and error count are shown.
+In default or `--no-progress` mode, only the summary and error count are shown.
 
 Common errors:
 - **API Key Issues**: Check `OPENAI_API_KEY` environment variable
-- **Rate Limits**: Reduce `--max-concurrent` or wait before retrying
+- **Rate Limits**: Wait before retrying (reindex already runs sequentially)
 - **Network Issues**: Check internet connectivity
 - **Permission Issues**: Ensure write access to skills directory
 
-## Database Location
+## On-Disk Layout
 
-The vector index is stored in the skills directory:
+Reindex maintains two files inside the skills directory's `.fastskill/` folder:
 
 ```
 .claude/skills/
 └── .fastskill/
-    └── index.db
+    ├── index.db           # vector index (embeddings)
+    └── build-cache.json   # change-detection cache (file hashes)
 ```
 
-**File Details:**
+**`index.db`** — the vector index:
 - **Format**: SQLite database
 - **Size**: ~1-10MB depending on number of skills
-- **Content**: Metadata, embeddings, file hashes, timestamps
+- **Content**: Metadata and embeddings used by semantic search
+
+**`build-cache.json`** — the change-detection cache:
+- **Format**: JSON
+- **Content**: Per-skill file hashes used to decide which skills changed since the last run
+- Used to skip re-embedding unchanged skills (bypassed with `--force`)
 
 ## Performance Considerations
 
@@ -310,9 +312,6 @@ The vector index is stored in the skills directory:
 ### Optimization Tips
 
 ```bash
-# Use smaller batches for rate limit avoidance
-fastskill reindex --max-concurrent 2
-
 # Index only changed skills (default behavior)
 fastskill reindex --skills-dir .claude/skills/
 
@@ -355,14 +354,12 @@ no separate metadata file to generate or sync.
 
 #### Reindex skipped: no embedding provider configured
 `reindex` requires an embedding provider. When none is configured it is skipped (not an error) —
-run `fastskill doctor` to confirm, then configure one in `.fastskill/config.yaml`:
+run `fastskill doctor` to confirm, then configure one in `skill-project.toml`:
 
-```bash
-cat > .fastskill/config.yaml << EOF
-embedding:
-  openai_base_url: "https://api.openai.com/v1"
-  embedding_model: "text-embedding-3-small"
-EOF
+```toml
+[tool.fastskill.embedding]
+openai_base_url = "https://api.openai.com/v1"
+embedding_model = "text-embedding-3-small"
 ```
 
 #### "OPENAI_API_KEY environment variable not set"
@@ -379,8 +376,8 @@ chmod 755 .claude/skills/
 
 #### Rate limit exceeded
 ```bash
-# Solution: Reduce concurrency and retry
-fastskill reindex --max-concurrent 1 --skills-dir .claude/skills/
+# Solution: reindex already runs sequentially; wait and retry
+fastskill reindex --skills-dir .claude/skills/
 ```
 
 ### Debug Mode
@@ -409,10 +406,10 @@ fastskill search "test" --local --embedding false --skills-dir .claude/skills
 
 Use different OpenAI models:
 
-```yaml
-embedding:
-  openai_base_url: "https://api.openai.com/v1"
-  embedding_model: "text-embedding-3-large"  # Higher accuracy, higher cost
+```toml
+[tool.fastskill.embedding]
+openai_base_url = "https://api.openai.com/v1"
+embedding_model = "text-embedding-3-large"  # Higher accuracy, higher cost
 ```
 
 ### Multiple Directories

--- a/webdocs/cli-reference/repository-command.mdx
+++ b/webdocs/cli-reference/repository-command.mdx
@@ -253,13 +253,15 @@ fastskill repos skills --scope acme --all-versions --json
 - `--scope <SCOPE>`: Filter skills by scope (exact match)
 - `--all-versions`: Include all versions for each skill (default: latest only)
 - `--include-pre-release`: Include pre-release versions (default: exclude)
-- `--format <table|json|grid>`: Output format (default: table)
+- `--format <table|json|grid|xml>`: Output format (default: table)
 - `--json`: Shorthand for --format json (mutually exclusive with --format)
 - `--repository <NAME>`: Repository name to list skills from (defaults to default repository if not specified)
 
 **Output Format**:
-- **Grid (default)**: Human-readable table with columns: scope, name, description (truncated to 50 chars), latest version (or "version" when `--all-versions` is used), published date
+- **Table (default)**: Human-readable table with columns: scope, name, description (truncated to 50 chars), latest version (or "version" when `--all-versions` is used), published date
+- **Grid**: Human-readable columnar layout with the same fields as table
 - **JSON**: Machine-readable array with fields: id, scope, name, description, latest_version, published_at, and optionally versions array
+- **XML**: Structured XML for agent consumption
 
 ### show
 

--- a/webdocs/cli-reference/search-command.mdx
+++ b/webdocs/cli-reference/search-command.mdx
@@ -278,8 +278,8 @@ echo "$RESULTS" | jq -r '.[].name'
 - **Solution**: Try broader terms or different search method
 
 #### "Embedding configuration required but not found"
-- **Cause**: No `.fastskill/config.yaml` configuration file found in searched locations
-- **Solution**: Run `fastskill init` to set up your project, or create `.fastskill/config.yaml` manually
+- **Cause**: No `[tool.fastskill.embedding]` section found in `skill-project.toml` (walked up from the current directory)
+- **Solution**: Run `fastskill init` to set up your project, or add `[tool.fastskill.embedding]` to `skill-project.toml` manually
 
 #### "Vector index service not available"
 - **Cause**: Skills not indexed yet
@@ -307,8 +307,8 @@ sqlite3 .claude/skills/.fastskill/index.db "SELECT COUNT(*) FROM skills;"
 
 #### Verify Configuration
 ```bash
-# Check if configuration file exists
-cat .fastskill/config.yaml
+# Check the embedding configuration
+cat skill-project.toml
 
 # Test API key is set
 echo $OPENAI_API_KEY
@@ -341,8 +341,10 @@ fastskill search "query" --format table # For human reading
 
 #### API Integration
 ```bash
-# For web applications
-curl -X GET "http://localhost:8080/api/search?q=powerpoint&format=json"
+# For web applications (POST JSON body to the running `fastskill serve` API)
+curl -X POST "http://localhost:8080/api/v1/search" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "powerpoint", "limit": 10, "semantic": true}'
 
 # For command-line tools
 fastskill search "$USER_QUERY" --format json | jq '.[] | select(.similarity > 0.8)'

--- a/webdocs/cli-reference/skill-commands.mdx
+++ b/webdocs/cli-reference/skill-commands.mdx
@@ -130,7 +130,7 @@ You can also run `fastskill <skill-id>` with no subcommand; it routes to the sam
 
 ### fastskill install
 
-Install skills from `skill-project.toml` to skills storage directory (like `poetry install`). The storage location is configured in `.fastskill/config.yaml` via `skills_directory` (default: `.claude/skills/`).
+Install skills from `skill-project.toml` to skills storage directory (like `poetry install`). The storage location is configured in `skill-project.toml` via `skills_directory` under `[tool.fastskill]` (default: `.claude/skills/`).
 
 <Callout type="info">
 See [install Command](/cli-reference/install-command) for complete documentation with groups, lockfile, and reconciliation features.
@@ -157,10 +157,10 @@ fastskill install --lock
 
 ### fastskill update
 
-Update skills in skills storage directory to their latest versions from source. The storage location is configured in `.fastskill/config.yaml` via `skills_directory` (default: `.claude/skills/`).
+Update skills in skills storage directory to their latest versions from source. The storage location is configured in `skill-project.toml` via `skills_directory` under `[tool.fastskill]` (default: `.claude/skills/`).
 
 <Callout type="info">
-See [update Command](/cli-reference/update-command) for complete documentation with strategies and version constraints.
+See [update Command](/cli-reference/update-command) for complete documentation of the working flags.
 </Callout>
 
 ```bash
@@ -181,9 +181,11 @@ fastskill update --dry-run
 - `<SKILL_ID>`: Skill ID to update (if not specified, updates all)
 - `--check`: Check for updates without installing
 - `--dry-run`: Show what would be updated without actually updating
-- `--version <VERSION>`: Update to specific version
-- `--source <SOURCE>`: Update from specific source
-- `--strategy <STRATEGY>`: Update strategy: latest, patch, minor, major (default: latest)
+- `--reindex` / `--no-reindex`: Control whether the vector index is rebuilt after updating
+
+<Callout type="warning">
+`--version`, `--source`, and `--strategy` are parsed for compatibility but currently have **no effect** — update always re-resolves each skill to what its origin considers current. See the [update Command](/cli-reference/update-command) page for details.
+</Callout>
 
 ### fastskill read (metadata and tree)
 
@@ -217,7 +219,7 @@ fastskill list
 
 Add a skill from a source (git URL, local folder, or zip file) and install it to the skills storage directory. Updates both `skill-project.toml` and `skills.lock`.
 
-**Storage Location**: Skills are installed to the directory configured in `.fastskill/config.yaml` via the `skills_directory` setting (default: `.claude/skills/`). Repository configuration is stored in `[tool.fastskill.repositories]` section of `skill-project.toml`.
+**Storage Location**: Skills are installed to the directory configured in `skill-project.toml` via the `skills_directory` setting under `[tool.fastskill]` (default: `.claude/skills/`). Repository configuration is stored in the `[[tool.fastskill.repositories]]` section of `skill-project.toml`.
 
 **Installing from a subdirectory**: Use a GitHub tree URL to add a skill that lives in a subfolder of a repo. Format: `https://github.com/user/repo/tree/<branch>/<path/to/skill>`. The CLI clones the repo and uses the specified path as the skill root.
 
@@ -258,7 +260,7 @@ fastskill add ./skills -r -e --group dev
 
 ### fastskill remove
 
-Remove a skill from the skills storage directory and update both `skill-project.toml` and `skills.lock`. The storage location is configured in `.fastskill/config.yaml` via `skills_directory` (default: `.claude/skills/`).
+Remove a skill from the skills storage directory and update both `skill-project.toml` and `skills.lock`. The storage location is configured in `skill-project.toml` via `skills_directory` under `[tool.fastskill]` (default: `.claude/skills/`).
 
 ```bash
 # Remove skill (with confirmation)

--- a/webdocs/cli-reference/update-command.mdx
+++ b/webdocs/cli-reference/update-command.mdx
@@ -5,7 +5,12 @@ api: "update"
 
 # update Command
 
-Update installed skills to the latest versions from their sources. Updates `skills.lock` with new versions.
+Update installed skills to the current version from their sources, then update `skills.lock`.
+
+For each skill, `update` re-resolves its origin to whatever that origin currently considers
+current — the newest allowed version for a registry/repository origin, or a fresh re-fetch for a
+git, local, or zip-url origin — and reinstalls it. There is no per-version or per-strategy
+selection (see the callout below).
 
 ## Usage
 
@@ -20,15 +25,24 @@ fastskill update [SKILL_ID] [OPTIONS]
 | `<SKILL_ID>` | Skill ID to update (if not specified, updates all) | None |
 | `--check` | Check for updates without installing | `false` |
 | `--dry-run` | Show what would be updated without actually updating | `false` |
-| `--version <VERSION>` | Update to specific version | None |
-| `--source <SOURCE>` | Update from specific source | None |
-| `--strategy <STRATEGY>` | Update strategy: latest, patch, minor, major | `latest` |
+| `--reindex` | Rebuild the search index after updating (overrides config) | config |
+| `--no-reindex` | Skip rebuilding the search index after updating | config |
+| `--global` | Operate on the global skill set (`~/.config/fastskill/skills`) instead of the project | `false` |
+
+<Callout type="warning">
+**`--version`, `--source`, and `--strategy` are parsed but currently have no effect.** They are
+accepted for backward compatibility, but the update seam always re-resolves each skill to what its
+origin considers current — it does not honor a requested version, alternate source, or SemVer
+strategy (`latest`/`patch`/`minor`/`major`). Do not rely on them to pin or constrain a version.
+To install an exact, reproducible set of versions, use `fastskill install --lock` against a
+committed `skills.lock`.
+</Callout>
 
 ## Examples
 
 ### Update All Skills
 
-Update all installed skills to latest compatible versions:
+Update all installed skills to their current versions:
 
 ```bash
 fastskill update
@@ -36,13 +50,13 @@ fastskill update
 
 This:
 - Reads all skills from `skill-project.toml` dependencies
-- Resolves latest versions from configured repositories
+- Re-resolves each origin to its current version
 - Updates skills in `.claude/skills/`
-- Updates `skills.lock` with new versions
+- Updates `skills.lock` with the resolved versions
 
-### Update Specific Skill
+### Update a Specific Skill
 
-Update only a specific skill:
+Update only one skill by ID:
 
 ```bash
 fastskill update web-scraper
@@ -50,14 +64,15 @@ fastskill update web-scraper
 
 ### Check for Updates
 
-Check which skills have updates available without installing:
+Show which skills have updates available without installing anything:
 
 ```bash
 fastskill update --check
 ```
 
 <Callout type="info">
-Use `--check` to see what's available before updating. Useful for reviewing changes before applying them.
+`--check` reports a coarse classification per skill — Updatable, Up to date, or Immutable — and
+makes no changes to any file. Use it to review before applying updates.
 </Callout>
 
 ### Dry Run
@@ -68,103 +83,47 @@ Preview what would be updated without making changes:
 fastskill update --dry-run
 ```
 
-### Update to Specific Version
+### Control Reindexing
 
-Update a skill to a specific version:
+By default, whether the search index is rebuilt after an update follows your configuration
+(`auto_reindex`). Override it per invocation:
 
 ```bash
-fastskill update web-scraper --version "2.0.0"
+# Force a reindex after updating
+fastskill update --reindex
+
+# Skip the reindex after updating
+fastskill update --no-reindex
 ```
 
-### Update with Patch Strategy
+### Update the Global Skill Set
 
-Update skills to latest patch version only (no minor or major changes):
-
-```bash
-# Update web-scraper from 1.2.3 to 1.2.4 (patch)
-fastskill update web-scraper --strategy patch
-
-# Update all skills to latest patch
-fastskill update --strategy patch
-```
-
-### Update with Minor Strategy
-
-Update skills to latest minor version (allows minor features, no breaking changes):
+Operate on the global skills directory (`~/.config/fastskill/skills`) and `global-skills.lock`
+instead of the current project:
 
 ```bash
-# Update web-scraper from 1.2.3 to 1.3.0 (minor)
-fastskill update web-scraper --strategy minor
-
-# Update all skills to latest minor
-fastskill update --strategy minor
-```
-
-### Update with Major Strategy
-
-Update skills to latest major version (allows breaking changes):
-
-```bash
-# Update web-scraper from 1.2.3 to 2.0.0 (major)
-fastskill update web-scraper --strategy major
-
-# Update all skills to latest major
-fastskill update --strategy major
-```
-
-## Update Strategies
-
-Update strategies determine which versions are considered for updates:
-
-| Strategy | Behavior | Example |
-|----------|----------|---------|
-| `latest` | Update to absolute latest version available | `1.2.3` → `2.5.1` (any version) |
-| `patch` | Update to latest patch version within current minor | `1.2.3` → `1.2.4` (1.2.x only) |
-| `minor` | Update to latest minor version within current major | `1.2.3` → `1.3.0` (1.x.x only) |
-| `major` | Update to latest major version (allows breaking changes) | `1.2.3` → `2.0.0` (any version) |
-
-### Strategy Examples
-
-```bash
-# Current version: 1.2.3
-
-# Update to latest (any version)
-fastskill update --strategy latest
-# Result: Could update to 2.5.1 (latest available)
-
-# Update to patch only
-fastskill update --strategy patch
-# Result: Updates to 1.2.4 (or 1.2.5, 1.2.6, etc., but stays in 1.2.x)
-
-# Update to minor only
-fastskill update --strategy minor
-# Result: Updates to 1.3.0 (or 1.4.0, 1.5.0, etc., but stays in 1.x.x)
-
-# Update to major (allows breaking)
-fastskill update --strategy major
-# Result: Updates to 2.0.0 (or 3.0.0, etc.)
+fastskill update --global
 ```
 
 ## Behavior
 
 The `update` command:
 
-1. **Locates Project File**: Finds `skill-project.toml` at project root
-2. **Loads Dependencies**: Reads `[dependencies]` section
-3. **Filters Skills**: If skill_id is specified, only updates that skill
-4. **Resolves Updates**: For each skill:
-   - If `--version` is set: Resolves specific version
-   - Otherwise: Resolves version based on strategy (latest/patch/minor/major)
-   - If `--source` is set: Uses specific source
-   - Otherwise: Uses source from dependency definition
-5. **Updates Skills**: Downloads and installs updated versions into `.claude/skills/`
-6. **Updates Lockfile**: Writes new versions to `skills.lock`
+1. **Locates Project File**: Finds `skill-project.toml` (or, with `--global`, the global skill set)
+2. **Loads Dependencies**: Reads the declared skills
+3. **Filters Skills**: If `SKILL_ID` is specified, only that skill is considered
+4. **Re-resolves Origins**: For each skill, resolves its origin to the current version — newest
+   allowed for a registry/repository origin, or a fresh re-fetch for a git/local/zip-url origin
+5. **Updates Skills**: Downloads and installs the resolved versions into `.claude/skills/`
+6. **Updates Lockfile**: Writes the resolved versions to `skills.lock`
+7. **Reindexes** (unless suppressed): Rebuilds the search index when an embedding provider is
+   configured and reindexing is not disabled
 
 ## Update Modes
 
 ### Update Mode (default)
 
-Updates skills and modifies lockfile:
+Updates skills and modifies the lockfile:
 
 ```bash
 fastskill update
@@ -177,7 +136,6 @@ Updating skills...
 Updating web-scraper...
 ✓ Updated web-scraper from 1.2.3 to 2.0.0
   Source: git
-  Changes: Breaking changes in version 2.0.0
 
 Updating data-processor...
 ✓ Updated data-processor from 2.1.0 to 2.2.0
@@ -203,13 +161,8 @@ Checking for updates...
 
 Skills with updates available:
 
-web-scraper: 1.2.3 → 2.0.0 (major update)
-  - Breaking changes in version 2.0.0
-  - New features: X, Y, Z
-
-data-processor: 2.1.0 → 2.2.0 (patch update)
-  - Bug fixes and improvements
-
+web-scraper: 1.2.3 → 2.0.0 (update available)
+data-processor: 2.1.0 → 2.2.0 (update available)
 demo-skill: Already up to date (0.1.0)
 
 Run 'fastskill update' to apply updates
@@ -229,93 +182,13 @@ Dry run: Showing what would be updated...
 
 Would update web-scraper from 1.2.3 to 2.0.0
   Source: git
-  Strategy: latest
 
 Would update data-processor from 2.1.0 to 2.2.0
   Source: registry
-  Strategy: latest
 
 Would keep demo-skill at 0.1.0 (already up to date)
 
 Dry run complete. No changes were made.
-```
-
-## Output Examples
-
-### Update All Skills
-
-```bash
-$ fastskill update
-Updating skills...
-
-Updating web-scraper...
-✓ Updated web-scraper from 1.2.3 to 2.0.0
-  Source: https://github.com/user/web-scraper.git
-
-Updating data-processor...
-✓ Updated data-processor from 2.1.0 to 2.2.0
-  Source: public-registry
-
-demo-skill: Already up to date (0.1.0)
-
-Updated skills.lock with 2 skill(s)
-
-✓ Update complete
-```
-
-### Update Single Skill
-
-```bash
-$ fastskill update web-scraper
-Updating skills...
-
-Updating web-scraper...
-✓ Updated web-scraper from 1.2.3 to 2.0.0
-  Source: https://github.com/user/web-scraper.git
-
-Updated skills.lock with 1 skill(s)
-
-✓ Update complete
-```
-
-### Update with Strategy
-
-```bash
-$ fastskill update --strategy minor
-Updating skills...
-
-Updating web-scraper...
-✓ Updated web-scraper from 1.2.3 to 1.3.0
-  Strategy: minor (updates within 1.x.x only)
-
-Updating data-processor...
-✓ Updated data-processor from 2.1.0 to 2.2.0
-  Strategy: minor (updates within 2.x.x only)
-
-demo-skill: Already up to date (0.1.0)
-
-Updated skills.lock with 2 skill(s)
-
-✓ Update complete
-```
-
-### Check for Updates
-
-```bash
-$ fastskill update --check
-Checking for updates...
-
-Skills with updates available:
-
-web-scraper: 1.2.3 → 2.0.0 (major update available)
-  Source: https://github.com/user/web-scraper.git
-
-data-processor: 2.1.0 → 2.2.0 (patch update available)
-  Source: public-registry
-
-demo-skill: Already up to date (0.1.0)
-
-Run 'fastskill update' to apply updates
 ```
 
 ## Update Workflow
@@ -326,13 +199,13 @@ Run 'fastskill update' to apply updates
 # 1. Check for updates
 fastskill update --check
 
-# 2. Review updates and decide
-# (e.g., skip major updates if breaking changes are concerning)
+# 2. Preview with a dry run
+fastskill update --dry-run
 
 # 3. Apply updates
-fastskill update --strategy minor
+fastskill update
 
-# 4. Reindex for search
+# 4. Reindex for search (or rely on auto-reindex)
 fastskill reindex
 
 # 5. Commit lockfile
@@ -340,62 +213,14 @@ git add skills.lock
 git commit -m "Update dependencies"
 ```
 
-### Controlled Production Update
+### Pinning to Exact Versions
+
+`update` does not pin versions. To reproduce an exact set of versions across machines or in CI,
+commit `skills.lock` and install from it:
 
 ```bash
-# 1. Check what's available
-fastskill update --check
-
-# 2. Dry run to preview
-fastskill update --strategy minor --dry-run
-
-# 3. Apply selective updates
-fastskill update web-scraper --version "1.3.0"
-fastskill update data-processor --strategy patch
-
-# 4. Reindex
-fastskill reindex
-```
-
-### Automated Update (CI/CD)
-
-```bash
-# Update all dependencies in CI/CD
-fastskill update --strategy patch
-
-# Or update only specific skills
-fastskill update web-scraper data-processor
-```
-
-## Version Constraint Examples
-
-### Update to Specific Version
-
-```bash
-# Update to exact version
-fastskill update web-scraper --version "2.0.0"
-
-# Output:
-# ✓ Updated web-scraper from 1.2.3 to 2.0.0
-#   Version constraint: 2.0.0
-```
-
-### Update from Specific Source
-
-```bash
-# Update from a different repository
-fastskill update web-scraper --source team-registry
-
-# Useful when skill is available in multiple repositories
-```
-
-### Combined with Strategy
-
-```bash
-# Update with strategy, then override version
-fastskill update --strategy patch --version "1.2.5"
-
-# Note: --version takes precedence over --strategy
+# Reproducible install from the committed lockfile
+fastskill install --lock
 ```
 
 ## Dependency Management
@@ -422,7 +247,7 @@ Updated skills.lock with 3 skill(s)
 
 ### Update Failures
 
-If one skill fails to update, the command continues with remaining skills:
+If one skill fails to update, the command continues with the remaining skills:
 
 ```bash
 $ fastskill update
@@ -450,16 +275,16 @@ $ fastskill update unknown-skill
 error: Skill 'unknown-skill' not found in skill-project.toml dependencies
 ```
 
-**Solution**: Check skill ID in `skill-project.toml` or add it first with `fastskill add`.
+**Solution**: Check the skill ID in `skill-project.toml`, or add it first with `fastskill add`.
 
-### Version Not Found
+### Missing Lockfile
 
 ```bash
-$ fastskill update web-scraper --version "99.9.9"
-error: Version '99.9.9' not found for skill 'web-scraper'
+$ fastskill update
+error: skills.lock not found. Run 'fastskill install' first.
 ```
 
-**Solution**: Check available versions with `fastskill repos versions web-scraper`.
+**Solution**: Run `fastskill install` to create `skills.lock`, then update.
 
 ### No Updates Available
 
@@ -489,32 +314,31 @@ Updating data-processor...
 ✓ Update complete with errors (1 failed)
 ```
 
-**Solution**: Check network connection and retry failed skills individually.
+**Solution**: Check the network connection and retry failed skills individually.
 
 ## Best Practices
 
 ### 1. Check before updating
 
-Use `fastskill update --check` to see what's available before applying updates. Review changes, especially for major version bumps.
+Use `fastskill update --check` and `fastskill update --dry-run` to see what would change before
+applying updates.
 
-### 2. Use appropriate strategies
+### 2. Reindex after updates
 
-- Use `--strategy patch` for bug fixes only
-  - Use `--strategy minor` for new features without breaking changes
-  - Use `--strategy major` when you're ready for breaking changes
-  - Use `--strategy latest` for bleeding edge (not recommended for production)
+Run `fastskill reindex` after updating (or rely on auto-reindex) to keep the search index current.
 
-### 3. Reindex after updates
-
-Always run `fastskill reindex` after updating skills to keep search index current.
-
-### 4. Commit lockfile after updates
+### 3. Commit the lockfile after updates
 
 Commit `skills.lock` after successful updates to track version changes in version control.
 
+### 4. Pin with the lockfile, not with flags
+
+Because `update` always resolves to the current version, use a committed `skills.lock` plus
+`fastskill install --lock` to reproduce an exact version set.
+
 ### 5. Test updates in development first
 
-Test skill updates in development environment before deploying to production, especially for major version updates.
+Test skill updates in a development environment before deploying to production.
 
 ## See Also
 

--- a/webdocs/configuration/init-command.mdx
+++ b/webdocs/configuration/init-command.mdx
@@ -5,195 +5,154 @@ description: "Create skill-project.toml for skill authors and project configurat
 
 ## Overview
 
-The `fastskill init` command creates a `skill-project.toml` file for skill authors. This command extracts metadata from an existing `SKILL.md` file (if present) and interactively prompts for any missing information to create a properly configured skill project.
+`fastskill init` creates a single file: `skill-project.toml` in the current directory. If a `SKILL.md` is present, it extracts metadata (version, description, author) from its frontmatter; anything missing is either taken from CLI flags or prompted for interactively.
 
 <Callout type="info">
-This command is for **skill authors** who want to create a new skill project. It generates the `skill-project.toml` manifest file that defines your skill's metadata, dependencies, and configuration. For general FastSkill setup, see the [Installation Guide](/installation).
+`init` writes **only** `skill-project.toml`. It does not create a skills directory, example skills, or any other file. All FastSkill configuration lives in `skill-project.toml`.
 </Callout>
 
 <Callout type="info">
-**Context Detection**: `fastskill init` automatically detects whether you're working in a skill directory or project root:
-- **Skill-level**: If run in a directory containing `SKILL.md`, creates `skill-project.toml` with `[metadata]` section (for skill authors)
-- **Project-level**: If run at project root, can create `skill-project.toml` with `[dependencies]` section (for skill consumers)
-
-See [Skill Commands](/cli-reference/skill-commands) for details on skill-level initialization.
+**Context detection**: `init` detects whether you're in a skill directory or a project root:
+- **Skill-level**: run in a directory containing `SKILL.md` — writes a `[metadata]` section for skill authors. `skills_directory` is optional.
+- **Project-level**: run at a project root — writes `[dependencies]` for skill consumers. A skills directory is required (via `--skills-dir`, or the prompt).
 </Callout>
 
-## What It Does
+## What it does
 
-When you run `fastskill init`, it performs the following steps:
-
-1. **Checks for Existing Files**: Validates if `skill-project.toml` already exists
-2. **Reads SKILL.md**: Extracts metadata from frontmatter (name, description, version, etc.)
-3. **Interactive Prompts**: Asks for missing information or uses provided CLI arguments
-4. **Creates skill-project.toml**: Generates the manifest file with proper structure
-5. **Validates Configuration**: Ensures all required fields are present and valid
+1. **Checks for an existing file**: refuses to overwrite `skill-project.toml` unless `--force` is given.
+2. **Reads `SKILL.md`** (if present): pulls `version`, `description`, and `author` from the frontmatter.
+3. **Resolves missing fields**: from CLI flags, or by prompting (unless `--yes`).
+4. **Writes `skill-project.toml`**: with `[metadata]`, `[dependencies]`, and — when a skills directory is set — `[tool.fastskill]`.
+5. **Validates**: the skill ID (derived from the directory name) and the version (must be valid semver).
 
 ## Usage
 
-### Interactive Setup (Recommended)
+### Interactive setup
 
 ```bash
 fastskill init
 ```
 
-This will prompt you for each configuration option:
+Prompts for each missing field. For example, at a project root:
 
 ```
-🚀 FastSkill Project Initialization
+FastSkill Skill Initialization
 
-🔑 OpenAI API Key
-Enter your OpenAI API key (or press Enter to set via environment variable): sk-...
+Description (optional, press Enter to skip): My project skills
+Author (optional, press Enter to skip): Jane Doe
+Download URL (optional, press Enter to skip):
+Skills directory (default: .claude/skills): .claude/skills
 
-✅ API key format validated
-
-🤖 Embedding Model
-Choose an embedding model:
-  1. text-embedding-3-small (recommended, cost-effective)
-  2. text-embedding-3-large (higher accuracy, more expensive)
-  3. Custom model
-Enter choice (1-3) [1]: 1
-
-📁 Skills Directory
-Enter skills directory path [.skills]: .skills
-
-✅ FastSkill project initialized successfully!
-
-💡 Next steps:
-  • Add skills to the '.skills' directory
-  • Run: fastskill reindex
-  • Then: fastskill search "your query"
+Created skill-project.toml with version: 1.0.0
+Skills directory: .claude/skills
 ```
 
-### Non-Interactive Setup
+### Non-interactive setup
 
 ```bash
-# Use defaults for everything (requires OPENAI_API_KEY env var)
+# Skill-level: skip all prompts, take metadata from SKILL.md
 fastskill init --yes
 
-# Specify custom options
-fastskill init --yes --skills-dir my-skills
+# Project-level with --yes: a skills directory is required
+fastskill init --yes --skills-dir .claude/skills
 
-# Skip creating example skill
-fastskill init --yes --no-example
+# Provide metadata directly
+fastskill init --yes --version 1.2.0 --description "Team skills" --author "Jane Doe"
 ```
 
-## Command Options
+<Callout type="warn">
+At a project root, `--yes` requires `--skills-dir <path>`. Without it, either drop `--yes` to be prompted or pass the flag.
+</Callout>
+
+## Command options
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--yes` | Skip interactive prompts, use defaults | `false` |
-| `--force` | Reinitialize even if files exist | `false` |
-| `--skills-dir <DIR>` | Skills directory path | `.skills` |
-| `--no-example` | Skip creating example skill | `false` |
+| `--yes` | Skip interactive prompts and use defaults | `false` |
+| `--force` | Overwrite an existing `skill-project.toml` | `false` |
+| `--version <VER>` | Set the skill version (validated as semver) | from `SKILL.md`, else `1.0.0` |
+| `--description <TEXT>` | Set the description | from `SKILL.md`, else empty |
+| `--author <NAME>` | Set the author | from `SKILL.md`, else empty |
+| `--download-url <URL>` | Set the download URL | empty |
+| `--skills-dir <DIR>` | Skills directory (global flag) | `.claude/skills` |
 
-**Note**: The `--embedding-model` option is not yet available. To configure embedding model, edit the `.fastskill/config.yaml` file after initialization.
+## The file it creates
 
-## Files Created
+At a project root, `init` produces a `skill-project.toml` like:
 
-### `.fastskill/config.yaml`
+```toml skill-project.toml
+[metadata]
+id = "my-project"
+version = "1.0.0"
+description = "Team skills"
+author = "Jane Doe"
 
-Service-level configuration file with your embedding settings:
+[dependencies]
 
-```yaml
-# FastSkill Configuration
-# This file configures embedding search settings
+[tool.fastskill]
+skills_directory = ".claude/skills"
 
-embedding:
-  openai_base_url: "https://api.openai.com/v1"
-  embedding_model: "text-embedding-3-small"
+# Additional configuration options for [tool.fastskill]:
+#
+# [tool.fastskill.embedding]
+# openai_base_url = "https://api.openai.com/v1"
+# embedding_model = "text-embedding-3-small"
+#
+# [[tool.fastskill.repositories]]
+# name = "default"
+# type = "http-registry"
+# index_url = "https://registry.fastskill.dev"
+# priority = 0
 ```
 
-**Note**: Service-level configuration (embedding settings) is stored in `.fastskill/config.yaml`. Project-level configuration (skill dependencies and repositories) is stored in `skill-project.toml` at your project root.
+The commented block is written verbatim so you can uncomment and fill in embedding settings or repositories later.
 
-### `.skills/` Directory Structure
+## Skills directory
 
-```
-.skills/
-├── .fastskill/          # Internal FastSkill data (index, cache)
-├── examples/            # Example skills for learning
-│   └── hello-world/
-│       └── SKILL.md    # Sample skill definition
-└── README.md           # Directory documentation
-```
+- **Default**: `.claude/skills`
+- **Custom**: any path you pass via `--skills-dir` or the prompt
+- **Resolution at runtime**: `--skills-dir` flag > `--global` (`~/.config/fastskill/skills`) > `skills_directory` under `[tool.fastskill]` > walk up to an existing `.claude/skills/` > default `.claude/skills/`
 
-### Example Skill
+## Embedding configuration
 
-Creates a basic skill at `.skills/examples/hello-world/SKILL.md`:
+Semantic search uses OpenAI-compatible embeddings, configured under `[tool.fastskill.embedding]` in `skill-project.toml` (not created by `init` — add it when you need it):
 
-```markdown
----
-name: Hello World
-description: A simple example skill that demonstrates the FastSkill format
-version: 1.0.0
-author: FastSkill
-tags: [example, demo, hello-world]
-capabilities: [text_processing, greeting]
----
-
-# Hello World Skill
-
-This is an example skill to demonstrate the FastSkill format and structure.
-
-## Purpose
-
-This skill demonstrates how to create a basic FastSkill skill definition.
+```toml
+[tool.fastskill.embedding]
+openai_base_url = "https://api.openai.com/v1"
+embedding_model = "text-embedding-3-small"
+# index_path = ".fastskill/index"
 ```
 
-## Configuration Options
-
-### Embedding Models
-
-| Model | Description | Cost | Use Case |
-|-------|-------------|------|----------|
-| `text-embedding-3-small` | Cost-effective, good performance | Low | Most projects |
-| `text-embedding-3-large` | Higher accuracy, more expensive | High | Enterprise, high-precision needs |
-| Custom | Any OpenAI-compatible model | Varies | Advanced users |
-
-### Skills Directory
-
-- **Default**: `.skills` (recommended)
-- **Custom**: Any directory path you specify
-- **Existing**: Will be created if it doesn't exist
-
-## Environment Variables
-
-### OPENAI_API_KEY
-
-The init command will use this environment variable if set:
+Set the API key via the environment; if it is unset, semantic search is silently skipped:
 
 ```bash
-export OPENAI_API_KEY="your-api-key-here"
-fastskill init --yes  # Will use the env var automatically
+export OPENAI_API_KEY="your-key-here"
 ```
-
-If not set, you'll be prompted to enter it interactively.
 
 ## Troubleshooting
 
-### "API key should start with 'sk-'"
+### "skill-project.toml already exists. Use --force to overwrite."
 
-**Cause**: The provided API key doesn't match OpenAI's format
-**Solution**: Check that you're using a valid OpenAI API key
+**Cause**: a `skill-project.toml` is already present.
+**Solution**: pass `--force` to overwrite it, or remove the file first.
 
-### "API key appears to be too short"
+### "Project-level init requires --skills-dir"
 
-**Cause**: The API key is incomplete
-**Solution**: Ensure you're copying the complete API key from OpenAI
+**Cause**: `--yes` was used at a project root without a skills directory.
+**Solution**: add `--skills-dir <path>`, or drop `--yes` to be prompted.
 
-### "FastSkill is already initialized"
+### Invalid version
 
-**Cause**: Configuration files already exist
-**Solution**: Use `--force` to reinitialize, or remove existing files first
+**Cause**: the version (from `--version` or `SKILL.md`) is not valid semver.
+**Solution**: use a semver string such as `1.0.0`.
 
-### Permission Denied
+### Permission denied
 
-**Cause**: Cannot write to the current directory
-**Solution**: Check file permissions or run in a directory where you have write access
+**Cause**: the current directory is not writable.
+**Solution**: fix permissions or run in a directory where you have write access.
 
 ## Integration with CI/CD
-
-For automated setups in CI/CD pipelines:
 
 ```yaml
 # .github/workflows/setup-fastskill.yml
@@ -208,63 +167,20 @@ jobs:
         run: curl -fsSL https://raw.githubusercontent.com/gofastskill/fastskill/main/scripts/install.sh | bash
 
       - name: Initialize FastSkill
+        run: fastskill init --yes --skills-dir .claude/skills
+
+      - name: Install skills from the manifest
+        run: fastskill install
+
+      - name: Index skills (needs OPENAI_API_KEY for semantic search)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: fastskill init --yes --no-example
-
-      - name: Add skills
-        run: cp -r my-skills/* .skills/
-
-      - name: Index skills
         run: fastskill reindex
 ```
 
-## Best Practices
+## Next steps after init
 
-### Project Structure
-
-Keep FastSkill configuration at the project root:
-
-```
-my-project/
-├── .fastskill/
-│   └── config.yaml  # Service-level configuration (embedding settings)
-├── skill-project.toml  # Project-level configuration (dependencies, repositories)
-├── skills.lock       # Lock file (auto-generated)
-├── .claude/
-│   └── skills/      # Skills directory (default location)
-│       ├── my-skill/
-│       └── another-skill/
-└── src/              # Your application code
-```
-
-### API Key Management
-
-- **Development**: Use environment variables
-- **Production**: Use secure secret management
-- **CI/CD**: Store in encrypted secrets
-
-### Version Control
-
-Consider what to commit:
-
-```bash
-# Commit these files
-git add .fastskill/config.yaml
-git add skill-project.toml
-git add skills.lock
-git add .claude/skills/README.md
-git add .claude/skills/examples/
-
-# Don't commit these (generated)
-echo ".skills/.fastskill/" >> .gitignore
-```
-
-## Next Steps After Init
-
-1. **Add Your Skills**: Create skill directories under `.skills/`
-2. **Index Skills**: Run `fastskill reindex` to build the search index
-3. **Test Search**: Try `fastskill search "your query"`
-4. **Integration**: Connect to your AI agent or application
-
-The init command gets you started quickly with a properly configured FastSkill environment. All the complexity of configuration files and directory structure is handled automatically.
+1. **Add skills**: `fastskill add <skill-id>` (registry, Git, or local path).
+2. **Install from the manifest**: `fastskill install`.
+3. **Index for search**: `fastskill reindex` (requires `OPENAI_API_KEY`).
+4. **Search**: `fastskill search "your query"`.

--- a/webdocs/examples/advanced-patterns.mdx
+++ b/webdocs/examples/advanced-patterns.mdx
@@ -1,20 +1,92 @@
 ---
 title: "Advanced Patterns"
-description: "Advanced FastSkill usage patterns including multi-skill workflows and performance optimization."
+description: "Worked examples for a growing skill collection: analyze overlap, optimize skills, filter install groups, and manage editable and global skills."
 ---
 
 ## Overview
 
-Advanced patterns demonstrate sophisticated ways to use FastSkill in complex scenarios.
+These are real, source-backed workflows for teams managing many skills. Every command below exists in
+the CLI.
 
-## Patterns
+## Find duplicate and overlapping skills
 
-- Multi-skill workflows
-- Performance optimization
-- Custom skill development
-- Enterprise integration
-- Advanced routing strategies
+As a collection grows, skills drift into overlap. `fastskill analyze` surfaces that:
+
+```bash
+# Similarity matrix across installed skills
+fastskill analyze matrix
+
+# Cluster related skills
+fastskill analyze cluster
+
+# List likely duplicate/overlapping pairs, with a merge suggestion per pair
+fastskill analyze duplicates
+```
+
+`analyze duplicates` supports filtering and output control:
+
+```bash
+fastskill analyze duplicates --threshold 0.85 --limit 20 --severity high --format json
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--threshold` | Minimum similarity to report |
+| `--limit` | Maximum number of pairs to show |
+| `--severity` | Filter by minimum severity: `critical`, `high`, `medium`, `all` |
+| `--format` | `table`, `json`, `grid`, or `xml` (`--json` is shorthand) |
+
+## Improve a skill with `optimize`
+
+`fastskill optimize` runs a text-gradient loop to iteratively improve a skill's content:
+
+```bash
+fastskill optimize run       # start an optimization run
+fastskill optimize status    # check progress
+fastskill optimize resume    # resume an interrupted run
+fastskill optimize inspect   # inspect run detail
+fastskill optimize export    # export the result
+```
+
+## Install only part of a collection with groups
+
+Skills can be tagged into groups; installs can include or exclude them (poetry-style):
+
+```bash
+# Only install skills in the "docs" and "core" groups
+fastskill install --only docs --only core
+
+# Install everything except the "dev" group
+fastskill install --without dev
+```
+
+## Editable and recursive local skills
+
+For local skill development, add without copying and add whole trees at once:
+
+```bash
+# Editable install: symlink/reference so in-place edits apply without reinstall (local only)
+fastskill add ./dev-skill -e
+
+# Recursively add every subdirectory containing a SKILL.md (local trees only)
+fastskill add ./skills -r
+```
+
+After editing an editable skill in place, run `fastskill reindex` so semantic search and resolve
+reflect the changes.
+
+## Project vs. global scope
+
+Most commands default to the current project. Use `--global` to operate on the shared user-level
+skills directory (`~/.config/fastskill/skills`, tracked by `global-skills.lock`):
+
+```bash
+fastskill add pptx --global
+fastskill list --global
+fastskill install --global --lock
+```
 
 <Callout>
-Advanced patterns showcase FastSkill's capabilities in complex, real-world scenarios.
+Use `analyze` to keep a collection tidy, `optimize` to sharpen individual skills, and group filters
+plus `--global` to control what gets installed where.
 </Callout>

--- a/webdocs/examples/integration-tutorials.mdx
+++ b/webdocs/examples/integration-tutorials.mdx
@@ -1,24 +1,88 @@
 ---
 title: "Integration Tutorials"
-description: "Step-by-step guides for integrating FastSkill with popular AI agent frameworks and platforms."
+description: "Connect FastSkill to agents and pipelines: MCP into Claude Code and Cursor, the serve HTTP API, and locked installs in CI."
 ---
 
 ## Overview
 
-Integration tutorials show how to connect FastSkill with various AI agent frameworks and platforms.
+These tutorials cover FastSkill's real integration surfaces: the **MCP** server for agents, the
+**HTTP API** from `fastskill serve`, and **locked installs** in CI. Each uses commands and endpoints
+that exist in the tool.
 
-## Integration Guides
+## 1. MCP into Claude Code
 
-- LangChain integration
-- AutoGen integration
-- Custom agent frameworks
-- Web application integration
-- Microservices architecture
+Expose every FastSkill command to Claude Code as MCP tools.
 
-## Examples
+```bash
+# Register FastSkill as an MCP server for Claude Code in this project
+fastskill mcp install --agent claude --scope project --stdio
 
-Follow the step-by-step tutorials to integrate FastSkill into your projects.
+# Confirm it's registered
+fastskill mcp list
+```
+
+Claude Code will now see tools named `fastskill.<command>` — for example `fastskill.search`,
+`fastskill.install`, `fastskill.resolve`, and `fastskill.repos.add`. To point the agent at a running
+HTTP MCP server instead of spawning FastSkill itself:
+
+```bash
+fastskill mcp serve --transport http --port 8080 --path /mcp
+fastskill mcp install --agent claude --scope project --url http://127.0.0.1:8080/mcp
+```
+
+## 2. MCP into Cursor
+
+Same flow, different agent key:
+
+```bash
+fastskill mcp install --agent cursor --scope global --url http://127.0.0.1:8080/mcp
+```
+
+Supported agents: `claude`, `cursor`, `gemini`, `copilot`, `opencode`, `codex`. See the full
+[MCP tool-calling guide](/tool-calling/development).
+
+## 3. Call the HTTP API from an app
+
+Run the server and use the versioned `/api/v1/...` REST surface. Start read-only:
+
+```bash
+fastskill serve
+```
+
+```bash
+# List installed skills
+curl http://localhost:8080/api/v1/skills
+
+# Search
+curl -X POST http://localhost:8080/api/v1/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "convert pdf"}'
+
+# Resolve the most relevant skills for a prompt (context loading)
+curl -X POST http://localhost:8080/api/v1/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "build a slide deck from notes", "limit": 5}'
+```
+
+These are all read endpoints and work without `--enable-write`. To manage skills over HTTP (install /
+update / delete), start with `fastskill serve --enable-write`, and front the port with an
+authenticating proxy if it is exposed — `serve` enforces no auth of its own. See the
+[serve command reference](/cli-reference/serve-command) and [security model](/security/model).
+
+## 4. Reproducible installs in CI
+
+Commit `skill-project.toml` and `skills.lock`, then install exact locked versions in the pipeline:
+
+```bash
+# In CI: install exactly what the lockfile records
+fastskill install --lock
+```
+
+Set `OPENAI_API_KEY` from a CI secret if the pipeline needs semantic search or reindex; without it
+those steps skip silently rather than failing.
 
 <Callout>
-Integration tutorials provide practical examples for common use cases and frameworks.
+For agents, install FastSkill as an MCP server. For services and pipelines, use the `serve` HTTP API
+and `install --lock`. There is no separate SDK to integrate — the CLI, MCP tools, and HTTP API are
+the surface.
 </Callout>

--- a/webdocs/installation.mdx
+++ b/webdocs/installation.mdx
@@ -115,11 +115,13 @@ Prefer a user-local path on macOS or Linux? Move `fastskill` to `~/.local/bin/` 
 
 **Skills Directory Resolution:**
 
-The CLI automatically discovers the skills directory in this priority order:
+The CLI resolves the skills directory in this priority order:
 
-1. `skills_directory` setting in `.fastskill/config.yaml`
-2. Walk up directory tree to find existing `.claude/skills/`
-3. Default to `.claude/skills/` in current directory
+1. `--skills-dir <path>` flag
+2. `--global` (uses `~/.config/fastskill/skills`)
+3. `skills_directory` under `[tool.fastskill]` in `skill-project.toml`
+4. Walk up the directory tree to find an existing `.claude/skills/`
+5. Default to `.claude/skills/` in the current directory
 
 **Manifests and lockfiles:**
 
@@ -130,20 +132,20 @@ The CLI automatically discovers the skills directory in this priority order:
 
 ## Configuration
 
-After installation, configure FastSkill by creating `.fastskill/config.yaml`:
+All configuration lives in `skill-project.toml` at your project root. Embedding settings and the skills directory go under the `[tool.fastskill]` tables:
 
-```yaml
-embedding:
-  openai_base_url: "https://api.openai.com/v1"
-  embedding_model: "text-embedding-3-small"
+```toml
+[tool.fastskill]
+skills_directory = ".claude/skills"
 
-# Optional: Custom skills directory
-skills_directory: ".claude/skills"
+[tool.fastskill.embedding]
+openai_base_url = "https://api.openai.com/v1"
+embedding_model = "text-embedding-3-small"
 ```
 
-**Note**: Service-level configuration (embedding settings) is stored in `.fastskill/config.yaml`. Project-level configuration (skill dependencies and repositories) is stored in `skill-project.toml` at your project root.
+**Note**: Skill dependencies and repositories live in the same `skill-project.toml` — under `[dependencies]` and `[[tool.fastskill.repositories]]` respectively.
 
-Set your OpenAI API key:
+Set your OpenAI API key (used for semantic search embeddings; if unset, semantic search is silently skipped):
 
 ```bash
 export OPENAI_API_KEY="your-key-here"
@@ -207,11 +209,11 @@ If you already have a project with `skill-project.toml`, try `fastskill list` or
 
 <Accordion id="configuration-issues" title="Configuration Issues">
   <Callout type="info">
-  **Embedding configuration required**: Create `.fastskill/config.yaml` with OpenAI API configuration.
+  **Embedding configuration required**: Add a `[tool.fastskill.embedding]` table to `skill-project.toml` with your OpenAI-compatible base URL and model.
   </Callout>
 
   <Callout type="info">
-  **OpenAI API key not found**: Set `OPENAI_API_KEY` environment variable or configure in `.fastskill/config.yaml`.
+  **OpenAI API key not found**: Set the `OPENAI_API_KEY` environment variable. Without it, semantic search is silently skipped.
   </Callout>
 </Accordion>
 

--- a/webdocs/integration/claude-code-integration.mdx
+++ b/webdocs/integration/claude-code-integration.mdx
@@ -67,8 +67,8 @@ the skills directory contains a valid `SKILL.md` for it. `fastskill read <skill-
 print its content.
 
 **Wrong skills directory:** Claude Code and FastSkill must agree on the location. The default
-is `.claude/skills/`; override it via `skills_directory` in `.fastskill/config.yaml` or the
-`--skills-dir` flag.
+is `.claude/skills/`; override it via `skills_directory` under `[tool.fastskill]` in
+`skill-project.toml` or the `--skills-dir` flag.
 
 ## MCP Registration
 

--- a/webdocs/integration/cursor-integration.mdx
+++ b/webdocs/integration/cursor-integration.mdx
@@ -66,8 +66,8 @@ Cursor scans installed skills for presentation-related descriptions, finds a mat
 ## Configuration
 
 Ensure your project has a `skill-project.toml` and that Cursor and FastSkill agree on the
-skills directory. The default is `.claude/skills/`; override it via `skills_directory` in
-`.fastskill/config.yaml` or the `--skills-dir` flag.
+skills directory. The default is `.claude/skills/`; override it via `skills_directory` under
+`[tool.fastskill]` in `skill-project.toml` or the `--skills-dir` flag.
 
 ```bash
 fastskill install

--- a/webdocs/progressive-loading/performance.mdx
+++ b/webdocs/progressive-loading/performance.mdx
@@ -1,23 +1,68 @@
 ---
-title: "Performance Optimization"
-description: "Optimize FastSkill performance through configuration tuning and monitoring."
+title: "Context Resolution API"
+description: "How agents get the most relevant skills for a prompt via `POST /api/v1/resolve`, and the embedding index that powers ranking."
 ---
 
 ## Overview
 
-Performance optimization ensures FastSkill runs efficiently in your environment.
+Progressive loading in FastSkill means **context resolution**: an agent sends a prompt and gets back
+the most relevant installed skills, so it can load only what it needs instead of every skill. This is
+served **over HTTP only** by `fastskill serve` — there is no CLI subcommand for it.
 
-## Performance Tuning
+## `POST /api/v1/resolve`
 
-- Configure cache settings
-- Optimize execution parameters
-- Monitor resource usage
-- Tune for specific workloads
+Start the server and call the resolve endpoint:
 
-## Monitoring
+```bash
+fastskill serve
+```
 
-Track performance metrics and identify optimization opportunities.
+```bash
+curl -X POST http://localhost:8080/api/v1/resolve \
+  -H 'Content-Type: application/json' \
+  -d '{"prompt": "generate a pptx deck from these notes", "limit": 5}'
+```
+
+Request body:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `prompt` | string | The task text to resolve against. Must not be empty (`RESOLVE_EMPTY_PROMPT`). |
+| `limit` | integer | Maximum number of skills to return. Must be greater than 0 (`RESOLVE_LIMIT_ZERO`). |
+
+The response ranks installed skills by relevance to the prompt so the agent can pull just the top
+matches into context. `resolve` is a **read** endpoint — it works whether or not `serve` was started
+with `--enable-write`.
+
+## How ranking works
+
+- **Embeddings power ranking when available.** With `OPENAI_API_KEY` set (and
+  `[tool.fastskill.embedding]` configured), FastSkill ranks skills semantically using the embedding
+  index.
+- **Keyword fallback otherwise.** If no embedding provider is configured, semantic ranking silently
+  skips and resolution falls back to keyword matching — the endpoint still returns results, it just
+  ranks them without embeddings.
+
+You can confirm whether an embedding provider is active from `GET /api/v1/status`
+(`embeddingProvider` flag) or with `fastskill doctor`.
+
+## Performance characteristics
+
+- **Local vector index.** Skill embeddings are stored in a local SQLite vector index (path set by
+  `index_path` under `[tool.fastskill.embedding]`), so resolution queries run against on-disk vectors
+  with no external service call at query time.
+- **Incremental reindexing.** A change-detection cache (`.fastskill/build-cache.json`) lets reindex
+  re-embed only what actually changed, so keeping the index current is cheap.
+- **Auto-reindex keeps the index fresh.** After `add` / `install` / `update` / `remove`, FastSkill
+  reindexes automatically (unless `auto_reindex = false` or `--no-reindex`, and only when an
+  embedding provider is available), so `resolve` reflects the current skill set.
 
 <Callout>
-Regular performance monitoring helps maintain optimal FastSkill operation.
+There are no cache-size, eviction, or tuning knobs to configure. Resolution is driven by the prompt,
+the `limit`, and the embedding index — not by a configurable runtime cache.
 </Callout>
+
+## See also
+
+- [Loading strategies](/progressive-loading/strategies) — practical guidance: when to reindex and local search.
+- [serve command](/cli-reference/serve-command) — full endpoint reference.

--- a/webdocs/progressive-loading/strategies.mdx
+++ b/webdocs/progressive-loading/strategies.mdx
@@ -1,30 +1,72 @@
 ---
 title: "Loading Strategies"
-description: "FastSkill's progressive loading strategies for efficient skill content management and performance optimization."
+description: "Practical guidance for context resolution: configuring embeddings, when to reindex, and local search."
 ---
 
 ## Overview
 
-Progressive loading strategies determine how and when skill content is loaded to optimize performance and memory usage.
+Context resolution ([the resolve API](/progressive-loading/performance)) lets an agent load only the
+skills relevant to a prompt. This page covers the practical setup and habits that keep resolution
+fast and accurate. These are real knobs and commands — FastSkill has no configurable cache or
+eviction policy to tune.
 
-## Loading Strategies
+## Enable semantic ranking
 
-### Metadata Only
-Load only essential skill information for fast discovery.
+Semantic ranking is what makes resolution useful. To turn it on:
 
-### Content on Demand
-Load full skill content when needed for execution.
+1. Configure an embedding provider in `skill-project.toml`:
 
-### Selective Loading
-Load specific parts of skills based on context and requirements.
+   ```toml
+   [tool.fastskill.embedding]
+   embedding_model = "text-embedding-3-small"
+   index_path = ".fastskill/index"
+   # openai_base_url = "https://api.openai.com/v1"  # override if using a proxy
+   ```
 
-### Caching Strategies
-Intelligent caching with configurable eviction policies for optimal performance.
+2. Set `OPENAI_API_KEY` in the environment (via a secret, never in config).
 
-## Implementation
+If no provider is configured, `resolve` and `search` still work but fall back to keyword matching.
+Verify the setup with `fastskill doctor`.
 
-FastSkill automatically manages loading strategies based on configuration and usage patterns.
+## When to reindex
+
+FastSkill **auto-reindexes** after `add`, `install`, `update`, and `remove` (unless
+`auto_reindex = false` in `[tool.fastskill]` or you pass `--no-reindex`), so day to day you rarely
+reindex by hand. Reindex explicitly when:
+
+- you edited a skill's `SKILL.md` in place (for example an editable `add -e` skill) without going
+  through install/update,
+- you set `auto_reindex = false` and manage indexing yourself,
+- you first configure embeddings for a skills directory that already has content.
+
+```bash
+fastskill reindex
+```
+
+Reindex needs an embedding provider; without `OPENAI_API_KEY` it skips silently. A change-detection
+cache (`.fastskill/build-cache.json`) lets reindex re-embed only what changed.
+
+## Search locally without the server
+
+For a quick, offline relevance check over skills already on disk, use `search --local` instead of the
+HTTP resolve endpoint:
+
+```bash
+# Rank installed skills for a query
+fastskill search "convert pdf to markdown" --local
+
+# Emit canonical skill paths (agent-friendly)
+fastskill search "convert pdf to markdown" --local --paths
+
+# Include SKILL.md content in JSON output
+fastskill search "convert pdf to markdown" --local --paths --content full
+```
+
+`resolve` (server) is for agents pulling context at runtime; `search --local` (CLI) is for
+interactive and scripted lookups over the local index. Both use the same embedding index when one is
+configured.
 
 <Callout>
-Choose loading strategies based on your performance requirements and usage patterns.
+Keep the embedding index fresh (auto-reindex or an explicit `fastskill reindex`) — that single habit
+covers essentially all resolution performance and quality concerns.
 </Callout>

--- a/webdocs/registry/index-system.mdx
+++ b/webdocs/registry/index-system.mdx
@@ -72,9 +72,10 @@ Each line is a compact `VersionEntry` JSON object:
 
 ## Accessing the Registry
 
-### HTTP Endpoint
+### Hosted registry server (external)
 
-The registry index is served over HTTP. Each skill's index file is accessible at:
+On the external registry server that hosts the index, each skill's NDJSON index
+file is served at its own flat path:
 
 ```
 GET /index/{skill_id}
@@ -88,12 +89,20 @@ curl https://api.fastskill.io/index/dev-user/web-scraper
 ```
 
 This returns the newline-delimited JSON entries for all versions of that skill.
+These `/index/...` NDJSON paths are the hosted registry server's own convention,
+not part of the `fastskill serve` versioned API.
 
-A browse/search surface is also available:
+### From `fastskill serve`
+
+When you run `fastskill serve` locally, the registry browse/search surface is
+exposed under the versioned API:
 
 ```
-GET /registry/index/skills
+GET /api/v1/registry/index/skills
 ```
+
+Unversioned `/api/...` requests are 308-redirected to their `/api/v1/...`
+equivalents.
 
 ### From FastSkill CLI
 

--- a/webdocs/registry/overview.mdx
+++ b/webdocs/registry/overview.mdx
@@ -25,6 +25,10 @@ fastskill serve
 
 Then open `http://localhost:8080/` or `http://localhost:8080/dashboard` in your browser.
 
+<Callout type="warn">
+`serve` is **read-only by default** (ADR-0003). Browsing and search work out of the box, but the Web UI "Install"/"Uninstall" buttons and other write actions require starting the server with `fastskill serve --enable-write`; otherwise those requests return HTTP 403.
+</Callout>
+
 ## Architecture
 
 The registry consists of:

--- a/webdocs/registry/repository-architecture.mdx
+++ b/webdocs/registry/repository-architecture.mdx
@@ -8,7 +8,7 @@ description: "Understanding FastSkill's multi-source repository system for skill
 FastSkill implements a flexible, multi-source repository system that allows you to discover and install skills from various sources including Git repositories, HTTP registries, ZIP files, and local filesystem paths.
 
 <Callout type="info">
-Repository configuration is stored in `[tool.fastskill.repositories]` section of `skill-project.toml` or in `.claude/repositories.toml` for backward compatibility.
+Repository configuration lives in the `[[tool.fastskill.repositories]]` array of your `skill-project.toml`.
 </Callout>
 
 ## Repository Types
@@ -27,41 +27,37 @@ url = "https://github.com/team/skills.git"
 branch = "main"
 priority = 0
 
-# Optional authentication
-auth_type = "pat"
-auth_value = "ghp_xxxxxxxxxxxxxxxxxxxx"
-
-# Optional subdirectory
-source_subdir = "skills"
+# Optional authentication (env-var indirection — never inline a token)
+auth = { type = "pat", env_var = "GITHUB_TOKEN" }
 ```
 
 **marketplace.json Format:**
 
+FastSkill uses the Claude Code plugin format: a top-level object with a
+`plugins` array, where each plugin lists its skills as a `skills` path array.
+See [Marketplace.json Format](/registry/marketplace-json) for the full schema.
+
 ```json marketplace.json
 {
-  "version": "1.0",
-  "skills": [
+  "name": "team-skills",
+  "owner": {
+    "name": "FastSkill Team",
+    "email": "team@example.com"
+  },
+  "metadata": {
+    "description": "Team skill catalog",
+    "version": "1.0.0"
+  },
+  "plugins": [
     {
-      "id": "web-scraper",
-      "name": "Web Scraper",
-      "description": "Scrape web content efficiently",
-      "version": "1.2.3",
-      "author": "FastSkill Team",
-      "license": "MIT",
-      "tags": ["web", "scraping", "data"],
-      "capabilities": ["http_requests", "file_io"],
-      "file_path": "web-scraper/SKILL.md"
-    },
-    {
-      "id": "data-processor",
-      "name": "Data Processor",
-      "description": "Process and analyze data",
-      "version": "2.1.0",
-      "author": "Data Team",
-      "license": "Apache-2.0",
-      "tags": ["data", "analysis", "python"],
-      "capabilities": ["file_processing", "statistics"],
-      "file_path": "data-processor/SKILL.md"
+      "name": "team-skills",
+      "description": "Skills for the team",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./web-scraper",
+        "./data-processor"
+      ]
     }
   ]
 }
@@ -91,9 +87,8 @@ type = "http-registry"
 index_url = "https://registry.fastskill.dev/index"
 priority = 0
 
-# Optional authentication
-auth_type = "api-key"
-auth_value = "registry-api-key-xxxxxxxx"
+# Optional authentication (env-var indirection — never inline a key)
+auth = { type = "api_key", env_var = "REGISTRY_TOKEN" }
 ```
 
 **Registry Index Format:**
@@ -148,7 +143,11 @@ priority = 0
 
 **Download Pattern:**
 
-Skills are downloaded as: `{base_url}/{skill_id}-{version}.zip`
+The ZIP source is discovered through a `marketplace.json` accessible under the
+`base_url` (`{base_url}/.claude-plugin/marketplace.json`, falling back to
+`{base_url}/marketplace.json`). Each skill's ZIP is fetched from the
+`download_url` resolved from that marketplace data, not from a hardcoded
+`{base_url}/{id}-{version}.zip` path.
 
 **Use cases:**
 - Simple file servers with ZIP archives
@@ -182,13 +181,17 @@ priority = 0
 
 ## Authentication Types
 
+Authentication is configured with an inline `auth` table. Secrets are always
+supplied through environment variables — FastSkill stores the variable *name*,
+never the token itself. The valid `type` values are `pat`, `ssh-key`, `ssh`,
+`basic`, and `api_key`.
+
 ### PAT (Personal Access Token)
 
 For Git repositories requiring token authentication.
 
 ```toml
-auth_type = "pat"
-auth_value = "ghp_xxxxxxxxxxxxxxxxxxxx"
+auth = { type = "pat", env_var = "GITHUB_TOKEN" }
 ```
 
 **Use cases:**
@@ -201,8 +204,7 @@ auth_value = "ghp_xxxxxxxxxxxxxxxxxxxx"
 Path to SSH private key file.
 
 ```toml
-auth_type = "ssh-key"
-auth_value = "/home/user/.ssh/id_ed25519"
+auth = { type = "ssh-key", path = "/home/user/.ssh/id_ed25519" }
 ```
 
 **Use cases:**
@@ -212,11 +214,10 @@ auth_value = "/home/user/.ssh/id_ed25519"
 
 ### SSH
 
-SSH connection without key file (uses system SSH agent).
+SSH authentication using a private key path.
 
 ```toml
-auth_type = "ssh"
-auth_value = "git@github.com:org/skills.git"
+auth = { type = "ssh", key_path = "/home/user/.ssh/id_ed25519" }
 ```
 
 **Use cases:**
@@ -226,16 +227,12 @@ auth_value = "git@github.com:org/skills.git"
 
 ### Basic Auth
 
-Username and password authentication.
+Username and password authentication. The username is stored inline; the
+password is read from the named environment variable.
 
 ```toml
-auth_type = "basic"
-auth_value = "username:password"
+auth = { type = "basic", username = "ci-bot", password_env = "REGISTRY_PASSWORD" }
 ```
-
-<Callout type="warn">
-Basic auth stores credentials in plain text. Use only for test environments or secure configuration management.
-</Callout>
 
 **Use cases:**
 - Simple HTTP registries
@@ -247,8 +244,7 @@ Basic auth stores credentials in plain text. Use only for test environments or s
 API key for HTTP registry access.
 
 ```toml
-auth_type = "api-key"
-auth_value = "registry-api-key-xxxxxxxx"
+auth = { type = "api_key", env_var = "REGISTRY_TOKEN" }
 ```
 
 **Use cases:**
@@ -354,19 +350,9 @@ priority = 1
 - Version control of entire project setup
 - Easy to share and maintain
 
-### .claude/repositories.toml (Legacy)
-
-Backward-compatible configuration file:
-
-```toml
-[[repositories]]
-name = "public-registry"
-type = "http-registry"
-index_url = "https://registry.fastskill.dev/index"
-priority = 0
-```
-
-**Note:** This format is supported for backward compatibility but `skill-project.toml` is preferred.
+All repository configuration lives here — there is no separate legacy config
+file. FastSkill reads `[[tool.fastskill.repositories]]` from `skill-project.toml`
+(walked up from the current directory).
 
 ## CLI Commands for Repository Management
 
@@ -439,7 +425,7 @@ fastskill repos add github-skills \
 fastskill repos add private-registry \
   --repo-type http-registry \
   https://private.example.com \
-  --auth-type api-key \
+  --auth-type api_key \
   --auth-env PRIVATE_REGISTRY_TOKEN
 ```
 
@@ -564,7 +550,7 @@ Use environment-specific repositories or branch parameters to control which skil
 
 <Accordion id="authentication-failures" title="Authentication failures">
   <Callout type="warn">
-  **Invalid credentials**: Check auth_type and auth_value are correct.
+  **Invalid credentials**: Check the `auth` table's `type` and that the referenced environment variable (`env_var` / `password_env`) is set.
   </Callout>
 
   <Callout type="warn">
@@ -589,9 +575,9 @@ Use environment-specific repositories or branch parameters to control which skil
 
 ## Best Practices
 
-### 1. Use skill-project.toml for repository configuration
+### 1. Keep repository configuration in skill-project.toml
 
-Prefer `skill-project.toml` [tool.fastskill.repositories] section over `.claude/repositories.toml` for better project organization.
+Define repositories in the `[[tool.fastskill.repositories]]` array of `skill-project.toml` so configuration travels with the project.
 
 ### 2. Set appropriate priorities
 

--- a/webdocs/registry/sources.mdx
+++ b/webdocs/registry/sources.mdx
@@ -7,7 +7,7 @@ api: "repositories"
 
 Repositories allow you to define where FastSkill should look for skills. FastSkill supports multiple repository types, all configured through a unified interface.
 
-**Important**: Repositories are used for skill discovery only. They define where skills come FROM. The storage location (where skills are installed when you run `fastskill add`) is configured separately in `.fastskill/config.yaml` via the `skills_directory` setting.
+**Important**: Repositories are used for skill discovery only. They define where skills come FROM. The storage location (where skills are installed when you run `fastskill add`) is configured separately via the `skills_directory` setting under `[tool.fastskill]` in `skill-project.toml`.
 
 ## Configuration File
 
@@ -722,18 +722,6 @@ fastskill repos add external-dev \
   --repo-type git-marketplace \
   ~/projects/external-skills \
   --priority 1
-```
-
-#### Hot Reloading
-
-Local sources support hot reloading during development:
-
-```bash
-# Enable hot reloading (if supported)
-export FASTSKILL_HOT_RELOAD=true
-
-# Changes to local skills are picked up automatically
-# No need to reinstall after file modifications
 ```
 
 #### Testing and Validation

--- a/webdocs/registry/web-ui.mdx
+++ b/webdocs/registry/web-ui.mdx
@@ -72,6 +72,10 @@ For sources with hundreds of skills, the UI uses virtual scrolling to:
 
 ### Install Skills
 
+<Callout type="warn">
+The "Install" and "Uninstall" buttons call write endpoints. They only work when the server is started with `fastskill serve --enable-write`. By default `serve` is read-only (ADR-0003) and these actions return HTTP 403.
+</Callout>
+
 1. Find the skill you want to install
 2. Click the "Install" button
 3. The skill will be added to your local installation
@@ -91,8 +95,12 @@ The UI uses the following API endpoints:
 - `GET /api/v1/registry/sources` - List all sources
 - `GET /api/v1/registry/skills` - Get all skills from all sources
 - `GET /api/v1/registry/sources/{name}/skills` - Get skills from specific source
-- `POST /api/v1/skills` - Install a skill
-- `DELETE /api/v1/skills/{id}` - Uninstall a skill
+- `POST /api/v1/skills/install` - Install a skill (write route)
+- `DELETE /api/v1/skills/{id}` - Uninstall a skill (write route)
+
+<Callout type="warn">
+`POST /api/v1/skills/install` and `DELETE /api/v1/skills/{id}` are **write routes**. The server is read-only by default (ADR-0003), so these endpoints return **HTTP 403** unless the server was started with `fastskill serve --enable-write`.
+</Callout>
 
 ## Performance
 
@@ -128,7 +136,7 @@ The UI works in modern browsers:
 
 ### Install/Uninstall Not Working
 
-- Verify you have proper permissions
+- Confirm the server was started with `fastskill serve --enable-write` — write routes return HTTP 403 in the default read-only mode (ADR-0003)
 - Check server logs for errors
 - Ensure the skill ID is valid
 

--- a/webdocs/security/best-practices.mdx
+++ b/webdocs/security/best-practices.mdx
@@ -1,26 +1,63 @@
 ---
 title: "Security Best Practices"
-description: "Security best practices for developing and deploying FastSkill in secure environments."
+description: "Operational guidance for running FastSkill safely: read-only serve, auth proxies, PAT env-var indirection, and locked CI installs."
 ---
 
 ## Overview
 
-Security best practices ensure FastSkill operates safely in production environments.
+These are the concrete, source-backed practices for operating FastSkill safely. They follow directly
+from the [security model](/security/model): FastSkill is a package manager with no in-app auth, so
+protection comes from *how you run and expose it*.
 
-## Development Practices
+## Running `fastskill serve`
 
-- Validate all skill inputs
-- Implement proper error handling
-- Use secure coding practices
-- Regular security reviews
+- **Expose read-only.** For a browsable UI or REST view over your skills, run `fastskill serve`
+  **without** `--enable-write`. Every mutation endpoint returns HTTP 403, so an exposed instance
+  cannot install, update, delete, reindex, or refresh anything.
+- **Only pass `--enable-write` when you mean it.** Enable writes for local skill management from the
+  browser/API — ideally on `localhost` only. Do not combine `--enable-write` with an open,
+  unfronted port.
+- **Front an exposed port with an authenticating proxy.** `serve` enforces no authentication of its
+  own and is *not* a security boundary. If the port is reachable off your machine, put a reverse
+  proxy or sidecar in front that owns authentication, and make sure the app port is not directly
+  reachable. Binding a non-loopback address is fine and expected behind such a proxy.
+- **Use the health probes for orchestration**, not for security: `GET /healthz` (liveness) and
+  `GET /readyz` (readiness).
 
-## Deployment Practices
+## Repository credentials
 
-- Use production configurations
-- Enable audit logging
-- Monitor security events
-- Regular security updates
+- **Use PAT env-var indirection.** Reference tokens by environment variable in
+  `skill-project.toml`, never inline:
+
+  ```toml
+  [[tool.fastskill.repositories]]
+  name = "team-registry"
+  type = "http-registry"
+  index_url = "https://registry.example.com/index.json"
+  auth = { type = "pat", env_var = "TEAM_REGISTRY_TOKEN" }
+  ```
+
+- **Never commit plaintext tokens.** Keep them in your shell profile, CI secret store, or a secrets
+  manager. Commit `skill-project.toml`; keep the token value out of the repo.
+- **Set `OPENAI_API_KEY` via secrets** where semantic search / reindex is used. If it is unset,
+  embedding-based features silently skip rather than failing — but do not paste the key into config
+  or version control.
+
+## Reproducible installs in CI
+
+- **Commit `skill-project.toml` and `skills.lock`.**
+- **Use `fastskill install --lock` in CI** so builds install the exact locked versions rather than
+  re-resolving. This makes installs reproducible and verifiable across environments. See the
+  [cheatsheet](/cheatsheet) for the full manifest workflow.
+
+## Verify configuration
+
+Run `fastskill doctor` (add `--json` for machine output) to confirm the skills directory,
+`skill-project.toml`, embedding configuration, `OPENAI_API_KEY`, and auth token are set up as
+expected before deploying. See [Debugging](/testing/debugging).
 
 <Callout>
-Security is an ongoing process. Regular reviews and updates are essential for maintaining a secure FastSkill deployment.
+FastSkill deliberately has **no audit-logging feature** and **no in-app auth** — do not rely on it
+for either. Request logging, authentication, and network policy belong to the proxy and platform
+that front an exposed instance.
 </Callout>

--- a/webdocs/security/model.mdx
+++ b/webdocs/security/model.mdx
@@ -1,27 +1,95 @@
 ---
 title: "Security Model"
-description: "FastSkill's comprehensive security model including sandboxing, access controls, and audit logging."
+description: "How FastSkill treats trust boundaries: read-only-by-default serve, no in-app auth, env-var token indirection, and reproducible locked installs."
 ---
 
 ## Overview
 
-FastSkill implements multiple layers of security to protect against malicious skills and ensure safe execution.
+FastSkill is a skill **package manager**, not a runtime. It installs, indexes, and serves skill
+directories; it does **not** execute skills, so there is no sandbox, no resource governor, and no
+per-request audit log to speak of. Its security model is about two things: what the `fastskill serve`
+HTTP surface lets a caller do, and how repository credentials are handled.
 
-## Security Features
+## `fastskill serve` is read-only by default
 
-- Sandboxed execution environment
-- Resource limits and monitoring
-- Access control and permissions
-- Comprehensive audit logging
-- Input validation and sanitization
+Per ADR-0003, `fastskill serve` mounts **only read endpoints** unless you start it with
+`--enable-write`. Reads (list/get skills, `POST /api/v1/search`, `POST /api/v1/resolve`,
+`GET /api/v1/status`, registry browse, manifest reads, the dashboard) are always available.
 
-## Best Practices
+Every state-changing endpoint — install, update, delete, reindex, registry refresh, manifest
+writes — returns **HTTP 403** when writes are disabled:
 
-- Follow security guidelines
-- Validate all inputs
-- Monitor execution logs
-- Keep dependencies updated
+```
+HTTP 403 Forbidden
+{
+  "success": false,
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "write operations disabled; start server with --enable-write",
+    "details": null
+  }
+}
+```
+
+"Anything that is not a pure read is gated" — reindex and registry refresh are included because they
+are side-effecting (disk, network, embedding-API cost), not just because they are destructive. This
+is one switch: `--enable-write` enables all mutations at once. See the
+[serve command reference](/cli-reference/serve-command).
+
+## `serve` is not a security boundary
+
+FastSkill enforces **no authentication of its own**. There is no token endpoint, and API routes
+require no `Authorization` or `x-api-key` header. It handles no identity and no per-user
+authorization by design.
+
+- **Run it local-first.** The default bind is `localhost` — a single operator viewing their own
+  skills on their own machine.
+- **Front it with an authenticating proxy if you expose it.** If the port is reachable on a shared
+  or untrusted network, put a reverse proxy or sidecar in front that owns request authentication,
+  and ensure the app port is not directly reachable. FastSkill will not police the bind address for
+  you, and binding a non-loopback address is the normal, expected configuration behind such a proxy.
+
+Combined with the read-only default, an exposed instance started **without** `--enable-write` cannot
+be used to mutate state even before the proxy is considered. Reaching a destructive endpoint
+unauthenticated requires the operator to have *both* enabled writes *and* exposed the port with no
+fronting proxy — a deliberate double opt-out.
 
 <Callout>
-Security is built into FastSkill's core architecture to protect your systems and data.
+A read-only exposed instance still **discloses skill data** to anyone who reaches it. That is the
+operator's call when they open the port; it is a disclosure consideration, not a mutation risk.
 </Callout>
+
+## Repository credentials: env-var indirection
+
+Private registries and Git sources authenticate with a **PAT referenced by environment variable** —
+tokens are never written into configuration:
+
+```toml
+[[tool.fastskill.repositories]]
+name = "team-registry"
+type = "http-registry"
+index_url = "https://registry.example.com/index.json"
+auth = { type = "pat", env_var = "TEAM_REGISTRY_TOKEN" }
+```
+
+FastSkill reads the token from `TEAM_REGISTRY_TOKEN` at runtime. Commit `skill-project.toml`; keep
+the token in your shell profile, CI secrets, or a secrets manager. Never commit a plaintext token.
+
+## Reproducible, verifiable installs
+
+`fastskill install` resolves the manifest and writes a lockfile (`skills.lock`, or
+`global-skills.lock` with `--global`). `fastskill install --lock` installs the **exact** versions
+recorded in the lock, giving reproducible and verifiable installs for CI and locked environments.
+Commit both `skill-project.toml` and `skills.lock`.
+
+## What FastSkill does not provide
+
+To set expectations honestly, FastSkill has **no**:
+
+- sandboxed execution environment (it does not run skills),
+- resource limits or execution monitoring,
+- built-in request audit log,
+- in-app authentication, identity, or per-user authorization.
+
+For deployed exposure, those responsibilities live in the surrounding infrastructure (proxy,
+network policy, secrets management).

--- a/webdocs/skill-management/reconciliation.mdx
+++ b/webdocs/skill-management/reconciliation.mdx
@@ -451,7 +451,7 @@ exit 0
 <Accordions>
 <Accordion id="all-skills-show-as-missing" title="All skills show as missing">
   <Callout type="warn">
-  **Skills directory incorrect**: Check that `skills_directory` in `.fastskill/config.yaml` points to correct location.
+  **Skills directory incorrect**: Check that `skills_directory` under `[tool.fastskill]` in `skill-project.toml` points to correct location.
   </Callout>
 
   <Callout type="warn">

--- a/webdocs/skill-management/validation.mdx
+++ b/webdocs/skill-management/validation.mdx
@@ -14,7 +14,7 @@ Validation happens at multiple stages: definition validation, registration valid
 ## What FastSkill checks
 
 - **Layout**: a `SKILL.md` file with readable YAML frontmatter at the skill root
-- **Identifiers**: skill ids that work on disk and in manifests (letters, numbers, `-`, `_`)
+- **Identifiers**: skill ids that work on disk and in manifests (an id is required and must not contain slashes, which are reserved as the scope separator)
 - **Versions**: semantic versions where a version is required (for example `1.2.0`)
 - **Paths**: references that resolve under the skill directory
 - **Consistency**: `fastskill list` compares installed files with `skill-project.toml` and `skills.lock`
@@ -27,10 +27,8 @@ Run `fastskill install` or `fastskill add …` to surface validation errors befo
 
 #### `id` (string, required)
 
-- Must be unique within the service
-- Alphanumeric characters, dashes, and underscores only
-- 3-50 characters in length
-- Cannot start or end with dashes/underscores
+- Required for every skill
+- Must not contain slashes (`/` is reserved as the scope separator)
 
 
 #### `name` (string, required)
@@ -77,18 +75,6 @@ Run `fastskill install` or `fastskill add …` to surface validation errors befo
 - Path relative to skill storage directory
 - Must exist and be readable
 - Should be a Python file or markdown document
-
-
-#### `execution_timeout` (integer, optional)
-
-- 1-300 seconds
-- Must be reasonable for the skill's operations
-
-
-#### `memory_limit_mb` (integer, optional)
-
-- 32-2048 MB
-- Must be sufficient for skill execution
 
 
 ## Automatic Validation
@@ -165,7 +151,7 @@ Capture which registries, groups, and approval steps apply to your org so skill 
   **Missing required fields**: Ensure all required fields are present and have valid values.
 
   Required fields:
-  - `id`: Must be alphanumeric with dashes/underscores only
+  - `id`: Required; must not contain slashes (`/` is the scope separator)
   - `name`: Human-readable name
   - `description`: Detailed description
   - `version`: Semantic version (e.g., "1.0.0")
@@ -175,16 +161,15 @@ Capture which registries, groups, and approval steps apply to your org so skill 
   **Invalid field types**: Check that field values match expected types.
 
   - `id`, `name`, `description`, `version`: strings
-  - `enabled`: boolean
-  - `timeout`: optional integer
+  - `tags`, `capabilities`: lists of strings
   </Callout>
 </Accordion>
 
 <Accordion id="security-validation-issues" title="Security Validation Issues">
   <Callout type="info">
   **Common validation issues**:
-  - Invalid skill ID format (must be alphanumeric, dashes, underscores only)
-  - Skill ID too long (max 255 characters)
+  - Missing skill ID (id is required)
+  - Invalid skill ID format (must not contain slashes; `/` is the scope separator)
   - Invalid file paths
   </Callout>
 </Accordion>

--- a/webdocs/testing/debugging.mdx
+++ b/webdocs/testing/debugging.mdx
@@ -1,26 +1,61 @@
 ---
 title: "Debugging Guide"
-description: "Debugging tools and techniques for troubleshooting FastSkill issues and performance problems."
+description: "Diagnose FastSkill setup and behavior with `fastskill doctor` and `--verbose` output."
 ---
 
 ## Overview
 
-Debugging tools help identify and resolve FastSkill issues quickly.
+The two tools for debugging FastSkill are `fastskill doctor` — an environment/configuration health
+check — and the global `--verbose` / `-v` flag for detailed command output.
 
-## Debugging Tools
+## `fastskill doctor`
 
-- Log analysis and filtering
-- Performance profiling
-- Error diagnostics
-- Interactive debugging
+`doctor` inspects your environment and reports what is and isn't set up:
 
-## Common Issues
+```bash
+fastskill doctor
+```
 
-- Configuration problems
-- Performance bottlenecks
-- Execution errors
-- Network connectivity
+It runs these checks:
+
+| Check | What it verifies |
+|-------|------------------|
+| `skills_dir` | The skills directory exists and is a directory |
+| `project_toml` | `skill-project.toml` is present (walk-up from cwd) |
+| `embedding_config` | `[tool.fastskill.embedding]` is configured (semantic search / reindex enabled) |
+| `api_key` | `OPENAI_API_KEY` is set (required for embeddings) |
+| `auth_token` | An auth token is present (`FASTSKILL_AUTH_TOKEN` or `FASTSKILL_TOKEN`) for remote registry operations |
+
+For machine-readable output (CI, scripts):
+
+```bash
+fastskill doctor --json
+```
+
+Common findings and fixes:
+
+- **`project_toml` failing** — run `fastskill init` to create `skill-project.toml`.
+- **`embedding_config` / `api_key` failing** — add `[tool.fastskill.embedding]` and set
+  `OPENAI_API_KEY`; without them semantic search and reindex are disabled (they skip silently, they
+  don't error).
+- **`auth_token` failing** — set `FASTSKILL_AUTH_TOKEN` (or `FASTSKILL_TOKEN`) if you use a private
+  registry.
+
+## Verbose output
+
+Add `--verbose` (or `-v`) to any command to see detailed diagnostic output about what FastSkill is
+doing — useful for understanding install resolution, indexing, and registry access:
+
+```bash
+fastskill install --verbose
+fastskill search "pdf" -v
+```
 
 <Callout>
-Effective debugging tools help maintain FastSkill's reliability and performance.
+Start with `fastskill doctor` to confirm the environment, then re-run the failing command with
+`--verbose` to see the detail.
 </Callout>
+
+## See also
+
+- [Troubleshooting](/troubleshooting) — common issues and resolutions.

--- a/webdocs/testing/framework.mdx
+++ b/webdocs/testing/framework.mdx
@@ -1,28 +1,60 @@
 ---
 title: "Testing Framework"
-description: "FastSkill's comprehensive testing framework for validating skills and integrations."
+description: "Test your skills with `fastskill eval` — validate configuration, run prompts against an agent, and score the results."
 ---
 
 ## Overview
 
-The testing framework provides tools and methodologies for comprehensive FastSkill testing.
+The way you test a skill in FastSkill is `fastskill eval`. You define eval cases in your project
+manifest, run them against an agent, and score the results. There is no separate unit/mock harness —
+eval is the testing framework.
 
-## Testing Types
+## Configure evals
 
-- Unit tests for individual components
-- Integration tests for component interactions
-- Performance tests for optimization
-- Security tests for vulnerability assessment
+Evals are declared under `[tool.fastskill.eval]` in `skill-project.toml`:
 
-## Testing Tools
+```toml
+[tool.fastskill.eval]
+prompts = "evals/prompts.csv"     # CSV of prompt cases
+checks = "evals/checks.toml"      # TOML of checks/assertions
+timeout_seconds = 600             # per-case timeout
+fail_on_missing_agent = false     # error if the target agent isn't available
+```
 
-- Test runners and frameworks
-- Mock and stub utilities
-- Performance profiling tools
-- Coverage analysis
+- `prompts` — path to a CSV of prompt cases to run.
+- `checks` — path to a TOML file of checks applied to each result.
+- `timeout_seconds` — per-case timeout.
+- `fail_on_missing_agent` — when `true`, eval fails instead of skipping if the agent isn't found.
 
-:::note
+## The eval subcommands
 
-Comprehensive testing ensures FastSkill's reliability and performance in production environments.
+| Command | What it does |
+|---------|--------------|
+| `fastskill eval validate` | Validates the eval configuration and referenced files before running |
+| `fastskill eval run` | Runs the eval cases against an agent |
+| `fastskill eval report` | Shows a report for a completed eval run |
+| `fastskill eval score` | Scores results |
 
-:::
+```bash
+# 1. Check the config and files are well-formed
+fastskill eval validate
+
+# 2. Run the prompt cases against the agent
+fastskill eval run
+
+# 3. Review and score
+fastskill eval report
+fastskill eval score
+```
+
+Eval output supports `--format table|json` (no grid/xml for eval).
+
+<Callout>
+Start by pinning down what "good" looks like in your `checks.toml`, then iterate: `eval run` →
+`eval report` → adjust the skill → repeat.
+</Callout>
+
+## See also
+
+- [Evals & quality overview](/evals-quality/overview) — the quality workflow and concepts.
+- [eval command reference](/cli-reference/eval-command) — full flags and output details.

--- a/webdocs/tool-calling/development.mdx
+++ b/webdocs/tool-calling/development.mdx
@@ -1,27 +1,91 @@
 ---
-title: "Tool Development"
-description: "Guide for developing custom tools for FastSkill with best practices and examples."
+title: "MCP Tool Calling"
+description: "Expose every FastSkill command to agents as MCP tools with `fastskill mcp serve`, and wire them into Claude Code, Cursor, and other agents with `fastskill mcp install`."
 ---
 
 ## Overview
 
-Tool development enables you to extend FastSkill with custom functionality.
+FastSkill's tool/integration surface for agents is **MCP** (Model Context Protocol). You do not
+author custom tools inside FastSkill — instead, `fastskill mcp serve` exposes **every** FastSkill CLI
+command to an agent as an MCP tool, and `fastskill mcp install` writes the server config into your
+agent's configuration.
 
-## Development Guide
+## Serve FastSkill as an MCP server
 
-- Define tool interfaces
-- Implement tool logic
-- Add parameter validation
-- Include comprehensive testing
-- Document tool capabilities
+```bash
+fastskill mcp serve
+```
 
-## Best Practices
+Every CLI command is registered as an MCP tool named `fastskill.<path>`, where the command path has
+its separators replaced by dots. For example:
 
-- Follow FastSkill conventions
-- Implement proper error handling
-- Add comprehensive documentation
-- Test thoroughly before deployment
+| CLI command | MCP tool name |
+|-------------|---------------|
+| `fastskill search` | `fastskill.search` |
+| `fastskill repos add` | `fastskill.repos.add` |
+| `fastskill install` | `fastskill.install` |
+| `fastskill list` | `fastskill.list` |
+
+The built-in `completion` command is the one exception — it is never exported as an MCP tool.
+
+### Transports
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--transport <http\|stdio>` | Streamable HTTP or stdin/stdout JSON-RPC | `http` |
+| `--host <HOST>` | Bind address (http only) | `127.0.0.1` |
+| `--port <PORT>` | Bind port (http only) | `8080` |
+| `--path <PATH>` | HTTP path prefix for MCP endpoints (http only) | `/mcp` |
+
+```bash
+# HTTP transport on a custom path
+fastskill mcp serve --transport http --host 127.0.0.1 --port 8080 --path /mcp
+
+# stdio transport (for agents that spawn the process directly)
+fastskill mcp serve --transport stdio
+```
+
+`--host`, `--port`, and `--path` are only valid with `--transport http`.
+
+## Install into an agent
+
+`fastskill mcp install` writes an MCP server entry into a supported agent's configuration file:
+
+```bash
+fastskill mcp install --agent claude --scope project
+```
+
+| Option | Description |
+|--------|-------------|
+| `--agent <AGENT>` | Target agent: `claude`, `cursor`, `gemini`, `copilot`, `opencode`, `codex` |
+| `--scope <SCOPE>` | `project` (default) or `global` |
+| `--name <NAME>` | Server name in the config (defaults to the app name) |
+| `--url <URL>` | HTTP MCP URL (defaults to `http://127.0.0.1:8080/mcp`) |
+| `--stdio` | Use stdio transport (registers `current_exe` as the command) |
+
+`--url` and `--stdio` are mutually exclusive. Use `--url` to point the agent at a running HTTP MCP
+server, or `--stdio` to have the agent launch FastSkill itself.
+
+```bash
+# Point Cursor at a running HTTP MCP server, globally
+fastskill mcp install --agent cursor --scope global --url http://127.0.0.1:8080/mcp
+
+# Register a stdio server for Claude Code in this project
+fastskill mcp install --agent claude --scope project --stdio
+```
+
+## List configured MCP servers
+
+```bash
+fastskill mcp list
+```
 
 <Callout>
-Custom tools extend FastSkill's capabilities and integrate with the skill ecosystem.
+Because MCP tools are generated from the CLI command tree, agents get the full FastSkill surface
+(search, install, repos, resolve, analyze, and more) without any per-tool wiring on your side.
 </Callout>
+
+## See also
+
+- [serve command](/cli-reference/serve-command) — the separate HTTP REST/UI server.
+- [Integration tutorials](/examples/integration-tutorials) — end-to-end MCP setup for Claude Code and Cursor.

--- a/webdocs/welcome.mdx
+++ b/webdocs/welcome.mdx
@@ -101,21 +101,15 @@ monitoring = { source = "source", name = "registry", skill = "monitoring", group
 
 ### Performance
 
-**Pre-computed embeddings and efficient storage.**
+**Efficient local storage.**
 
-FastSkill includes performance optimizations that make skill management scalable:
-
-**Pre-computed Embeddings:**
-- Skills can bundle pre-computed embeddings in ZIP packages
-- No API calls needed during installation
-- Faster search and discovery
-- Consistent embeddings across installations
+FastSkill keeps semantic search fast and self-contained:
 
 **Local Vector Storage:**
-- SQLite-based embedding database
-- Fast semantic search without external API calls
-- Offline operation capability
-- Incremental indexing for efficiency
+- SQLite-based embedding index stored on disk (`index_path`)
+- Fast semantic search that queries local vectors — no external service call at query time
+- Incremental indexing: a change-detection cache (`.fastskill/build-cache.json`) re-embeds only what changed
+- Auto-reindex after add/install/update/remove keeps the index current
 
 ## Expanding the Claude Code Standard
 
@@ -268,7 +262,7 @@ FastSkill focuses on **repeatable operations** for AI agent skills:
 - **Scale**: many skills and repositories in one project
 - **Collaboration**: shared manifests and locks
 - **Reliability**: explicit versions and dependency entries
-- **Performance**: optional precomputed embeddings in packages
+- **Performance**: a local SQLite vector index with incremental reindexing
 - **Standards-based**: Claude Code `SKILL.md` layout
 
 ## What's Next?


### PR DESCRIPTION
## Why

Full documentation audit against the actual CLI source (binary `0.9.152`) ahead of the release. The docs had drifted from the binary in ways that would actively mislead users — commands and a config file that don't exist, flags documented as functional that are no-ops, and stub pages describing features FastSkill doesn't have.

## README (end-user rewrite)

Restructured around **who it's for** (developer / team / organization / skill author), **use-case scenarios**, a **feature overview**, and the **full verified command reference** — previously it omitted `serve`, `optimize`, `repos`, `update`, `remove`, `analyze`, `marketplace`, and `mcp`.

## Correctness fixes (verified against `crates/`)

- **Phantom `.fastskill/config.yaml`** (never read by the binary) removed from 10 pages → all config is `skill-project.toml`.
- **Inert flags** no longer shown as functional: `reindex --max-concurrent` (reindex is sequential) and `update --strategy/--version/--source` (parsed but no-op, per the in-source NOTE).
- **Endpoints** corrected to the versioned `/api/v1/...` surface; install route is `POST /api/v1/skills/install`; `serve` is **read-only by default** with `--enable-write` (ADR-0003, HTTP 403 otherwise) — now covered on the security and registry pages.
- **Fabricated content removed**: skill `execution_timeout`/`memory_limit_mb` fields, legacy `marketplace.json` schema, plaintext repo `auth_value`, phantom `--repositories-path`/`repositories.toml`, `--no-example`, and the unsupported "precomputed embeddings ship in ZIP packages" claim.
- `--auth-type` spelling → `api_key`; eval `--format` → `table|json` only; assorted internal contradictions resolved.

## Stub pages rewritten to real features

`security/*`, `tool-calling/development`, `progressive-loading/*`, `testing/*`, and `examples/*` now document what actually exists: **MCP** (`mcp serve`/`mcp install`), context resolution (`POST /api/v1/resolve`), `eval`, `doctor`, and worked `analyze`/`optimize` examples.

## Verification

- Multi-pass source-grounded review + adversarial verification pass over every rewritten page.
- Banished-terms sweep clean; MDX frontmatter/tag-balance checks pass.
- Pre-commit hooks green (fmt, clippy, 386 tests).

## Companion PRs (separate repos, same release)

- `gofastskill/skill` — `SKILL.md` rewrite (removes non-existent `publish`/`auth`/`package`/`registry`/`show`; adds `optimize`/`analyze`/`mcp`).
- `gofastskill/.github` — profile README (drops the removed `sync` highlight).

## Follow-up (code, not docs)

`fastskill doctor`'s auth-failure message hints `fastskill auth login`, a command that doesn't exist — worth fixing in the binary.
