### PR TITLE
fix: doctor points to non-existent 'fastskill auth login'

### DIFF
--- a/crates/fastskill-cli/src/commands/doctor.rs
+++ b/crates/fastskill-cli/src/commands/doctor.rs
@@ -169,7 +169,7 @@ pub async fn execute_doctor(service: &FastSkillService, args: DoctorArgs) -> Cli
         DoctorCheckResult {
             check: "auth_token".to_string(),
             status: DoctorStatus::Warn,
-            message: "No auth token set. Remote registry operations may fail. Run 'fastskill auth login'.".to_string(),
+            message: "No auth token set. Remote registry operations may fail. Set FASTSKILL_AUTH_TOKEN (or FASTSKILL_TOKEN) with a registry token.".to_string(),
         }
     };
     checks.push(auth_check);


### PR DESCRIPTION
`fastskill doctor`'s auth-token check warns:

> No auth token set. Remote registry operations may fail. Run 'fastskill auth login'.

But there is no `fastskill auth` command — the check reads env vars (`FASTSKILL_AUTH_TOKEN` / `FASTSKILL_TOKEN`), and auth/publishing is platform-managed, not a CLI flow. The message sends users to a command that will never exist.

This points them at the actual mechanism instead:

> No auth token set. Remote registry operations may fail. Set FASTSKILL_AUTH_TOKEN (or FASTSKILL_TOKEN) with a registry token.

One-line message change; no test pinned the old string. Pre-commit hooks green (386 tests). Follow-up from the docs alignment work (#218).
