### PR TITLE
fix(mcp): make `mcp serve` usable; accurate typo suggestions; bump cli-framework to 0.5.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Build release binary (cross)
         if: matrix.use-cross
-        run: cross build --release --verbose --target ${{ matrix.target }} -p fastskill-cli -F vendored-openssl
+        run: cross build --release --verbose --target ${{ matrix.target }} -p fastskill-cli
         env:
           RUSTFLAGS: ""
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,19 +45,6 @@ dependencies = [
 [[package]]
 name = "aikit-agent"
 version = "0.1.0"
-source = "git+https://github.com/goaikit/aikit?rev=435a1132#435a1132859bbfaf2977c0fb0ce070c795525132"
-dependencies = [
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "aikit-agent"
-version = "0.1.0"
 source = "git+https://github.com/goaikit/aikit.git?rev=435a1132859bbfaf2977c0fb0ce070c795525132#435a1132859bbfaf2977c0fb0ce070c795525132"
 dependencies = [
  "reqwest 0.12.28",
@@ -71,9 +58,9 @@ dependencies = [
 [[package]]
 name = "aikit-evals"
 version = "0.1.0"
-source = "git+https://github.com/goaikit/aikit?rev=435a1132#435a1132859bbfaf2977c0fb0ce070c795525132"
+source = "git+https://github.com/goaikit/aikit.git?rev=435a1132859bbfaf2977c0fb0ce070c795525132#435a1132859bbfaf2977c0fb0ce070c795525132"
 dependencies = [
- "aikit-sdk 0.3.0 (git+https://github.com/goaikit/aikit?rev=435a1132)",
+ "aikit-sdk",
  "async-trait",
  "base64 0.22.1",
  "num_cpus",
@@ -88,29 +75,9 @@ dependencies = [
 [[package]]
 name = "aikit-sdk"
 version = "0.3.0"
-source = "git+https://github.com/goaikit/aikit?rev=435a1132#435a1132859bbfaf2977c0fb0ce070c795525132"
-dependencies = [
- "aikit-agent 0.1.0 (git+https://github.com/goaikit/aikit?rev=435a1132)",
- "dirs 6.0.0",
- "glob",
- "jsonschema",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "tempfile",
- "toml 1.1.2+spec-1.1.0",
- "tracing",
- "uuid",
- "walkdir",
- "zip 2.4.2",
-]
-
-[[package]]
-name = "aikit-sdk"
-version = "0.3.0"
 source = "git+https://github.com/goaikit/aikit.git?rev=435a1132859bbfaf2977c0fb0ce070c795525132#435a1132859bbfaf2977c0fb0ce070c795525132"
 dependencies = [
- "aikit-agent 0.1.0 (git+https://github.com/goaikit/aikit.git?rev=435a1132859bbfaf2977c0fb0ce070c795525132)",
+ "aikit-agent",
  "dirs 6.0.0",
  "glob",
  "jsonschema",
@@ -128,10 +95,10 @@ dependencies = [
 [[package]]
 name = "aikit-skillopt"
 version = "0.1.0"
-source = "git+https://github.com/goaikit/aikit?rev=435a1132#435a1132859bbfaf2977c0fb0ce070c795525132"
+source = "git+https://github.com/goaikit/aikit.git?rev=435a1132859bbfaf2977c0fb0ce070c795525132#435a1132859bbfaf2977c0fb0ce070c795525132"
 dependencies = [
  "aikit-evals",
- "aikit-sdk 0.3.0 (git+https://github.com/goaikit/aikit?rev=435a1132)",
+ "aikit-sdk",
  "aikit-textgrad",
  "anyhow",
  "async-trait",
@@ -141,10 +108,10 @@ dependencies = [
 [[package]]
 name = "aikit-textgrad"
 version = "0.1.0"
-source = "git+https://github.com/goaikit/aikit?rev=435a1132#435a1132859bbfaf2977c0fb0ce070c795525132"
+source = "git+https://github.com/goaikit/aikit.git?rev=435a1132859bbfaf2977c0fb0ce070c795525132#435a1132859bbfaf2977c0fb0ce070c795525132"
 dependencies = [
  "aikit-evals",
- "aikit-sdk 0.3.0 (git+https://github.com/goaikit/aikit?rev=435a1132)",
+ "aikit-sdk",
  "anyhow",
  "async-trait",
  "serde",
@@ -157,8 +124,8 @@ dependencies = [
 
 [[package]]
 name = "ailoop-core"
-version = "1.0.5"
-source = "git+https://github.com/goailoop/ailoop.git?rev=dd186c055dbfcbf5c32c8e58b251eaf0bf07343b#dd186c055dbfcbf5c32c8e58b251eaf0bf07343b"
+version = "1.0.13"
+source = "git+https://github.com/goailoop/ailoop.git?rev=c9b70bcc0bd659823dc8ddf71d8571a8e011113b#c9b70bcc0bd659823dc8ddf71d8571a8e011113b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -167,13 +134,13 @@ dependencies = [
  "dashmap",
  "dirs 5.0.1",
  "futures-util",
- "reqwest 0.11.27",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite 0.21.0",
- "toml 0.8.23",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -400,7 +367,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
  "tower",
@@ -422,7 +389,7 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -701,10 +668,10 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli-framework"
-version = "0.4.2"
-source = "git+https://github.com/aroff/cli-framework?rev=76a83e0d57e88b55e5f8c44fd3dffe1444443924#76a83e0d57e88b55e5f8c44fd3dffe1444443924"
+version = "0.5.8"
+source = "git+https://github.com/aroff/cli-framework?rev=f6b77aebc6518c5e819f685942ed8257442717d0#f6b77aebc6518c5e819f685942ed8257442717d0"
 dependencies = [
- "aikit-sdk 0.3.0 (git+https://github.com/goaikit/aikit.git?rev=435a1132859bbfaf2977c0fb0ce070c795525132)",
+ "aikit-sdk",
  "ailoop-core",
  "anyhow",
  "async-trait",
@@ -713,7 +680,9 @@ dependencies = [
  "clap",
  "crossterm 0.28.1",
  "dirs 5.0.1",
+ "http 1.4.0",
  "httpdate",
+ "opentelemetry",
  "regex",
  "reqwest 0.12.28",
  "rmcp",
@@ -869,16 +838,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1386,7 +1345,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 name = "fastskill-cli"
 version = "0.9.155"
 dependencies = [
- "aikit-sdk 0.3.0 (git+https://github.com/goaikit/aikit?rev=435a1132)",
+ "aikit-sdk",
  "aikit-skillopt",
  "anyhow",
  "assert_cmd",
@@ -1403,7 +1362,6 @@ dependencies = [
  "insta",
  "num_cpus",
  "once_cell",
- "openssl",
  "predicates",
  "regex",
  "reqwest 0.12.28",
@@ -1559,21 +1517,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2078,20 +2021,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
@@ -2099,27 +2028,11 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.38",
+ "rustls",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2140,11 +2053,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.5.10",
- "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2518,7 +2429,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "reqwest 0.13.4",
- "rustls 0.23.38",
+ "rustls",
  "serde",
  "serde_json",
  "unicode-general-category",
@@ -2764,23 +2675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,56 +2853,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "openssl-src"
-version = "300.6.0+3.6.2"
+name = "opentelemetry"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -3325,7 +3186,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.38",
+ "rustls",
  "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
@@ -3345,7 +3206,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3614,82 +3475,35 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls 0.27.9",
- "hyper-tls",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3699,7 +3513,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3718,20 +3532,20 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls 0.27.9",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3897,18 +3711,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
@@ -3917,7 +3719,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -3932,15 +3734,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -3959,15 +3752,15 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.38",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -3979,16 +3772,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -4065,23 +3848,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4472,12 +4245,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -4516,48 +4283,6 @@ dependencies = [
  "thiserror 2.0.18",
  "walkdir",
  "yaml-rust",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -4741,32 +4466,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.38",
+ "rustls",
  "tokio",
 ]
 
@@ -4908,7 +4613,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -5457,12 +5162,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -5541,17 +5240,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
 
 [[package]]
 name = "windows-result"
@@ -5809,16 +5497,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,17 @@ license = "Apache-2.0"
 repository = "https://github.com/aroff/fastskill"
 
 [workspace.dependencies]
+# NOTE: the git URL and rev below must match cli-framework's own aikit-sdk
+# dependency spelling exactly (`.git` suffix + full 40-char rev). Cargo keys git
+# sources on the literal URL+rev string, so any divergence resolves aikit twice
+# and compiles two mutually-incompatible copies into the binary.
+#
 # aikit-sdk for agent metadata file resolution
-aikit-sdk = { git = "https://github.com/goaikit/aikit", rev = "435a1132" }
+aikit-sdk = { git = "https://github.com/goaikit/aikit.git", rev = "435a1132859bbfaf2977c0fb0ce070c795525132" }
 # aikit-evals provides the generic eval runner infrastructure
-aikit-evals = { git = "https://github.com/goaikit/aikit", rev = "435a1132" }
+aikit-evals = { git = "https://github.com/goaikit/aikit.git", rev = "435a1132859bbfaf2977c0fb0ce070c795525132" }
 # aikit-skillopt provides the text-gradient skill optimization loop
-aikit-skillopt = { git = "https://github.com/goaikit/aikit", rev = "435a1132" }
+aikit-skillopt = { git = "https://github.com/goaikit/aikit.git", rev = "435a1132859bbfaf2977c0fb0ce070c795525132" }
 
 # Async runtime
 tokio = { version = "1.52", features = ["rt-multi-thread", "net", "fs", "io-util", "macros", "process"] }
@@ -66,7 +71,7 @@ tower = { version = "0.5", features = ["util", "timeout", "limit"] }
 tower-http = { version = "0.6", features = ["cors", "trace", "compression-gzip", "fs"] }
 
 # CLI framework for versioned API server hosting
-cli-framework = { git = "https://github.com/aroff/cli-framework", rev = "76a83e0d57e88b55e5f8c44fd3dffe1444443924", default-features = false, features = ["api-server"] }
+cli-framework = { git = "https://github.com/aroff/cli-framework", rev = "f6b77aebc6518c5e819f685942ed8257442717d0", default-features = false, features = ["api-server"] }
 
 # Request validation
 validator = { version = "0.20", features = ["derive"] }

--- a/crates/fastskill-cli/Cargo.toml
+++ b/crates/fastskill-cli/Cargo.toml
@@ -82,15 +82,8 @@ dirs.workspace = true
 # Semantic versioning
 semver.workspace = true
 
-# Vendored OpenSSL — required for musl cross-compilation because cli-framework and
-# aikit-sdk depend on reqwest without default-features = false, which unifies
-# native-tls into the build. The vendored feature compiles OpenSSL from source
-# so the build is self-contained in environments without a system OpenSSL.
-openssl = { version = "0.10", optional = true, features = ["vendored"] }
-
 [features]
 default = []
-vendored-openssl = ["dep:openssl"]
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/fastskill-cli/src/commands/add/install.rs
+++ b/crates/fastskill-cli/src/commands/add/install.rs
@@ -112,21 +112,23 @@ pub(super) async fn finish_skill_install(
 
     if ctx.global {
         super::update_global_files(&skill_def)?;
-        println!(
+        crate::outln!(
             "Successfully added skill: {} (v{})",
-            skill_def.name, version_display
+            skill_def.name,
+            version_display
         );
-        println!(
+        crate::outln!(
             "{}",
             crate::utils::messages::ok("Updated global-skills.lock")
         );
     } else {
         super::update_project_files(&skill_def, ctx.groups.clone())?;
-        println!(
+        crate::outln!(
             "Successfully added skill: {} (v{})",
-            skill_def.name, version_display
+            skill_def.name,
+            version_display
         );
-        println!(
+        crate::outln!(
             "{}",
             crate::utils::messages::ok("Updated skill-project.toml and skills.lock")
         );
@@ -254,7 +256,7 @@ pub(super) async fn handle_recursive_add(
             path.display()
         )));
     }
-    println!(
+    crate::outln!(
         "Found {} skill(s) in directory {}",
         skill_dirs.len(),
         path.display()

--- a/crates/fastskill-cli/src/commands/add/mod.rs
+++ b/crates/fastskill-cli/src/commands/add/mod.rs
@@ -610,11 +610,12 @@ pub async fn execute_add(service: &FastSkillService, args: AddArgs, global: bool
         Err(_) => outcome.id.clone(),
     };
 
-    println!(
+    crate::outln!(
         "Successfully added skill: {} (v{})",
-        display_name, outcome.resolved.version
+        display_name,
+        outcome.resolved.version
     );
-    println!(
+    crate::outln!(
         "{}",
         crate::utils::messages::ok("Updated skill-project.toml and skills.lock")
     );

--- a/crates/fastskill-cli/src/commands/analyze/cluster.rs
+++ b/crates/fastskill-cli/src/commands/analyze/cluster.rs
@@ -144,7 +144,7 @@ pub async fn execute_cluster(ctx: AnalysisContext, args: ClusterArgs) -> CliResu
     }
 
     if !use_json {
-        println!("Clustering {} skills into {} groups...", n, k);
+        crate::outln!("Clustering {} skills into {} groups...", n, k);
     }
 
     all_skills.sort_by(|a, b| a.id.cmp(&b.id));
@@ -213,7 +213,7 @@ pub async fn execute_cluster(ctx: AnalysisContext, args: ClusterArgs) -> CliResu
     if use_json {
         let json_output = serde_json::to_string_pretty(&clusters)
             .map_err(|e| CliError::Validation(format!("Failed to serialize JSON: {}", e)))?;
-        println!("{}", json_output);
+        crate::outln!("{}", json_output);
     } else {
         print_cluster_output(&clusters, n, k);
     }
@@ -227,26 +227,29 @@ pub(super) fn print_cluster_output(
     actual_k: usize,
 ) {
     if clusters.is_empty() {
-        println!("\nNo clusters to display (all clusters are below the --min-size threshold).");
+        crate::outln!(
+            "\nNo clusters to display (all clusters are below the --min-size threshold)."
+        );
         return;
     }
 
-    println!();
+    crate::outln!();
     for (display_idx, cluster) in clusters.iter().enumerate() {
-        println!(
+        crate::outln!(
             "Cluster {} — {} ({} skills)",
             display_idx + 1,
             cluster.representative,
             cluster.size
         );
-        println!("  Members:");
+        crate::outln!("  Members:");
         for member in &cluster.members {
-            println!(
+            crate::outln!(
                 "    {:<30} {:.2}",
-                member.skill_id, member.distance_to_centroid
+                member.skill_id,
+                member.distance_to_centroid
             );
         }
-        println!();
+        crate::outln!();
     }
 
     let mut largest = &clusters[0];
@@ -260,7 +263,7 @@ pub(super) fn print_cluster_output(
         }
     }
 
-    println!(
+    crate::outln!(
         "Summary: {} clusters  largest: {} skills ({})  smallest: {} skills ({})",
         clusters.len(),
         largest.size,
@@ -272,7 +275,7 @@ pub(super) fn print_cluster_output(
     if actual_k < total_skills {
         let mean_size = total_skills as f32 / actual_k as f32;
         if largest.size as f32 > 2.0 * mean_size {
-            println!(
+            crate::outln!(
                 "Hint: Re-run with -k {} to split larger clusters further.",
                 largest.size
             );

--- a/crates/fastskill-cli/src/commands/analyze/duplicates.rs
+++ b/crates/fastskill-cli/src/commands/analyze/duplicates.rs
@@ -202,9 +202,10 @@ pub async fn execute_duplicates(ctx: AnalysisContext, args: DuplicatesArgs) -> C
     let effective_floor = args.threshold.max(s_floor);
 
     if !use_json {
-        println!(
+        crate::outln!(
             "Scanning {} skills for duplicates (threshold: {:.2})...",
-            n, args.threshold
+            n,
+            args.threshold
         );
     }
 
@@ -265,21 +266,21 @@ pub async fn execute_duplicates(ctx: AnalysisContext, args: DuplicatesArgs) -> C
         };
         let json_output = serde_json::to_string_pretty(&output)
             .map_err(|e| CliError::Validation(format!("Failed to serialize JSON: {}", e)))?;
-        println!("{}", json_output);
+        crate::outln!("{}", json_output);
     } else if pairs.is_empty() {
-        println!("No duplicate pairs found above threshold.");
+        crate::outln!("No duplicate pairs found above threshold.");
     } else {
-        println!("Found {} potential duplicate pairs\n", pairs.len());
+        crate::outln!("Found {} potential duplicate pairs\n", pairs.len());
         for pair in &pairs {
-            println!(
+            crate::outln!(
                 "{}  {:.3}  {}  ↔  {}",
                 pair.severity.label(),
                 pair.similarity,
                 pair.skill_a.id,
                 pair.skill_b.id
             );
-            println!("  Suggestion: {}", pair.suggestion);
-            println!();
+            crate::outln!("  Suggestion: {}", pair.suggestion);
+            crate::outln!();
         }
 
         struct SeverityCounts {
@@ -312,8 +313,8 @@ pub async fn execute_duplicates(ctx: AnalysisContext, args: DuplicatesArgs) -> C
         .map(|(n, label)| format!("{} {}", n, label))
         .collect::<Vec<_>>()
         .join(", ");
-        println!("Summary: {}", summary);
-        println!("Run 'fastskill remove <skill-id>' to remove a skill after review.");
+        crate::outln!("Summary: {}", summary);
+        crate::outln!("Run 'fastskill remove <skill-id>' to remove a skill after review.");
     }
 
     Ok(())

--- a/crates/fastskill-cli/src/commands/analyze/matrix.rs
+++ b/crates/fastskill-cli/src/commands/analyze/matrix.rs
@@ -127,14 +127,14 @@ pub async fn execute_matrix(ctx: AnalysisContext, args: MatrixArgs) -> CliResult
 
     if !use_json && all_skills.len() > 50 {
         let total_comparisons = all_skills.len() * (all_skills.len() - 1) / 2;
-        println!(
+        crate::outln!(
             "Calculating {} pairwise comparisons for {} skills...",
             total_comparisons,
             all_skills.len()
         );
-        println!("This may take a moment for large skill collections.");
+        crate::outln!("This may take a moment for large skill collections.");
     } else if !use_json {
-        println!(
+        crate::outln!(
             "Calculating pairwise similarities for {} skills...",
             all_skills.len()
         );
@@ -154,7 +154,7 @@ pub async fn execute_matrix(ctx: AnalysisContext, args: MatrixArgs) -> CliResult
         let json_output = serde_json::to_string_pretty(&filtered).map_err(|e| {
             crate::error::CliError::Validation(format!("Failed to serialize JSON: {}", e))
         })?;
-        println!("{}", json_output);
+        crate::outln!("{}", json_output);
     } else {
         print!("{}", build_grid_string(&similarity_matrix, args.threshold));
     }

--- a/crates/fastskill-cli/src/commands/analyze/mod.rs
+++ b/crates/fastskill-cli/src/commands/analyze/mod.rs
@@ -35,7 +35,7 @@ pub struct AnalysisContext {
 
 pub async fn load_analysis_context(svc: &FastSkillService) -> CliResult<Option<AnalysisContext>> {
     let Some(vector_svc) = svc.vector_index_service() else {
-        println!("Note: semantic analysis requires an embedding provider. Results may be limited to structural analysis.");
+        crate::outln!("Note: semantic analysis requires an embedding provider. Results may be limited to structural analysis.");
         return Ok(None);
     };
     let skills = vector_svc
@@ -43,7 +43,7 @@ pub async fn load_analysis_context(svc: &FastSkillService) -> CliResult<Option<A
         .await
         .map_err(|e| CliError::Validation(format!("Failed to get indexed skills: {}", e)))?;
     if skills.is_empty() {
-        println!("No skills indexed. Run 'fastskill reindex' first.");
+        crate::outln!("No skills indexed. Run 'fastskill reindex' first.");
         return Ok(None);
     }
     Ok(Some(AnalysisContext { skills, vector_svc }))

--- a/crates/fastskill-cli/src/commands/doctor.rs
+++ b/crates/fastskill-cli/src/commands/doctor.rs
@@ -194,17 +194,17 @@ pub async fn execute_doctor(service: &FastSkillService, args: DoctorArgs) -> Cli
 }
 
 fn print_human(checks: &[DoctorCheckResult]) {
-    println!("FastSkill Doctor");
-    println!("{}", "=".repeat(40));
+    crate::outln!("FastSkill Doctor");
+    crate::outln!("{}", "=".repeat(40));
     for check in checks {
         let icon = match check.status {
             DoctorStatus::Pass => "[PASS]",
             DoctorStatus::Warn => "[WARN]",
             DoctorStatus::Fail => "[FAIL]",
         };
-        println!("{} {}: {}", icon, check.check, check.message);
+        crate::outln!("{} {}: {}", icon, check.check, check.message);
     }
-    println!();
+    crate::outln!();
     let errors = checks
         .iter()
         .filter(|c| c.status == DoctorStatus::Fail)
@@ -214,9 +214,9 @@ fn print_human(checks: &[DoctorCheckResult]) {
         .filter(|c| c.status == DoctorStatus::Warn)
         .count();
     if errors == 0 && warnings == 0 {
-        println!("All checks passed.");
+        crate::outln!("All checks passed.");
     } else {
-        println!("{} error(s), {} warning(s).", errors, warnings);
+        crate::outln!("{} error(s), {} warning(s).", errors, warnings);
     }
 }
 
@@ -231,7 +231,7 @@ fn print_json(checks: &[DoctorCheckResult]) {
             })
         })
         .collect();
-    println!(
+    crate::outln!(
         "{}",
         serde_json::to_string_pretty(&items).unwrap_or_default()
     );

--- a/crates/fastskill-cli/src/commands/eval/report.rs
+++ b/crates/fastskill-cli/src/commands/eval/report.rs
@@ -122,18 +122,18 @@ pub async fn execute_report(args: ReportArgs) -> CliResult<()> {
     })?;
 
     if use_json {
-        println!(
+        crate::outln!(
             "{}",
             serde_json::to_string_pretty(&summary).unwrap_or_default()
         );
     } else {
-        println!("Eval Report");
-        println!("  run_dir: {}", args.run_dir.display());
-        println!("  agent: {}", summary.agent);
+        crate::outln!("Eval Report");
+        crate::outln!("  run_dir: {}", args.run_dir.display());
+        crate::outln!("  agent: {}", summary.agent);
         if let Some(ref model) = summary.model {
-            println!("  model: {}", model);
+            crate::outln!("  model: {}", model);
         }
-        println!(
+        crate::outln!(
             "  result: {}",
             if summary.suite_pass {
                 "PASSED"
@@ -141,10 +141,10 @@ pub async fn execute_report(args: ReportArgs) -> CliResult<()> {
                 "FAILED"
             }
         );
-        println!("  cases: {}/{} passed", summary.passed, summary.total_cases);
+        crate::outln!("  cases: {}/{} passed", summary.passed, summary.total_cases);
 
         if !summary.cases.is_empty() {
-            println!("\nCase Results:");
+            crate::outln!("\nCase Results:");
             for case in &summary.cases {
                 let token_info = match (case.input_tokens, case.output_tokens) {
                     (Some(i), Some(o)) => format!(" (in={} out={})", i, o),
@@ -152,7 +152,7 @@ pub async fn execute_report(args: ReportArgs) -> CliResult<()> {
                     (None, Some(o)) => format!(" (out={})", o),
                     (None, None) => String::new(),
                 };
-                println!("  [{}] {}{}", case.status, case.id, token_info);
+                crate::outln!("  [{}] {}{}", case.status, case.id, token_info);
             }
         }
     }

--- a/crates/fastskill-cli/src/commands/eval/run.rs
+++ b/crates/fastskill-cli/src/commands/eval/run.rs
@@ -740,12 +740,12 @@ pub async fn execute_run_with_runner<R: EvalRunner + 'static>(
     // Output results.
     if use_json {
         if all_summaries.len() == 1 {
-            println!(
+            crate::outln!(
                 "{}",
                 serde_json::to_string_pretty(&all_summaries[0]).unwrap_or_default()
             );
         } else {
-            println!(
+            crate::outln!(
                 "{}",
                 serde_json::to_string_pretty(&all_summaries).unwrap_or_default()
             );
@@ -753,29 +753,31 @@ pub async fn execute_run_with_runner<R: EvalRunner + 'static>(
     } else {
         for summary in &all_summaries {
             let suite_pass_rate = summary.suite_pass_rate.unwrap_or(0.0);
-            println!(
+            crate::outln!(
                 "\nEval run complete for agent '{}': {}/{} passed",
-                summary.agent, summary.passed, summary.total_cases
+                summary.agent,
+                summary.passed,
+                summary.total_cases
             );
-            println!("  run_dir: {}", summary.run_dir.display());
+            crate::outln!("  run_dir: {}", summary.run_dir.display());
             if summary.suite_pass {
                 if args.ci {
-                    println!(
+                    crate::outln!(
                         "  result: PASSED (suite pass rate {:.0}% ≥ {:.0}% threshold)",
                         suite_pass_rate * 100.0,
                         pass_threshold * 100.0
                     );
                 } else {
-                    println!("  result: PASSED");
+                    crate::outln!("  result: PASSED");
                 }
             } else if args.ci {
-                println!(
+                crate::outln!(
                     "  result: FAILED (suite pass rate {:.0}% < {:.0}% threshold)",
                     suite_pass_rate * 100.0,
                     pass_threshold * 100.0
                 );
             } else {
-                println!("  result: FAILED ({} case(s) failed)", summary.failed);
+                crate::outln!("  result: FAILED ({} case(s) failed)", summary.failed);
             }
         }
     }

--- a/crates/fastskill-cli/src/commands/eval/score.rs
+++ b/crates/fastskill-cli/src/commands/eval/score.rs
@@ -258,13 +258,13 @@ pub async fn execute_score(args: ScoreArgs) -> CliResult<()> {
         .map_err(|e| CliError::Config(format!("Failed to write updated summary.json: {}", e)))?;
 
     if use_json {
-        println!(
+        crate::outln!(
             "{}",
             serde_json::to_string_pretty(&summary).unwrap_or_default()
         );
     } else {
-        println!("Re-scoring complete");
-        println!(
+        crate::outln!("Re-scoring complete");
+        crate::outln!(
             "  result: {}",
             if summary.suite_pass {
                 "PASSED"
@@ -272,7 +272,7 @@ pub async fn execute_score(args: ScoreArgs) -> CliResult<()> {
                 "FAILED"
             }
         );
-        println!("  cases: {}/{} passed", summary.passed, summary.total_cases);
+        crate::outln!("  cases: {}/{} passed", summary.passed, summary.total_cases);
     }
 
     if !summary.suite_pass && !args.no_fail {

--- a/crates/fastskill-cli/src/commands/eval/validate.rs
+++ b/crates/fastskill-cli/src/commands/eval/validate.rs
@@ -195,23 +195,23 @@ pub async fn execute_validate(args: ValidateArgs) -> CliResult<()> {
             "case_count": case_count,
             "check_count": check_count,
         });
-        println!(
+        crate::outln!(
             "{}",
             serde_json::to_string_pretty(&output).unwrap_or_default()
         );
     } else {
-        println!("eval configuration: valid");
-        println!("  prompts: {}", eval_config.prompts_path.display());
-        println!("  cases: {}", case_count);
+        crate::outln!("eval configuration: valid");
+        crate::outln!("  prompts: {}", eval_config.prompts_path.display());
+        crate::outln!("  cases: {}", case_count);
         if let Some(ref checks) = eval_config.checks_path {
-            println!("  checks: {}", checks.display());
-            println!("  check count: {}", check_count);
+            crate::outln!("  checks: {}", checks.display());
+            crate::outln!("  check count: {}", check_count);
         }
-        println!("  timeout: {}s", eval_config.timeout_seconds);
-        println!("  trials_per_case: {}", eval_config.trials_per_case);
-        println!("  parallel: {}", eval_config.parallel.unwrap_or(0));
-        println!("  pass_threshold: {}", eval_config.pass_threshold);
-        println!(
+        crate::outln!("  timeout: {}s", eval_config.timeout_seconds);
+        crate::outln!("  trials_per_case: {}", eval_config.trials_per_case);
+        crate::outln!("  parallel: {}", eval_config.parallel.unwrap_or(0));
+        crate::outln!("  pass_threshold: {}", eval_config.pass_threshold);
+        crate::outln!(
             "  fail_on_missing_agent: {}",
             eval_config.fail_on_missing_agent
         );
@@ -234,7 +234,7 @@ pub async fn execute_validate(args: ValidateArgs) -> CliResult<()> {
                 );
             }
             if !use_json {
-                println!(
+                crate::outln!(
                     "  agent '{}': {}",
                     agent_key,
                     if available {

--- a/crates/fastskill-cli/src/commands/init.rs
+++ b/crates/fastskill-cli/src/commands/init.rs
@@ -148,8 +148,8 @@ impl FromArgValueMap for InitArgs {
 }
 
 pub async fn execute_init(args: InitArgs) -> CliResult<()> {
-    println!("FastSkill Skill Initialization");
-    println!();
+    crate::outln!("FastSkill Skill Initialization");
+    crate::outln!();
 
     let skill_project_path = Path::new("skill-project.toml");
     ensure_can_init(skill_project_path, args.force)?;
@@ -409,7 +409,7 @@ fn append_tool_comment(path: &Path, is_skill_level: bool) -> CliResult<()> {
 }
 
 fn print_success(is_skill_level: bool, version: &str, skills_directory: Option<&str>) {
-    println!(
+    crate::outln!(
         "{}",
         messages::ok(&format!(
             "Created skill-project.toml with version: {}",
@@ -417,24 +417,24 @@ fn print_success(is_skill_level: bool, version: &str, skills_directory: Option<&
         ))
     );
     if is_skill_level {
-        println!();
-        println!(
+        crate::outln!();
+        crate::outln!(
             "{}",
             messages::info("This file contains author-provided metadata for your skill.")
         );
-        println!("   It will be used by fastskill for version management.");
+        crate::outln!("   It will be used by fastskill for version management.");
         return;
     }
     if let Some(dir) = skills_directory {
-        println!();
-        println!("{}", messages::info(&format!("Skills directory: {}", dir)));
+        crate::outln!();
+        crate::outln!("{}", messages::info(&format!("Skills directory: {}", dir)));
     }
-    println!();
-    println!(
+    crate::outln!();
+    crate::outln!(
         "{}",
         messages::info("This file configures your project's skill dependencies.")
     );
-    println!("   Add skills with: fastskill add <skill-id>");
+    crate::outln!("   Add skills with: fastskill add <skill-id>");
 }
 
 fn extract_version_from_skill_md(content: &str, skip_prompts: bool) -> CliResult<String> {
@@ -520,8 +520,8 @@ fn version_from_frontmatter_text(frontmatter: &str) -> Option<String> {
 }
 
 fn prompt_for_version() -> CliResult<String> {
-    println!("Version");
-    println!("No version found in SKILL.md frontmatter.");
+    crate::outln!("Version");
+    crate::outln!("No version found in SKILL.md frontmatter.");
     print!("Enter version (or press Enter for 1.0.0): ");
     io::stdout().flush()?;
 

--- a/crates/fastskill-cli/src/commands/install.rs
+++ b/crates/fastskill-cli/src/commands/install.rs
@@ -214,8 +214,8 @@ pub async fn execute_install(args: InstallArgs) -> CliResult<()> {
         ));
     }
 
-    println!("Installing skills...");
-    println!();
+    crate::outln!("Installing skills...");
+    crate::outln!();
 
     // Validate depth argument (must be > 0 if provided)
     if let Some(depth) = args.depth {
@@ -288,7 +288,7 @@ pub async fn execute_install(args: InstallArgs) -> CliResult<()> {
         let lock = ProjectSkillsLock::load_from_file(&lock_path)
             .map_err(|e| CliError::Config(format!("Failed to load lock file: {}", e)))?;
 
-        println!("Using lock file ({} skills)", lock.skills.len());
+        crate::outln!("Using lock file ({} skills)", lock.skills.len());
 
         // Convert lock entries to installable items
         lock.skills
@@ -360,10 +360,10 @@ pub async fn execute_install(args: InstallArgs) -> CliResult<()> {
         filtered_items
     };
 
-    println!("Found {} skills to install", skills_to_install.len());
+    crate::outln!("Found {} skills to install", skills_to_install.len());
 
     if skills_to_install.is_empty() {
-        println!(
+        crate::outln!(
             "{}",
             messages::info("No skills to install (filtered by groups)")
         );
@@ -378,7 +378,7 @@ pub async fn execute_install(args: InstallArgs) -> CliResult<()> {
     let mut installed_skills = Vec::new();
     let mut failed_skills = Vec::new();
     for item in &skills_to_install {
-        println!("  Installing {} (depth {})...", item.entry.id, item.depth);
+        crate::outln!("  Installing {} (depth {})...", item.entry.id, item.depth);
         match install_utils::install_skill_from_entry(
             &service,
             item.entry.clone(),
@@ -393,7 +393,7 @@ pub async fn execute_install(args: InstallArgs) -> CliResult<()> {
                     item.depth,
                     item.parent_skill.clone(),
                 ));
-                println!(
+                crate::outln!(
                     "  {}",
                     messages::ok(&format!("Installed {}", item.entry.id))
                 );
@@ -427,9 +427,9 @@ pub async fn execute_install(args: InstallArgs) -> CliResult<()> {
         .map_err(|e| CliError::Config(format!("Failed to update lock file: {}", e)))?;
     }
 
-    println!();
-    println!("{}", messages::ok("Installation complete"));
-    println!("   Updated skills.lock");
+    crate::outln!();
+    crate::outln!("{}", messages::ok("Installation complete"));
+    crate::outln!("   Updated skills.lock");
 
     // Return error if any skills failed to install
     if !failed_skills.is_empty() {

--- a/crates/fastskill-cli/src/commands/list.rs
+++ b/crates/fastskill-cli/src/commands/list.rs
@@ -284,7 +284,7 @@ pub async fn execute_list(
 
     let formatted_output = fastskill_core::output::format_list_results(&rows, format, args.details)
         .map_err(CliError::Config)?;
-    println!("{}", formatted_output);
+    crate::outln!("{}", formatted_output);
 
     Ok(())
 }

--- a/crates/fastskill-cli/src/commands/read.rs
+++ b/crates/fastskill-cli/src/commands/read.rs
@@ -295,7 +295,7 @@ pub async fn execute_read(service: Arc<FastSkillService>, args: ReadArgs) -> Cli
 
         let output = format_show_results(&[skill], format)
             .map_err(|e| CliError::Config(format!("Failed to format output: {}", e)))?;
-        println!("{}", output);
+        crate::outln!("{}", output);
 
         // If --tree is also set, fall through to print tree after meta
         if args.tree {
@@ -479,30 +479,30 @@ pub async fn execute_read(service: Arc<FastSkillService>, args: ReadArgs) -> Cli
 
     // T014: Implement structured output format (header, base directory, content, footer)
     // T016: Ensure plain text output with no ANSI colors or formatting codes
-    println!("Reading: {}", args.skill_id);
-    println!("Base directory: {}", base_dir_absolute.display());
-    println!();
+    crate::outln!("Reading: {}", args.skill_id);
+    crate::outln!("Base directory: {}", base_dir_absolute.display());
+    crate::outln!();
     print!("{}", content);
     if !content.ends_with('\n') {
-        println!();
+        crate::outln!();
     }
-    println!();
-    println!("Skill read: {}", args.skill_id);
+    crate::outln!();
+    crate::outln!("Skill read: {}", args.skill_id);
 
     Ok(())
 }
 
 /// Print a dependency tree for the given skill definition.
 fn print_dependency_tree(skill: &SkillDefinition) {
-    println!("{}", skill.id);
+    crate::outln!("{}", skill.id);
     match &skill.dependencies {
         Some(deps) if !deps.is_empty() => {
             for dep in deps {
-                println!("  - {}", dep);
+                crate::outln!("  - {}", dep);
             }
         }
         _ => {
-            println!("  (no dependencies)");
+            crate::outln!("  (no dependencies)");
         }
     }
 }

--- a/crates/fastskill-cli/src/commands/registry/formatters.rs
+++ b/crates/fastskill-cli/src/commands/registry/formatters.rs
@@ -103,8 +103,8 @@ pub fn format_table_output(
         .enumerate()
         .map(|(i, h)| format!("{:width$}", h, width = col_widths[i]))
         .collect();
-    println!("\n{}", header_row.join("  "));
-    println!("{}", "-".repeat(header_row.join("  ").len()));
+    crate::outln!("\n{}", header_row.join("  "));
+    crate::outln!("{}", "-".repeat(header_row.join("  ").len()));
 
     for summary in summaries {
         let description = if summary.description.len() > 50 {
@@ -125,10 +125,10 @@ pub fn format_table_output(
             format!("{:width$}", summary.latest_version, width = col_widths[3]),
             format!("{:width$}", published, width = col_widths[4]),
         ];
-        println!("{}", row.join("  "));
+        crate::outln!("{}", row.join("  "));
     }
 
-    println!();
+    crate::outln!();
     Ok(())
 }
 
@@ -137,14 +137,16 @@ pub fn format_grid_output(
     _all_versions: bool,
 ) -> CliResult<()> {
     if summaries.is_empty() {
-        println!("No skills found.");
+        crate::outln!("No skills found.");
         return Ok(());
     }
 
     for summary in summaries {
-        println!(
+        crate::outln!(
             "- {}/{} ({})",
-            summary.scope, summary.name, summary.latest_version
+            summary.scope,
+            summary.name,
+            summary.latest_version
         );
     }
     Ok(())
@@ -153,7 +155,7 @@ pub fn format_grid_output(
 pub fn format_xml_output(
     summaries: &[fastskill_core::core::registry_index::SkillSummary],
 ) -> CliResult<()> {
-    println!("{}", summaries_to_xml(summaries));
+    crate::outln!("{}", summaries_to_xml(summaries));
     Ok(())
 }
 

--- a/crates/fastskill-cli/src/commands/registry/marketplace.rs
+++ b/crates/fastskill-cli/src/commands/registry/marketplace.rs
@@ -103,14 +103,14 @@ pub async fn execute_create(
     fs::write(&output_path, json_content)
         .map_err(|e| CliError::Validation(format!("Failed to write marketplace.json: {}", e)))?;
 
-    println!(
+    crate::outln!(
         "{}",
         messages::ok(&format!(
             "Created marketplace.json: {}",
             output_path.display()
         ))
     );
-    println!("   Found {} skills", skills_count);
+    crate::outln!("   Found {} skills", skills_count);
 
     Ok(())
 }

--- a/crates/fastskill-cli/src/commands/registry/repo_ops.rs
+++ b/crates/fastskill-cli/src/commands/registry/repo_ops.rs
@@ -27,14 +27,16 @@ pub async fn execute_list_with_format(format: OutputFormat) -> CliResult<()> {
         OutputFormat::Json => {
             let json_output = serde_json::to_string_pretty(&repos)
                 .map_err(|e| CliError::Config(format!("Failed to serialize JSON: {}", e)))?;
-            println!("{}", json_output);
+            crate::outln!("{}", json_output);
         }
-        OutputFormat::Table => println!("{}", super::formatters::format_repository_list(&repos)),
+        OutputFormat::Table => {
+            crate::outln!("{}", super::formatters::format_repository_list(&repos))
+        }
         OutputFormat::Grid => {
-            println!("{}", super::formatters::format_repository_list_grid(&repos))
+            crate::outln!("{}", super::formatters::format_repository_list_grid(&repos))
         }
         OutputFormat::Xml => {
-            println!("{}", super::formatters::format_repository_list_xml(&repos))
+            crate::outln!("{}", super::formatters::format_repository_list_xml(&repos))
         }
     }
     Ok(())
@@ -61,17 +63,19 @@ pub async fn execute_show_with_format(name: String, format: OutputFormat) -> Cli
         OutputFormat::Json => {
             let json_output = serde_json::to_string_pretty(&repo)
                 .map_err(|e| CliError::Config(format!("Failed to serialize JSON: {}", e)))?;
-            println!("{}", json_output);
+            crate::outln!("{}", json_output);
         }
-        OutputFormat::Table => println!("{}", super::formatters::format_repository_details(repo)),
+        OutputFormat::Table => {
+            crate::outln!("{}", super::formatters::format_repository_details(repo))
+        }
         OutputFormat::Grid => {
-            println!(
+            crate::outln!(
                 "{}",
                 super::formatters::format_repository_details_grid(repo)
             )
         }
         OutputFormat::Xml => {
-            println!("{}", super::formatters::format_repository_details_xml(repo))
+            crate::outln!("{}", super::formatters::format_repository_details_xml(repo))
         }
     }
 
@@ -129,7 +133,7 @@ pub async fn execute_update(
         .save()
         .map_err(|e| CliError::Config(format!("Failed to save repositories: {}", e)))?;
 
-    println!("{}", messages::ok(&format!("Updated repository: {}", name)));
+    crate::outln!("{}", messages::ok(&format!("Updated repository: {}", name)));
     Ok(())
 }
 
@@ -140,7 +144,7 @@ pub async fn execute_test(name: String) -> CliResult<()> {
         .get_repository(&name)
         .ok_or_else(|| CliError::Config(format!("Repository '{}' not found", name)))?;
 
-    println!(
+    crate::outln!(
         "{}",
         messages::info(&format!("Testing repository: {}...", name))
     );
@@ -148,7 +152,7 @@ pub async fn execute_test(name: String) -> CliResult<()> {
     match repo_manager.get_client(&name).await {
         Ok(client) => match client.list_skills().await {
             Ok(skills) => {
-                println!(
+                crate::outln!(
                     "{}",
                     messages::ok(&format!(
                         "Repository '{}' is accessible ({} skills found)",
@@ -177,12 +181,12 @@ pub async fn execute_test(name: String) -> CliResult<()> {
 
 pub async fn execute_refresh(name: Option<String>) -> CliResult<()> {
     if let Some(repo_name) = name {
-        println!(
+        crate::outln!(
             "{}",
             messages::ok(&format!("Refreshed cache for repository: {}", repo_name))
         );
     } else {
-        println!("{}", messages::ok("Refreshed cache for all repositories"));
+        crate::outln!("{}", messages::ok("Refreshed cache for all repositories"));
     }
     Ok(())
 }
@@ -223,7 +227,7 @@ pub async fn execute_add(
         .save()
         .map_err(|e| CliError::Config(format!("Failed to save repositories: {}", e)))?;
 
-    println!("{}", messages::ok(&format!("Added repository: {}", name)));
+    crate::outln!("{}", messages::ok(&format!("Added repository: {}", name)));
     Ok(())
 }
 
@@ -237,7 +241,7 @@ pub async fn execute_remove(name: String) -> CliResult<()> {
         .save()
         .map_err(|e| CliError::Config(format!("Failed to save repositories: {}", e)))?;
 
-    println!("{}", messages::ok(&format!("Removed repository: {}", name)));
+    crate::outln!("{}", messages::ok(&format!("Removed repository: {}", name)));
     Ok(())
 }
 

--- a/crates/fastskill-cli/src/commands/registry/skill_ops.rs
+++ b/crates/fastskill-cli/src/commands/registry/skill_ops.rs
@@ -71,7 +71,7 @@ pub async fn execute_list_skills(
     };
 
     if matches!(resolved_format, OutputFormat::Table | OutputFormat::Grid) {
-        println!(
+        crate::outln!(
             "{}",
             messages::info(&format!("Listing skills from repository: {}", repo_name))
         );
@@ -94,13 +94,13 @@ pub async fn execute_list_skills(
     if summaries.is_empty() {
         match resolved_format {
             OutputFormat::Json => {
-                println!("[]");
+                crate::outln!("[]");
             }
             OutputFormat::Xml => {
                 super::formatters::format_xml_output(&summaries)?;
             }
             OutputFormat::Table | OutputFormat::Grid => {
-                println!("{}", messages::warning("No skills found in repository"));
+                crate::outln!("{}", messages::warning("No skills found in repository"));
             }
         }
         return Ok(());
@@ -110,7 +110,7 @@ pub async fn execute_list_skills(
         OutputFormat::Json => {
             let json_output = serde_json::to_string_pretty(&summaries)
                 .map_err(|e| CliError::Config(format!("Failed to serialize JSON: {}", e)))?;
-            println!("{}", json_output);
+            crate::outln!("{}", json_output);
         }
         OutputFormat::Table => {
             super::formatters::format_table_output(&summaries, all_versions)?;
@@ -129,7 +129,7 @@ pub async fn execute_show_skill(skill_id: String, repository: Option<String>) ->
 
     let repo_name = super::helpers::resolve_repository_name(&repo_manager, repository)?;
 
-    println!(
+    crate::outln!(
         "{}",
         messages::info(&format!("Fetching skill: {} from {}", skill_id, repo_name))
     );
@@ -141,17 +141,17 @@ pub async fn execute_show_skill(skill_id: String, repository: Option<String>) ->
 
     match client.get_skill(&skill_id, None).await {
         Ok(Some(skill)) => {
-            println!("\nSkill: {}", skill.name);
-            println!("Version: {}", skill.version);
+            crate::outln!("\nSkill: {}", skill.name);
+            crate::outln!("Version: {}", skill.version);
             if !skill.description.is_empty() {
-                println!("Description: {}", skill.description);
+                crate::outln!("Description: {}", skill.description);
             }
             if let Some(author) = &skill.author {
-                println!("Author: {}", author);
+                crate::outln!("Author: {}", author);
             }
         }
         Ok(None) => {
-            println!(
+            crate::outln!(
                 "{}",
                 messages::warning(&format!("Skill '{}' not found in repository", skill_id))
             );
@@ -169,7 +169,7 @@ pub async fn execute_versions(skill_id: String, repository: Option<String>) -> C
 
     let repo_name = super::helpers::resolve_repository_name(&repo_manager, repository)?;
 
-    println!(
+    crate::outln!(
         "{}",
         messages::info(&format!(
             "Fetching versions for: {} from {}",
@@ -185,16 +185,16 @@ pub async fn execute_versions(skill_id: String, repository: Option<String>) -> C
     match client.get_versions(&skill_id).await {
         Ok(versions) => {
             if versions.is_empty() {
-                println!(
+                crate::outln!(
                     "{}",
                     messages::warning(&format!("No versions found for skill: {}", skill_id))
                 );
                 return Ok(());
             }
 
-            println!("\nAvailable versions:");
+            crate::outln!("\nAvailable versions:");
             for version in versions {
-                println!("  - {}", version);
+                crate::outln!("  - {}", version);
             }
             Ok(())
         }

--- a/crates/fastskill-cli/src/commands/reindex.rs
+++ b/crates/fastskill-cli/src/commands/reindex.rs
@@ -229,10 +229,10 @@ pub async fn execute_reindex(service: &FastSkillService, args: ReindexArgs) -> C
         seen_any_cb.store(true, Ordering::SeqCst);
         found_total_cb.store(p.total, Ordering::SeqCst);
         if !no_progress && !printed_found_cb.swap(true, Ordering::SeqCst) {
-            println!("Found {} skills to process", p.total);
+            crate::outln!("Found {} skills to process", p.total);
         }
         if verbose {
-            println!("  Processing: {} ({}/{})", p.skill_id, p.current, p.total);
+            crate::outln!("  Processing: {} ({}/{})", p.skill_id, p.current, p.total);
         } else if live {
             let pct = p
                 .current
@@ -250,7 +250,7 @@ pub async fn execute_reindex(service: &FastSkillService, args: ReindexArgs) -> C
         .map_err(CliError::Service)?;
 
     if live && seen_any.load(Ordering::SeqCst) {
-        println!();
+        crate::outln!();
     }
 
     if !outcome.reindexed {
@@ -258,7 +258,7 @@ pub async fn execute_reindex(service: &FastSkillService, args: ReindexArgs) -> C
             .reason
             .as_deref()
             .unwrap_or("no embedding provider configured");
-        println!("Reindex skipped: {reason}. Run 'fastskill doctor' for setup guidance.");
+        crate::outln!("Reindex skipped: {reason}. Run 'fastskill doctor' for setup guidance.");
         return Ok(());
     }
 
@@ -269,17 +269,17 @@ pub async fn execute_reindex(service: &FastSkillService, args: ReindexArgs) -> C
                 .skills_dir
                 .clone()
                 .unwrap_or_else(|| service.config().skill_storage_path.clone());
-            println!("Found 0 skills to process");
-            println!("No skills found in {}", dir.display());
+            crate::outln!("Found 0 skills to process");
+            crate::outln!("No skills found in {}", dir.display());
         }
         return Ok(());
     }
 
     if mode != ProgressMode::Quiet {
-        println!("Reindex completed");
-        println!("  Total skills: {}", found_total.load(Ordering::SeqCst));
-        println!("  Indexed/updated: {}", outcome.count);
-        println!("  Total time: {:.2}s", start_time.elapsed().as_secs_f64());
+        crate::outln!("Reindex completed");
+        crate::outln!("  Total skills: {}", found_total.load(Ordering::SeqCst));
+        crate::outln!("  Indexed/updated: {}", outcome.count);
+        crate::outln!("  Total time: {:.2}s", start_time.elapsed().as_secs_f64());
     }
 
     Ok(())

--- a/crates/fastskill-cli/src/commands/remove.rs
+++ b/crates/fastskill-cli/src/commands/remove.rs
@@ -193,9 +193,9 @@ fn confirm_removal(skill_ids: &[String], force: bool) -> CliResult<bool> {
         return Ok(true);
     }
 
-    println!("Warning: This will permanently remove the following skills:");
+    crate::outln!("Warning: This will permanently remove the following skills:");
     for skill_id in skill_ids {
-        println!("  - {}", skill_id);
+        crate::outln!("  - {}", skill_id);
     }
     print!("Are you sure you want to continue? (y/n): ");
     io::stdout()
@@ -360,7 +360,7 @@ pub async fn execute_remove(
 
     // Get user confirmation
     if !confirm_removal(&args.skill_ids, args.force)? {
-        println!("Removal cancelled.");
+        crate::outln!("Removal cancelled.");
         return Ok(());
     }
 
@@ -368,19 +368,19 @@ pub async fn execute_remove(
     let mut removed_count = 0;
     for (skill_id, raw_id) in parsed_ids.into_iter().zip(args.skill_ids.iter()) {
         remove_single_skill(service, skill_id, raw_id, global).await?;
-        println!("Removed skill: {}", raw_id);
+        crate::outln!("Removed skill: {}", raw_id);
         removed_count += 1;
     }
 
     // Display success message
     if removed_count > 0 {
         if global {
-            println!(
+            crate::outln!(
                 "{}",
                 crate::utils::messages::ok("Updated global-skills.lock")
             );
         } else {
-            println!(
+            crate::outln!(
                 "{}",
                 crate::utils::messages::ok("Updated skill-project.toml and skills.lock")
             );

--- a/crates/fastskill-cli/src/commands/search.rs
+++ b/crates/fastskill-cli/src/commands/search.rs
@@ -296,14 +296,14 @@ pub async fn execute_search(service: &FastSkillService, args: SearchArgs) -> Cli
 
     // Format and output results
     if results.is_empty() {
-        println!("No skills found matching '{}'", args.query);
+        crate::outln!("No skills found matching '{}'", args.query);
         return Ok(());
     }
 
     let formatted_output = output::format_search_results(&results, format, &args.query)
         .map_err(CliError::Validation)?;
 
-    println!("{}", formatted_output);
+    crate::outln!("{}", formatted_output);
     Ok(())
 }
 
@@ -328,7 +328,7 @@ async fn execute_search_with_paths(service: &FastSkillService, args: &SearchArgs
     let json_output = serde_json::to_string_pretty(&response)
         .map_err(|e| CliError::Validation(format!("Failed to serialize results to JSON: {}", e)))?;
 
-    println!("{}", json_output);
+    crate::outln!("{}", json_output);
     Ok(())
 }
 

--- a/crates/fastskill-cli/src/commands/serve.rs
+++ b/crates/fastskill-cli/src/commands/serve.rs
@@ -114,11 +114,11 @@ pub async fn execute_serve(
         }
     );
 
-    println!("FastSkill HTTP server starting...");
+    crate::outln!("FastSkill HTTP server starting...");
     if args.enable_write {
-        println!("  Write endpoints: ENABLED (--enable-write)");
+        crate::outln!("  Write endpoints: ENABLED (--enable-write)");
     } else {
-        println!("  Write endpoints: disabled (read-only); pass --enable-write to enable");
+        crate::outln!("  Write endpoints: disabled (read-only); pass --enable-write to enable");
     }
 
     // Build the served service directly (rather than reusing the CLI's cached

--- a/crates/fastskill-cli/src/commands/skillopt/inspect.rs
+++ b/crates/fastskill-cli/src/commands/skillopt/inspect.rs
@@ -120,13 +120,13 @@ pub async fn execute_inspect(args: InspectArgs) -> CliResult<()> {
         ShowMode::Gate => show_gate(&step_dir)?,
         ShowMode::Skips => show_skips(&step_dir)?,
         ShowMode::All => {
-            println!("=== patches ===");
+            crate::outln!("=== patches ===");
             show_patches(&step_dir)?;
-            println!("\n=== diffs ===");
+            crate::outln!("\n=== diffs ===");
             show_diffs(&step_dir)?;
-            println!("\n=== gate ===");
+            crate::outln!("\n=== gate ===");
             show_gate(&step_dir)?;
-            println!("\n=== skips ===");
+            crate::outln!("\n=== skips ===");
             show_skips(&step_dir)?;
         }
     }
@@ -136,12 +136,12 @@ pub async fn execute_inspect(args: InspectArgs) -> CliResult<()> {
 
 fn pretty_print_json(path: &std::path::Path, label: &str) -> CliResult<()> {
     if !path.exists() {
-        println!("(no {} artifact)", label);
+        crate::outln!("(no {} artifact)", label);
         return Ok(());
     }
     let bytes = std::fs::read(path).map_err(CliError::Io)?;
     let val: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
-    println!("{}", serde_json::to_string_pretty(&val).unwrap_or_default());
+    crate::outln!("{}", serde_json::to_string_pretty(&val).unwrap_or_default());
     Ok(())
 }
 
@@ -173,8 +173,8 @@ fn show_diffs(step_dir: &std::path::Path) -> CliResult<()> {
         String::new()
     };
 
-    println!("--- skill_before.md");
-    println!("+++ skill_after.md");
+    crate::outln!("--- skill_before.md");
+    crate::outln!("+++ skill_after.md");
     render_unified_diff(&before, &after);
 
     Ok(())
@@ -191,7 +191,7 @@ fn render_unified_diff(before: &str, after: &str) {
         return;
     }
 
-    println!(
+    crate::outln!(
         "@@ -{},{} +{},{} @@",
         1,
         before_lines.len(),
@@ -200,9 +200,9 @@ fn render_unified_diff(before: &str, after: &str) {
     );
 
     for line in &before_lines {
-        println!("-{}", line);
+        crate::outln!("-{}", line);
     }
     for line in &after_lines {
-        println!("+{}", line);
+        crate::outln!("+{}", line);
     }
 }

--- a/crates/fastskill-cli/src/commands/skillopt/resume.rs
+++ b/crates/fastskill-cli/src/commands/skillopt/resume.rs
@@ -130,6 +130,6 @@ pub async fn execute_resume(args: ResumeArgs) -> CliResult<()> {
     .await
     .map_err(|e| CliError::Config(format!("OPTIMIZE_TRAINING_FAILED: {e}")))?;
 
-    println!("{}", outcome.best_artifact_path.display());
+    crate::outln!("{}", outcome.best_artifact_path.display());
     Ok(())
 }

--- a/crates/fastskill-cli/src/commands/skillopt/run.rs
+++ b/crates/fastskill-cli/src/commands/skillopt/run.rs
@@ -194,6 +194,6 @@ pub async fn execute_run(args: RunArgs) -> CliResult<()> {
         .await
         .map_err(|e| CliError::Config(format!("OPTIMIZE_TRAINING_FAILED: {e}")))?;
 
-    println!("{}", outcome.best_artifact_path.display());
+    crate::outln!("{}", outcome.best_artifact_path.display());
     Ok(())
 }

--- a/crates/fastskill-cli/src/commands/skillopt/status.rs
+++ b/crates/fastskill-cli/src/commands/skillopt/status.rs
@@ -118,19 +118,24 @@ fn render_status(run_dir: &Path) -> CliResult<()> {
     let history_bytes = std::fs::read(&history_path).map_err(CliError::Io)?;
     let history: Vec<StepRecordView> = serde_json::from_slice(&history_bytes).unwrap_or_default();
 
-    println!(
+    crate::outln!(
         "Run: {}  |  epoch: {}  global_step: {}  best_score: {:.4}",
         run_dir.display(),
         state.epoch,
         state.global_step,
         state.best_score
     );
-    println!();
-    println!(
+    crate::outln!();
+    crate::outln!(
         "{:<6}  {:<10}  {:<10}  {:<10}  {:<8}  {:<10}",
-        "step", "gate", "score(S)", "score(S')", "delta", "tokens"
+        "step",
+        "gate",
+        "score(S)",
+        "score(S')",
+        "delta",
+        "tokens"
     );
-    println!("{}", "-".repeat(62));
+    crate::outln!("{}", "-".repeat(62));
 
     for record in &history {
         let gate_label = if record.accepted {
@@ -143,7 +148,7 @@ fn render_status(run_dir: &Path) -> CliResult<()> {
             .input_tokens
             .unwrap_or(0)
             .saturating_add(record.output_tokens.unwrap_or(0));
-        println!(
+        crate::outln!(
             "{:<6}  {:<10}  {:<10.4}  {:<10.4}  {:<+8.4}  {:<10}",
             record.global_step,
             gate_label,

--- a/crates/fastskill-cli/src/commands/update.rs
+++ b/crates/fastskill-cli/src/commands/update.rs
@@ -210,14 +210,14 @@ pub async fn execute_update(args: UpdateArgs, global: bool) -> CliResult<()> {
 }
 
 async fn execute_update_global(args: UpdateArgs) -> CliResult<()> {
-    println!("Updating global skills...");
-    println!();
+    crate::outln!("Updating global skills...");
+    crate::outln!();
 
     let lock_path = global_lock_path()
         .map_err(|e| CliError::Config(format!("Failed to resolve global lock path: {}", e)))?;
 
     if !lock_path.exists() {
-        println!(
+        crate::outln!(
             "{}",
             messages::info(
                 "No global-skills.lock found. Run 'fastskill add --global <skill>' first."
@@ -236,15 +236,15 @@ async fn execute_update_global(args: UpdateArgs) -> CliResult<()> {
     };
 
     if skill_ids.is_empty() {
-        println!("{}", messages::info("No global skills to update"));
+        crate::outln!("{}", messages::info("No global skills to update"));
         return Ok(());
     }
 
     if args.check || args.dry_run {
-        println!("\nGlobal skills (check mode):\n");
+        crate::outln!("\nGlobal skills (check mode):\n");
         for id in &skill_ids {
             if let Some(entry) = lock.skills.iter().find(|s| s.id == *id) {
-                println!("  • {} @ {}", entry.id, entry.resolved.version);
+                crate::outln!("  • {} @ {}", entry.id, entry.resolved.version);
             }
         }
         if args.check {
@@ -254,7 +254,7 @@ async fn execute_update_global(args: UpdateArgs) -> CliResult<()> {
             }
             lock.save_to_file(&lock_path)
                 .map_err(|e| CliError::Config(format!("Failed to save global lock: {}", e)))?;
-            println!(
+            crate::outln!(
                 "\n{}",
                 messages::info("Updated last_checked_at in global-skills.lock")
             );
@@ -269,19 +269,19 @@ async fn execute_update_global(args: UpdateArgs) -> CliResult<()> {
         if lock.skills.iter().any(|s| s.id == *id) {
             lock.mark_updated(id, now);
             updated_count += 1;
-            println!("  {}", messages::ok(&format!("Marked {} as updated", id)));
+            crate::outln!("  {}", messages::ok(&format!("Marked {} as updated", id)));
         }
     }
 
     lock.save_to_file(&lock_path)
         .map_err(|e| CliError::Config(format!("Failed to save global lock: {}", e)))?;
 
-    println!();
-    println!(
+    crate::outln!();
+    crate::outln!(
         "{}",
         messages::ok(&format!("Updated {} global skill(s)", updated_count))
     );
-    println!("   Updated global-skills.lock");
+    crate::outln!("   Updated global-skills.lock");
 
     Ok(())
 }
@@ -302,8 +302,8 @@ async fn execute_update_global(args: UpdateArgs) -> CliResult<()> {
 /// `--check`/`--dry-run` is likewise replaced by `preflight`'s coarser
 /// Updatable/UpToDate/Immutable classification.
 async fn execute_update_project(args: UpdateArgs) -> CliResult<()> {
-    println!("Updating skills...");
-    println!();
+    crate::outln!("Updating skills...");
+    crate::outln!();
 
     // T034: Resolve skill-project.toml from project root
     let current_dir = env::current_dir()
@@ -338,7 +338,7 @@ async fn execute_update_project(args: UpdateArgs) -> CliResult<()> {
     entries.sort_by(|a, b| a.id.as_str().cmp(b.id.as_str()));
 
     if entries.is_empty() {
-        println!("{}", messages::info("No skills to update"));
+        crate::outln!("{}", messages::info("No skills to update"));
         return Ok(());
     }
 
@@ -379,30 +379,30 @@ async fn execute_update_project(args: UpdateArgs) -> CliResult<()> {
     let service = crate::config::inject_edge_services(service)?;
 
     if args.check || args.dry_run {
-        println!("\nSkills that would be updated:\n");
+        crate::outln!("\nSkills that would be updated:\n");
         let mut any_reported = false;
         for entry in &entries {
             any_reported = true;
             match service.preflight(&entry.origin).await {
                 Ok(UpdatePreflight::Updatable) => {
-                    println!("  • {} (from {:?})", entry.id, entry.origin);
+                    crate::outln!("  • {} (from {:?})", entry.id, entry.origin);
                 }
                 Ok(UpdatePreflight::UpToDate) => {
-                    println!("  • {} is already up to date", entry.id);
+                    crate::outln!("  • {} is already up to date", entry.id);
                 }
                 Ok(UpdatePreflight::Immutable { reason }) => {
-                    println!("  • {} is immutable: {}", entry.id, reason);
+                    crate::outln!("  • {} is immutable: {}", entry.id, reason);
                 }
                 Err(e) => {
-                    println!("  • {}: {}", entry.id, e);
+                    crate::outln!("  • {}: {}", entry.id, e);
                 }
             }
         }
         if !any_reported {
-            println!("{}", messages::info("No updates available"));
+            crate::outln!("{}", messages::info("No updates available"));
         }
         if args.check {
-            println!(
+            crate::outln!(
                 "\n{}",
                 messages::info("Run without --check to actually update")
             );
@@ -414,7 +414,7 @@ async fn execute_update_project(args: UpdateArgs) -> CliResult<()> {
     // UpToDate/Immutable), then re-fetch only what's Updatable.
     let mut updated_count = 0;
     for entry in entries {
-        println!("  Updating {}...", entry.id);
+        crate::outln!("  Updating {}...", entry.id);
         match service.preflight(&entry.origin).await {
             Ok(UpdatePreflight::Updatable) => {
                 // Pass the existing groups so update preserves group membership.
@@ -424,7 +424,7 @@ async fn execute_update_project(args: UpdateArgs) -> CliResult<()> {
                 {
                     Ok(_outcome) => {
                         updated_count += 1;
-                        println!("  {}", messages::ok(&format!("Updated {}", entry.id)));
+                        crate::outln!("  {}", messages::ok(&format!("Updated {}", entry.id)));
                     }
                     Err(e) => {
                         eprintln!(
@@ -435,13 +435,13 @@ async fn execute_update_project(args: UpdateArgs) -> CliResult<()> {
                 }
             }
             Ok(UpdatePreflight::UpToDate) => {
-                println!(
+                crate::outln!(
                     "  {}",
                     messages::info(&format!("{} is already up to date", entry.id))
                 );
             }
             Ok(UpdatePreflight::Immutable { reason }) => {
-                println!(
+                crate::outln!(
                     "  {}",
                     messages::info(&format!("{} is immutable: {}", entry.id, reason))
                 );
@@ -455,12 +455,12 @@ async fn execute_update_project(args: UpdateArgs) -> CliResult<()> {
         }
     }
 
-    println!();
-    println!(
+    crate::outln!();
+    crate::outln!(
         "{}",
         messages::ok(&format!("Updated {} skill(s)", updated_count))
     );
-    println!("   Updated skills.lock");
+    crate::outln!("   Updated skills.lock");
 
     Ok(())
 }

--- a/crates/fastskill-cli/src/main.rs
+++ b/crates/fastskill-cli/src/main.rs
@@ -16,6 +16,8 @@ mod config;
 mod config_file;
 mod context;
 mod error;
+mod output;
+mod registration;
 pub mod runtime_selector;
 mod shorthand;
 mod utils;
@@ -51,6 +53,18 @@ fn skill_is_installed(name: &str) -> bool {
             .map(|dir| dir.join(name).is_dir())
             .unwrap_or(false)
     })
+}
+
+/// Whether this invocation is `fastskill mcp serve`, ignoring any flags that
+/// appear between or around the two path segments.
+fn is_mcp_serve(args: &[String]) -> bool {
+    let positionals: Vec<&str> = args
+        .iter()
+        .skip(1)
+        .filter(|a| !a.starts_with('-'))
+        .map(String::as_str)
+        .collect();
+    matches!(positionals.first(), Some(&"mcp")) && positionals.contains(&"serve")
 }
 
 fn ctx_global(ctx: &dyn AppContext) -> bool {
@@ -89,6 +103,14 @@ async fn main() {
     let verbose = raw.iter().any(|a| a == "--verbose" || a == "-v");
     fastskill_core::init_logging_with_verbose(verbose);
 
+    // Under `mcp serve` the process speaks JSON-RPC on stdout, so command output
+    // is buffered and returned as the tool result instead of being printed.
+    output::init(if is_mcp_serve(&raw) {
+        output::Mode::Capture
+    } else {
+        output::Mode::Direct
+    });
+
     let state = Arc::new(FsState::new());
     let ctx = FsCtx;
 
@@ -101,6 +123,10 @@ async fn main() {
         builder
             .with_version("fastskill", fastskill_core::VERSION)
             .with_git_sha_short(None)
+            // Honour `expose_mcp`. The framework default (`AllCommands`)
+            // ignores it, which exported `serve` as a tool -- an MCP call that
+            // starts a server and never returns.
+            .with_mcp_export_policy(cli_framework::mcp::McpToolExportPolicy::ExposeMcpOnly)
             .build(ctx),
         "Error initialising app",
     );
@@ -181,6 +207,7 @@ async fn main() {
 }
 
 fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuilder> {
+    use crate::registration::AppBuilderExt;
     use cli_framework::path;
     use cli_framework::spec::arg_spec::{ArgKind, ArgSpec, ArgValueType, Cardinality};
 
@@ -217,10 +244,10 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
 
     // ── Typed commands (no service) ──────────────────────────────────────────
     let builder = builder
-        .register(path!["init"], |_ctx, args: init::InitArgs| async move {
+        .register_out(path!["init"], |_ctx, args: init::InitArgs| async move {
             init::execute_init(args).await.map_err(anyhow::Error::from)
         })?
-        .register(
+        .register_out(
             path!["install"],
             |_ctx, args: install::InstallArgs| async move {
                 install::execute_install(args)
@@ -228,7 +255,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                     .map_err(anyhow::Error::from)
             },
         )?
-        .register(path!["update"], |ctx, args: update::UpdateArgs| {
+        .register_out(path!["update"], |ctx, args: update::UpdateArgs| {
             let global = ctx_global(ctx);
             async move {
                 update::execute_update(args, global)
@@ -242,7 +269,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
         let state_list = Arc::clone(&state);
         let state_read = Arc::clone(&state);
         builder
-            .register(path!["list"], move |ctx, args: list::ListArgs| {
+            .register_out(path!["list"], move |ctx, args: list::ListArgs| {
                 let global = ctx_global(ctx);
                 let skills_dir = ctx_skills_dir(ctx);
                 let state = Arc::clone(&state_list);
@@ -253,7 +280,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 }
             })?
-            .register(path!["read"], move |ctx, args: read::ReadArgs| {
+            .register_out(path!["read"], move |ctx, args: read::ReadArgs| {
                 let global = ctx_global(ctx);
                 let skills_dir = ctx_skills_dir(ctx);
                 let state = Arc::clone(&state_read);
@@ -277,7 +304,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                     hidden: false,
                 },
             )?
-            .register(
+            .register_out(
                 path!["repos", "list"],
                 |_ctx, args: repos::ReposListArgs| async move {
                     repos::execute_repos_list(args)
@@ -285,7 +312,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["repos", "add"],
                 |_ctx, args: repos::ReposAddArgs| async move {
                     repos::execute_repos_add(args)
@@ -293,7 +320,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["repos", "remove"],
                 |_ctx, args: repos::ReposRemoveArgs| async move {
                     repos::execute_repos_remove(args)
@@ -301,7 +328,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["repos", "info"],
                 |_ctx, args: repos::ReposInfoArgs| async move {
                     repos::execute_repos_info(args)
@@ -309,7 +336,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["repos", "update"],
                 |_ctx, args: repos::ReposUpdateArgs| async move {
                     repos::execute_repos_update(args)
@@ -317,7 +344,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["repos", "test"],
                 |_ctx, args: repos::ReposTestArgs| async move {
                     repos::execute_repos_test(args)
@@ -325,7 +352,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["repos", "refresh"],
                 |_ctx, args: repos::ReposRefreshArgs| async move {
                     repos::execute_repos_refresh(args)
@@ -333,7 +360,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["repos", "skills"],
                 |_ctx, args: repos::ReposSkillsArgs| async move {
                     repos::execute_repos_skills(args)
@@ -341,7 +368,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["repos", "show"],
                 |_ctx, args: repos::ReposShowArgs| async move {
                     repos::execute_repos_show(args)
@@ -349,7 +376,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["repos", "versions"],
                 |_ctx, args: repos::ReposVersionsArgs| async move {
                     repos::execute_repos_versions(args)
@@ -370,7 +397,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                     hidden: false,
                 },
             )?
-            .register(
+            .register_out(
                 path!["marketplace", "create"],
                 |_ctx, args: marketplace::MarketplaceCreateArgs| async move {
                     marketplace::execute_marketplace_create(args)
@@ -391,7 +418,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                     hidden: false,
                 },
             )?
-            .register(
+            .register_out(
                 path!["eval", "validate"],
                 |_ctx, args: eval::validate::ValidateArgs| async move {
                     eval::validate::execute_validate(args)
@@ -399,7 +426,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["eval", "run"],
                 |_ctx, args: eval::run::RunArgs| async move {
                     eval::run::execute_run(args)
@@ -407,7 +434,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["eval", "report"],
                 |_ctx, args: eval::report::ReportArgs| async move {
                     eval::report::execute_report(args)
@@ -415,7 +442,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["eval", "score"],
                 |_ctx, args: eval::score::ScoreArgs| async move {
                     eval::score::execute_score(args)
@@ -436,7 +463,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                     hidden: false,
                 },
             )?
-            .register(
+            .register_out(
                 path!["optimize", "run"],
                 |_ctx, args: skillopt::run::RunArgs| async move {
                     skillopt::run::execute_run(args)
@@ -444,7 +471,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["optimize", "resume"],
                 |_ctx, args: skillopt::resume::ResumeArgs| async move {
                     skillopt::resume::execute_resume(args)
@@ -452,7 +479,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["optimize", "status"],
                 |_ctx, args: skillopt::status::StatusArgs| async move {
                     skillopt::status::execute_status(args)
@@ -460,7 +487,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["optimize", "inspect"],
                 |_ctx, args: skillopt::inspect::InspectArgs| async move {
                     skillopt::inspect::execute_inspect(args)
@@ -468,7 +495,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 },
             )?
-            .register(
+            .register_out(
                 path!["optimize", "export"],
                 |_ctx, args: skillopt::export::ExportArgs| async move {
                     skillopt::export::execute_export(args)
@@ -481,7 +508,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
     // ── add: fully migrated to typed API ─────────────────────────────────────
     let builder = {
         let state_add = Arc::clone(&state);
-        builder.register(path!["add"], move |ctx, args: add::AddArgs| {
+        builder.register_out(path!["add"], move |ctx, args: add::AddArgs| {
             let global = ctx_global(ctx);
             let skills_dir = ctx_skills_dir(ctx);
             let state = Arc::clone(&state_add);
@@ -506,7 +533,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                     hidden: false,
                 },
             )?
-            .register(path!["analyze", "matrix"], {
+            .register_out(path!["analyze", "matrix"], {
                 let state = Arc::clone(&state_analyze);
                 move |ctx, args: analyze::matrix::MatrixArgs| {
                     let global = ctx_global(ctx);
@@ -523,7 +550,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                     }
                 }
             })?
-            .register(path!["analyze", "cluster"], {
+            .register_out(path!["analyze", "cluster"], {
                 let state = Arc::clone(&state_analyze);
                 move |ctx, args: analyze::cluster::ClusterArgs| {
                     let global = ctx_global(ctx);
@@ -540,7 +567,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                     }
                 }
             })?
-            .register(path!["analyze", "duplicates"], {
+            .register_out(path!["analyze", "duplicates"], {
                 let state = Arc::clone(&state_analyze);
                 move |ctx, args: analyze::duplicates::DuplicatesArgs| {
                     let global = ctx_global(ctx);
@@ -566,7 +593,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
         let state_search = Arc::clone(&state);
         let state_doctor = Arc::clone(&state);
         builder
-            .register(path!["reindex"], move |ctx, args: reindex::ReindexArgs| {
+            .register_out(path!["reindex"], move |ctx, args: reindex::ReindexArgs| {
                 let global = ctx_global(ctx);
                 let skills_dir = ctx_skills_dir(ctx);
                 let state = Arc::clone(&state_reindex);
@@ -577,7 +604,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 }
             })?
-            .register(path!["remove"], move |ctx, args: remove::RemoveArgs| {
+            .register_out(path!["remove"], move |ctx, args: remove::RemoveArgs| {
                 let global = ctx_global(ctx);
                 let skills_dir = ctx_skills_dir(ctx);
                 let state = Arc::clone(&state_remove);
@@ -588,7 +615,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 }
             })?
-            .register(path!["search"], move |ctx, args: search::SearchArgs| {
+            .register_out(path!["search"], move |ctx, args: search::SearchArgs| {
                 let global = ctx_global(ctx);
                 let skills_dir = ctx_skills_dir(ctx);
                 let state = Arc::clone(&state_search);
@@ -599,7 +626,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 }
             })?
-            .register(path!["serve"], move |ctx, args: serve::ServeArgs| {
+            .register_out_no_mcp(path!["serve"], move |ctx, args: serve::ServeArgs| {
                 let global = ctx_global(ctx);
                 let skills_dir = ctx_skills_dir(ctx);
                 async move {
@@ -612,7 +639,7 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                         .map_err(anyhow::Error::from)
                 }
             })?
-            .register(path!["doctor"], move |ctx, args: doctor::DoctorArgs| {
+            .register_out(path!["doctor"], move |ctx, args: doctor::DoctorArgs| {
                 let global = ctx_global(ctx);
                 let skills_dir = ctx_skills_dir(ctx);
                 let state = Arc::clone(&state_doctor);

--- a/crates/fastskill-cli/src/main.rs
+++ b/crates/fastskill-cli/src/main.rs
@@ -17,6 +17,7 @@ mod config_file;
 mod context;
 mod error;
 pub mod runtime_selector;
+mod shorthand;
 mod utils;
 
 use cli_framework::app::context::AppContext;
@@ -33,6 +34,23 @@ fn or_exit<T, E: std::fmt::Display>(result: Result<T, E>, msg: &str) -> T {
             std::process::exit(1);
         }
     }
+}
+
+/// Whether a skill directory with this name exists in either the project or the
+/// global skills directory.
+///
+/// Used only to arbitrate the read shorthand against a command typo, so it is a
+/// deliberately cheap filesystem probe: config resolution plus an `is_dir`
+/// check, no service initialisation. Any resolution failure (no manifest, no
+/// config dir) is treated as "not installed" -- in that situation there is no
+/// skill to read anyway, so surfacing the command suggestion is the better
+/// outcome.
+fn skill_is_installed(name: &str) -> bool {
+    [false, true].iter().any(|&global| {
+        config::resolve_skills_storage_directory(global)
+            .map(|dir| dir.join(name).is_dir())
+            .unwrap_or(false)
+    })
 }
 
 fn ctx_global(ctx: &dyn AppContext) -> bool {
@@ -126,10 +144,28 @@ async fn main() {
             }
             break;
         }
+        // Unknown token: route it to `read` unless it looks like a typo of a
+        // command that no installed skill claims. Reporting the typo here rather
+        // than letting it fall through to the framework is deliberate -- clap's
+        // built-in suggester answers "init" for "insatll", and acting on that
+        // would scaffold a project the user never asked for.
         if i < raw.len() && !known.contains(raw[i].as_str()) {
-            let mut rewritten = raw;
-            rewritten.insert(i, "read".to_string());
-            rewritten
+            match shorthand::route(&raw[i], &known, skill_is_installed) {
+                shorthand::Routing::DidYouMean(cmd) => {
+                    eprintln!("error: unrecognized subcommand '{}'", raw[i]);
+                    eprintln!("  hint: Did you mean '{}'?", cmd);
+                    eprintln!(
+                        "  hint: to read a skill by this name, run: fastskill read {}",
+                        raw[i]
+                    );
+                    std::process::exit(1);
+                }
+                shorthand::Routing::Read => {
+                    let mut rewritten = raw;
+                    rewritten.insert(i, "read".to_string());
+                    rewritten
+                }
+            }
         } else {
             raw
         }

--- a/crates/fastskill-cli/src/output.rs
+++ b/crates/fastskill-cli/src/output.rs
@@ -1,0 +1,199 @@
+//! Command output routing.
+//!
+//! Commands must not write to `stdout` directly. Under `fastskill mcp serve
+//! --transport stdio`, `stdout` *is* the JSON-RPC channel, so a stray
+//! `println!` corrupts the protocol stream and the tool result is whatever the
+//! framework saw instead -- in practice the literal string `"OK"`, with the real
+//! output interleaved between JSON-RPC frames:
+//!
+//! ```text
+//! {"jsonrpc":"2.0","id":1,"result":{...}}
+//! ID          Name        Description          <- raw table on stdout
+//! demo-skill  demo-skill  A demo skill...      <- corrupts the stream
+//! {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"OK"}]}}
+//! ```
+//!
+//! Every command therefore emits through [`emit`] (usually via the [`outln!`]
+//! macro), which routes according to the process-wide [`Mode`] chosen once at
+//! startup:
+//!
+//! - [`Mode::Direct`] -- ordinary CLI use. Writes straight to `stdout`, so
+//!   long-running commands keep streaming their progress as before.
+//! - [`Mode::Capture`] -- `mcp serve`. Writes into a task-local buffer that the
+//!   command wrapper drains into `ctx.framework_println`, which the framework
+//!   turns into the tool's `content`.
+//!
+//! # Why task-local rather than a plain global
+//!
+//! MCP tool calls are dispatched concurrently, each on its own task. A global
+//! buffer would interleave the output of simultaneous calls; a task-local keeps
+//! each call's output to itself and still crosses `.await` points within that
+//! task.
+//!
+//! A task spawned *inside* a command does not inherit the task-local. Such
+//! output falls back to `stderr` under [`Mode::Capture`] -- missing from the
+//! tool result rather than corrupting the protocol, which is the safe direction
+//! to fail. No command currently emits from a spawned task (the per-trial
+//! `JoinSet` in `eval run` returns its results for the parent to render), so
+//! there is deliberately no API for propagating the buffer into one; add it
+//! alongside the first caller that needs it.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+/// Where [`emit`] sends output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Write to `stdout` immediately (ordinary CLI use).
+    Direct,
+    /// Buffer into the task-local sink; fall back to `stderr` (`mcp serve`).
+    Capture,
+}
+
+static MODE: OnceLock<Mode> = OnceLock::new();
+
+/// A captured output buffer, shared with any explicitly-propagated child task.
+pub type Sink = Arc<Mutex<String>>;
+
+tokio::task_local! {
+    static SINK: Sink;
+}
+
+/// Fix the output mode for this process. The first call wins; later calls are
+/// ignored so a stray re-initialisation cannot redirect output mid-run.
+pub fn init(mode: Mode) {
+    let _ = MODE.set(mode);
+}
+
+/// The active mode, defaulting to [`Mode::Direct`] when [`init`] was never
+/// called (unit tests, and any path that never reaches `main`).
+pub fn mode() -> Mode {
+    MODE.get().copied().unwrap_or(Mode::Direct)
+}
+
+/// Emit one line of user-visible output.
+///
+/// Prefer the [`outln!`] macro, which mirrors `println!`'s formatting.
+pub fn emit(line: &str) {
+    match mode() {
+        Mode::Direct => println!("{}", line),
+        Mode::Capture => {
+            let captured = SINK.try_with(|s| {
+                if let Ok(mut buf) = s.lock() {
+                    buf.push_str(line);
+                    buf.push('\n');
+                }
+            });
+            // No task-local sink in scope: this came from a task spawned inside
+            // a command. Route to stderr rather than stdout so the JSON-RPC
+            // stream stays clean.
+            if captured.is_err() {
+                eprintln!("{}", line);
+            }
+        }
+    }
+}
+
+/// Run `fut` with `sink` installed as the task-local output buffer.
+async fn with_sink<F: std::future::Future>(sink: Sink, fut: F) -> F::Output {
+    SINK.scope(sink, fut).await
+}
+
+/// Run `fut` with a fresh buffer, returning its output alongside everything
+/// emitted during the call.
+pub async fn capture<F: std::future::Future>(fut: F) -> (F::Output, String) {
+    let sink: Sink = Arc::new(Mutex::new(String::new()));
+    let out = with_sink(Arc::clone(&sink), fut).await;
+    let text = sink.lock().map(|b| b.clone()).unwrap_or_default();
+    (out, text)
+}
+
+/// `println!` for command output, routed through [`emit`].
+#[macro_export]
+macro_rules! outln {
+    () => { $crate::output::emit("") };
+    ($($arg:tt)*) => { $crate::output::emit(&format!($($arg)*)) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mode_defaults_to_direct_when_uninitialised() {
+        // `MODE` is a process-wide `OnceLock`; this test only asserts the
+        // default read, it must not call `init`.
+        assert_eq!(Mode::Direct, mode());
+    }
+
+    #[tokio::test]
+    async fn capture_collects_emitted_lines() {
+        let (_, text) = capture(async {
+            emit_as_capture("first");
+            emit_as_capture("second");
+        })
+        .await;
+        assert_eq!(text, "first\nsecond\n");
+    }
+
+    #[tokio::test]
+    async fn capture_returns_the_future_output() {
+        let (value, text) = capture(async { 42 }).await;
+        assert_eq!(value, 42);
+        assert!(text.is_empty());
+    }
+
+    #[tokio::test]
+    async fn concurrent_captures_do_not_interleave() {
+        // The property that rules out a plain global buffer.
+        let a = capture(async {
+            emit_as_capture("a1");
+            tokio::task::yield_now().await;
+            emit_as_capture("a2");
+        });
+        let b = capture(async {
+            emit_as_capture("b1");
+            tokio::task::yield_now().await;
+            emit_as_capture("b2");
+        });
+        let ((_, ta), (_, tb)) = tokio::join!(a, b);
+        assert_eq!(ta, "a1\na2\n");
+        assert_eq!(tb, "b1\nb2\n");
+    }
+
+    #[tokio::test]
+    async fn output_from_a_spawned_task_never_reaches_the_sink() {
+        // Documents the known limitation: a spawned task does not inherit the
+        // task-local, so its output is absent from the tool result rather than
+        // being written to stdout, where it would corrupt JSON-RPC.
+        let (_, text) = capture(async {
+            emit_as_capture("parent");
+            tokio::spawn(async { assert!(SINK.try_with(|_| ()).is_err()) })
+                .await
+                .unwrap();
+        })
+        .await;
+        assert_eq!(text, "parent\n");
+    }
+
+    #[tokio::test]
+    async fn capture_survives_await_points() {
+        let (_, text) = capture(async {
+            emit_as_capture("before");
+            tokio::task::yield_now().await;
+            emit_as_capture("after");
+        })
+        .await;
+        assert_eq!(text, "before\nafter\n");
+    }
+
+    /// `emit` consults the process-wide mode, which unit tests must not pin.
+    /// This writes to the task-local sink directly so the capture behaviour can
+    /// be tested independently of `MODE`.
+    fn emit_as_capture(line: &str) {
+        SINK.with(|s| {
+            let mut buf = s.lock().unwrap();
+            buf.push_str(line);
+            buf.push('\n');
+        });
+    }
+}

--- a/crates/fastskill-cli/src/registration.rs
+++ b/crates/fastskill-cli/src/registration.rs
@@ -1,0 +1,114 @@
+//! Command registration that keeps output out of the JSON-RPC stream.
+//!
+//! `AppBuilder::register` requires the handler's future to be `'static`, so a
+//! handler can read the [`AppContext`] synchronously but cannot write back to it
+//! once it starts awaiting. That is precisely what routing output to
+//! `ctx.framework_println` needs, and it is why `fastskill mcp serve` returned
+//! the literal string `"OK"` for every tool while the real output went to the
+//! process's `stdout`.
+//!
+//! `Command::execute` itself is more permissive than the `register` helper: its
+//! future may borrow the context (`Send + 'a`). [`AppBuilderExt::register_out`]
+//! builds that `Command` directly, keeping the existing handler shape while
+//! wrapping the returned future so buffered output is drained into the context
+//! after it resolves.
+
+use cli_framework::app::context::AppContext;
+use cli_framework::command::{Command, TypedArgs};
+use cli_framework::prelude::AppBuilder;
+use cli_framework::spec::command_tree::CommandPath;
+use std::future::Future;
+use std::sync::Arc;
+
+use crate::output::{self, Mode};
+
+/// Registration helpers for commands whose output must survive MCP dispatch.
+pub trait AppBuilderExt: Sized {
+    /// Register a typed command, routing its [`crate::outln!`] output through
+    /// the context under [`Mode::Capture`].
+    ///
+    /// The handler keeps the same shape as `AppBuilder::register`: it may read
+    /// the context synchronously and returns a `'static` future.
+    fn register_out<T, F, Fut>(self, path: CommandPath, handler: F) -> anyhow::Result<Self>
+    where
+        T: TypedArgs,
+        F: Fn(&mut dyn AppContext, T) -> Fut + Send + Sync + Clone + 'static,
+        Fut: Future<Output = anyhow::Result<()>> + Send + 'static;
+
+    /// As [`register_out`](AppBuilderExt::register_out), but the command is not
+    /// exported as an MCP tool.
+    ///
+    /// For commands that never return (`serve`) or that are meaningless over a
+    /// request/response tool call.
+    fn register_out_no_mcp<T, F, Fut>(self, path: CommandPath, handler: F) -> anyhow::Result<Self>
+    where
+        T: TypedArgs,
+        F: Fn(&mut dyn AppContext, T) -> Fut + Send + Sync + Clone + 'static,
+        Fut: Future<Output = anyhow::Result<()>> + Send + 'static;
+}
+
+/// Build a `Command` whose execute future drains captured output into the
+/// context before returning.
+fn build_command<T, F, Fut>(path: &CommandPath, handler: F, expose_mcp: bool) -> Command
+where
+    T: TypedArgs,
+    F: Fn(&mut dyn AppContext, T) -> Fut + Send + Sync + Clone + 'static,
+    Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+{
+    let spec = Arc::new(T::command_spec());
+    let id: Arc<str> = Arc::from(path.leaf().unwrap_or(""));
+    let handler = Arc::new(handler);
+
+    Command {
+        id,
+        spec,
+        validator: None,
+        expose_mcp,
+        expose_chat: expose_mcp,
+        meta: None,
+        visibility: None,
+        execute: Arc::new(move |ctx, args| {
+            let typed = T::from_arg_value_map(&args);
+            // The handler reads `ctx` synchronously; the future it returns is
+            // `'static` and does not hold the borrow, which frees `ctx` for the
+            // drain below.
+            let fut = handler(ctx, typed);
+            Box::pin(async move {
+                match output::mode() {
+                    Mode::Direct => fut.await,
+                    Mode::Capture => {
+                        let (result, text) = output::capture(fut).await;
+                        // Drain even on failure: partial output is often the
+                        // most useful part of a failed tool call.
+                        for line in text.lines() {
+                            ctx.framework_println(line);
+                        }
+                        result
+                    }
+                }
+            })
+        }),
+    }
+}
+
+impl AppBuilderExt for AppBuilder {
+    fn register_out<T, F, Fut>(self, path: CommandPath, handler: F) -> anyhow::Result<Self>
+    where
+        T: TypedArgs,
+        F: Fn(&mut dyn AppContext, T) -> Fut + Send + Sync + Clone + 'static,
+        Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        let command = build_command::<T, F, Fut>(&path, handler, true);
+        self.register_command_at(&path, command)
+    }
+
+    fn register_out_no_mcp<T, F, Fut>(self, path: CommandPath, handler: F) -> anyhow::Result<Self>
+    where
+        T: TypedArgs,
+        F: Fn(&mut dyn AppContext, T) -> Fut + Send + Sync + Clone + 'static,
+        Fut: Future<Output = anyhow::Result<()>> + Send + 'static,
+    {
+        let command = build_command::<T, F, Fut>(&path, handler, false);
+        self.register_command_at(&path, command)
+    }
+}

--- a/crates/fastskill-cli/src/shorthand.rs
+++ b/crates/fastskill-cli/src/shorthand.rs
@@ -1,0 +1,303 @@
+//! Read-shorthand routing: deciding when `fastskill <token>` means
+//! `fastskill read <token>`.
+//!
+//! `fastskill <skill-id>` is a shorthand for `fastskill read <skill-id>`, which
+//! means any unrecognised first positional would otherwise be silently treated
+//! as a skill name. That turned every command typo into a misleading error --
+//! `fastskill insatll` reported `Skill 'insatll' not found` rather than
+//! suggesting `install`.
+//!
+//! The rule implemented here: route to `read` *unless* the token is a near miss
+//! of a known command and no installed skill actually claims that name. When we
+//! decline to route, the framework reports an unrecognised subcommand and adds
+//! its own `Did you mean ...?` hint.
+//!
+//! An existing skill always wins. `fastskill repo` reads a skill named `repo`
+//! even though the `repos` command is one edit away -- we only intercept names
+//! that resolve to nothing.
+
+use std::collections::HashSet;
+
+/// Maximum edit distance at which a token is treated as a typo of a command.
+///
+/// Deliberately 1, using Damerau-Levenshtein so that a single transposition
+/// counts as one edit. That covers the overwhelming majority of real typos
+/// (`insatll`, `serach`, `doctr`, `lst`) while keeping the blast radius small:
+/// only names exactly one edit from a command can ever be intercepted, and even
+/// then only when no such skill exists.
+const MAX_TYPO_DISTANCE: usize = 1;
+
+/// Damerau-Levenshtein distance (optimal string alignment), capped at `max`.
+///
+/// Returns `max + 1` for any pair further apart than `max`, which is all the
+/// caller needs and lets us bail out early. Unlike plain Levenshtein this counts
+/// a transposition of two adjacent characters as a single edit, so `insatll` is
+/// distance 1 from `install` rather than 2.
+fn distance_within(a: &str, b: &str, max: usize) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let over = max + 1;
+
+    // Length difference alone already exceeds the budget.
+    if a.len().abs_diff(b.len()) > max {
+        return over;
+    }
+
+    let mut prev_prev: Vec<usize> = vec![0; b.len() + 1];
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr: Vec<usize> = vec![0; b.len() + 1];
+
+    for i in 1..=a.len() {
+        curr[0] = i;
+        let mut row_best = curr[0];
+
+        for j in 1..=b.len() {
+            let cost = usize::from(a[i - 1] != b[j - 1]);
+            let mut best = (curr[j - 1] + 1) // insertion
+                .min(prev[j] + 1) // deletion
+                .min(prev[j - 1] + cost); // substitution
+
+            // Transposition of two adjacent characters.
+            if i > 1 && j > 1 && a[i - 1] == b[j - 2] && a[i - 2] == b[j - 1] {
+                best = best.min(prev_prev[j - 2] + 1);
+            }
+
+            curr[j] = best;
+            row_best = row_best.min(best);
+        }
+
+        // Every alignment through this row already costs more than the budget.
+        if row_best > max {
+            return over;
+        }
+
+        std::mem::swap(&mut prev_prev, &mut prev);
+        std::mem::swap(&mut prev, &mut curr);
+    }
+
+    prev[b.len()].min(over)
+}
+
+/// The known command closest to `token`, if any lies within the typo budget.
+///
+/// Ties are broken by shortest-then-alphabetical so the result is deterministic
+/// regardless of `HashSet` iteration order. An exact match is not a typo --
+/// those tokens never reach this code path because they dispatch as commands.
+fn nearest_command<'a>(token: &str, known: &HashSet<&'a str>) -> Option<&'a str> {
+    known
+        .iter()
+        .filter(|cmd| **cmd != token)
+        .filter_map(|cmd| {
+            let d = distance_within(token, cmd, MAX_TYPO_DISTANCE);
+            (d <= MAX_TYPO_DISTANCE).then_some((d, cmd.len(), *cmd))
+        })
+        .min()
+        .map(|(_, _, cmd)| cmd)
+}
+
+/// How a bare first positional should be handled.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Routing<'a> {
+    /// Rewrite to `read <token>`.
+    Read,
+    /// Report a command typo, suggesting this command.
+    DidYouMean(&'a str),
+}
+
+/// Decide how to handle a bare first positional that matched no command.
+///
+/// `skill_exists` is consulted only when the token looks like a typo, so the
+/// (cheap, but non-zero) filesystem probe stays off the hot path for ordinary
+/// skill reads.
+pub fn route<'a>(
+    token: &str,
+    known: &HashSet<&'a str>,
+    skill_exists: impl Fn(&str) -> bool,
+) -> Routing<'a> {
+    match nearest_command(token, known) {
+        // A real skill outranks a command typo.
+        Some(cmd) if !skill_exists(token) => Routing::DidYouMean(cmd),
+        _ => Routing::Read,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn known() -> HashSet<&'static str> {
+        [
+            "init",
+            "install",
+            "update",
+            "list",
+            "read",
+            "add",
+            "remove",
+            "search",
+            "reindex",
+            "serve",
+            "doctor",
+            "repos",
+            "marketplace",
+            "eval",
+            "optimize",
+            "analyze",
+            "spec",
+            "mcp",
+            "help",
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    fn no_skills(_: &str) -> bool {
+        false
+    }
+
+    fn routes_to_read(token: &str, known: &HashSet<&str>, exists: impl Fn(&str) -> bool) -> bool {
+        route(token, known, exists) == Routing::Read
+    }
+
+    // ── distance ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn identical_strings_are_distance_zero() {
+        assert_eq!(distance_within("install", "install", 1), 0);
+    }
+
+    #[test]
+    fn single_transposition_is_one_edit() {
+        // Plain Levenshtein would score these 2; Damerau scores 1.
+        assert_eq!(distance_within("insatll", "install", 1), 1);
+        assert_eq!(distance_within("serach", "search", 1), 1);
+    }
+
+    #[test]
+    fn single_deletion_insertion_substitution_are_one_edit() {
+        assert_eq!(distance_within("doctr", "doctor", 1), 1); // deletion
+        assert_eq!(distance_within("lst", "list", 1), 1); // deletion
+        assert_eq!(distance_within("installs", "install", 1), 1); // insertion
+        assert_eq!(distance_within("lost", "list", 1), 1); // substitution
+    }
+
+    #[test]
+    fn two_edits_exceed_the_cap() {
+        // `installer` is 2 edits from `install` and must not be treated as a typo.
+        assert!(distance_within("installer", "install", 1) > 1);
+        assert!(distance_within("xyz", "install", 1) > 1);
+    }
+
+    #[test]
+    fn length_gap_short_circuits() {
+        assert!(distance_within("a", "abcdefgh", 1) > 1);
+    }
+
+    #[test]
+    fn distance_is_symmetric() {
+        assert_eq!(
+            distance_within("insatll", "install", 2),
+            distance_within("install", "insatll", 2)
+        );
+    }
+
+    #[test]
+    fn empty_token_is_not_within_one_of_a_command() {
+        assert!(distance_within("", "install", 1) > 1);
+    }
+
+    // ── routing ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn command_typos_do_not_route_to_read() {
+        for typo in ["insatll", "serach", "doctr", "lst", "ini", "serv"] {
+            assert!(
+                !routes_to_read(typo, &known(), no_skills),
+                "{typo} should surface as an unrecognized subcommand"
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_skill_names_route_to_read() {
+        for name in [
+            "pdf-processor",
+            "installer",
+            "my-skill",
+            "data-viz",
+            "fastskill",
+        ] {
+            assert!(
+                routes_to_read(name, &known(), no_skills),
+                "{name} should be read as a skill id"
+            );
+        }
+    }
+
+    #[test]
+    fn an_installed_skill_outranks_a_command_typo() {
+        // `repo` is one edit from the `repos` command, but a skill named `repo`
+        // exists -- reading it must still win.
+        assert!(routes_to_read("repo", &known(), |t| t == "repo"));
+        assert!(routes_to_read("specs", &known(), |t| t == "specs"));
+        // ...and with no such skill installed, it is treated as a typo.
+        assert!(!routes_to_read("repo", &known(), no_skills));
+    }
+
+    #[test]
+    fn skill_existence_is_only_probed_for_typo_candidates() {
+        use std::cell::Cell;
+        let probed = Cell::new(false);
+        let probe = |_: &str| {
+            probed.set(true);
+            false
+        };
+        // Nowhere near a command name -> no probe.
+        assert!(routes_to_read("pdf-processor", &known(), &probe));
+        assert!(!probed.get());
+        // One edit away -> probe.
+        assert!(!routes_to_read("lst", &known(), &probe));
+        assert!(probed.get());
+    }
+
+    #[test]
+    fn exact_command_names_are_not_their_own_typos() {
+        // Defensive: these dispatch as commands before reaching this code, but
+        // the predicate must not classify them as typos of themselves.
+        let mut h = HashSet::new();
+        h.insert("install");
+        assert_eq!(nearest_command("install", &h), None);
+    }
+
+    // ── suggestion quality ──────────────────────────────────────────────────
+
+    #[test]
+    fn suggests_the_actually_nearest_command() {
+        // Regression guard: clap's own suggester answers `init` for `insatll`
+        // and `serve` for `serach`. Running the suggested `init` would scaffold
+        // a project the user never asked for, so we compute the suggestion
+        // ourselves and must keep beating it.
+        for (typo, expected) in [
+            ("insatll", "install"),
+            ("serach", "search"),
+            ("doctr", "doctor"),
+            ("lst", "list"),
+            ("updte", "update"),
+        ] {
+            assert_eq!(
+                route(typo, &known(), no_skills),
+                Routing::DidYouMean(expected),
+                "{typo} should suggest {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn suggestion_is_deterministic_across_iteration_orders() {
+        // `HashSet` iteration order varies per process; the tie-break must not.
+        let first = route("rea", &known(), no_skills);
+        for _ in 0..50 {
+            assert_eq!(route("rea", &known(), no_skills), first);
+        }
+    }
+}

--- a/crates/fastskill-cli/src/shorthand.rs
+++ b/crates/fastskill-cli/src/shorthand.rs
@@ -9,8 +9,8 @@
 //!
 //! The rule implemented here: route to `read` *unless* the token is a near miss
 //! of a known command and no installed skill actually claims that name. When we
-//! decline to route, the framework reports an unrecognised subcommand and adds
-//! its own `Did you mean ...?` hint.
+//! decline to route, the caller reports an unrecognised subcommand along with
+//! the nearest command computed by [`nearest_command`].
 //!
 //! An existing skill always wins. `fastskill repo` reads a skill named `repo`
 //! even though the `repos` command is one edit away -- we only intercept names
@@ -253,10 +253,10 @@ mod tests {
             false
         };
         // Nowhere near a command name -> no probe.
-        assert!(routes_to_read("pdf-processor", &known(), &probe));
+        assert!(routes_to_read("pdf-processor", &known(), probe));
         assert!(!probed.get());
         // One edit away -> probe.
-        assert!(!routes_to_read("lst", &known(), &probe));
+        assert!(!routes_to_read("lst", &known(), probe));
         assert!(probed.get());
     }
 

--- a/crates/fastskill-cli/src/utils/reindex_utils.rs
+++ b/crates/fastskill-cli/src/utils/reindex_utils.rs
@@ -18,7 +18,7 @@ pub async fn maybe_auto_reindex(
 
     if service.config().embedding.is_none() {
         if verbose {
-            println!(
+            crate::outln!(
                 "Note: skipping auto-reindex after '{}' (no embedding provider configured).",
                 command_name
             );

--- a/crates/fastskill-cli/tests/mcp_stdio_protocol_test.rs
+++ b/crates/fastskill-cli/tests/mcp_stdio_protocol_test.rs
@@ -1,0 +1,189 @@
+//! `fastskill mcp serve --transport stdio` must speak only JSON-RPC on stdout.
+//!
+//! Regression coverage for the bug where commands wrote to `stdout` with
+//! `println!`. Under stdio transport `stdout` *is* the JSON-RPC channel, so the
+//! real output was interleaved between protocol frames and the tool result was
+//! the literal string `"OK"`:
+//!
+//! ```text
+//! {"jsonrpc":"2.0","id":1,"result":{...}}
+//! ID          Name        Description        <- raw table, corrupts the stream
+//! {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"OK"}]}}
+//! ```
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Drive `mcp serve --transport stdio` with `requests` and return stdout.
+fn mcp_session(project: &std::path::Path, requests: &[&str]) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_fastskill"))
+        .args(["mcp", "serve", "--transport", "stdio"])
+        .current_dir(project)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn fastskill mcp serve");
+
+    {
+        let stdin = child.stdin.as_mut().expect("stdin");
+        for line in requests {
+            writeln!(stdin, "{}", line).expect("write request");
+        }
+    }
+
+    let out = child.wait_with_output().expect("wait for mcp server");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+const INIT: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}"#;
+const INITIALIZED: &str = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+
+/// A project with one installed skill, so `list` has something to print.
+fn fixture() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("skill-project.toml"),
+        "[metadata]\nname = \"mcp-protocol-test\"\nversion = \"0.1.0\"\n\
+         [tool.fastskill]\nskills_directory = \".claude/skills\"\n[dependencies]\n",
+    )
+    .expect("write manifest");
+
+    let skill = dir.path().join(".claude/skills/demo-skill");
+    std::fs::create_dir_all(&skill).expect("create skill dir");
+    std::fs::write(
+        skill.join("SKILL.md"),
+        "---\nname: demo-skill\ndescription: A demo skill for MCP protocol testing\n---\n# Demo\n",
+    )
+    .expect("write SKILL.md");
+    dir
+}
+
+fn response<'a>(stdout: &'a str, id: i64) -> serde_json::Value {
+    stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+        .find(|v: &serde_json::Value| v.get("id").and_then(serde_json::Value::as_i64) == Some(id))
+        .unwrap_or_else(|| panic!("no response with id {id} in:\n{stdout}"))
+}
+
+#[test]
+fn stdout_carries_only_json_rpc_frames() {
+    let project = fixture();
+    let stdout = mcp_session(
+        project.path(),
+        &[
+            INIT,
+            INITIALIZED,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"fastskill_list","arguments":{}}}"#,
+        ],
+    );
+
+    let leaked: Vec<&str> = stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter(|l| serde_json::from_str::<serde_json::Value>(l).is_err())
+        .collect();
+
+    assert!(
+        leaked.is_empty(),
+        "command output leaked onto the JSON-RPC stream: {leaked:#?}\nfull stdout:\n{stdout}"
+    );
+}
+
+#[test]
+fn tool_result_carries_the_command_output_not_ok() {
+    let project = fixture();
+    let stdout = mcp_session(
+        project.path(),
+        &[
+            INIT,
+            INITIALIZED,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"fastskill_list","arguments":{}}}"#,
+        ],
+    );
+
+    let text = response(&stdout, 2)["result"]["content"][0]["text"]
+        .as_str()
+        .expect("text content")
+        .to_string();
+
+    assert_ne!(
+        text.trim(),
+        "OK",
+        "tool returned the placeholder, not output"
+    );
+    assert!(
+        text.contains("demo-skill"),
+        "tool result should carry the rendered skill list, got:\n{text}"
+    );
+}
+
+#[test]
+fn long_running_serve_is_not_exported_as_a_tool() {
+    // `serve` starts an HTTP server and never returns; exporting it as a tool
+    // means any caller invoking it hangs until the transport times out.
+    let project = fixture();
+    let stdout = mcp_session(
+        project.path(),
+        &[
+            INIT,
+            INITIALIZED,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#,
+        ],
+    );
+
+    let tools = response(&stdout, 2)["result"]["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|t| t["name"].as_str().map(str::to_string))
+        .collect::<Vec<_>>();
+
+    assert!(
+        !tools.contains(&"fastskill_serve".to_string()),
+        "serve must not be an MCP tool; exported: {tools:#?}"
+    );
+    // Sanity: the export policy did not filter everything away.
+    assert!(tools.contains(&"fastskill_list".to_string()));
+}
+
+#[test]
+fn tool_schemas_document_their_parameters() {
+    // cli-framework 0.5.8 forwards `ArgSpec.help` into the JSON-Schema
+    // `description`. Without it every property is a bare `{"type":"boolean"}`
+    // and a calling agent has to guess what the flags do.
+    let project = fixture();
+    let stdout = mcp_session(
+        project.path(),
+        &[
+            INIT,
+            INITIALIZED,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#,
+        ],
+    );
+
+    let tools = response(&stdout, 2)["result"]["tools"].clone();
+    let list = tools
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .find(|t| t["name"] == "fastskill_list")
+        .expect("fastskill_list tool");
+
+    let props = list["inputSchema"]["properties"]
+        .as_object()
+        .expect("schema properties");
+    assert!(!props.is_empty(), "fastskill_list should expose parameters");
+
+    let undocumented: Vec<&String> = props
+        .iter()
+        .filter(|(_, schema)| schema.get("description").is_none())
+        .map(|(name, _)| name)
+        .collect();
+    assert!(
+        undocumented.is_empty(),
+        "these parameters have no description: {undocumented:?}"
+    );
+}


### PR DESCRIPTION
Adopts the 45 commits of `cli-framework` this repo was behind, and fixes the two user-facing defects that bump exposed.

## 1. `fastskill mcp serve` returned `"OK"` for every tool 🔴

Commands wrote to stdout with `println!`. Under stdio transport **stdout is the JSON-RPC channel**, so a real `tools/call` session looked like this:

```
{"jsonrpc":"2.0","id":1,"result":{...}}
ID          Name        Description        <- raw table on stdout
demo-skill  demo-skill  A demo skill...    <- corrupts the stream
{"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"OK"}]}}
```

The caller received the literal string `"OK"` for all 35 tools, and a strict client rejects the interleaved plain text outright. `framework_println` — which cli-framework captures — had **0 call sites** against 217 `println!`.

Routing to the context is not directly possible: `AppBuilder::register` requires the handler future to be `'static`, so a handler can read the context but cannot write back once it awaits. `Command::execute` is more permissive (its future may borrow the context, `Send + 'a`), so `registration::register_out` builds that `Command` directly and drains a buffer into `ctx.framework_println` after the handler resolves. Handler shape is unchanged at all 34 call sites.

Output routing lives behind an `outln!` seam with a mode picked at startup: ordinary CLI runs write straight to stdout (long-running commands keep streaming), `mcp serve` buffers into a **task-local** sink — task-local rather than global because MCP dispatches tool calls concurrently.

Two corrections fall out:
- **`serve` is no longer an MCP tool.** It starts a server and never returns, so calling it hung until the transport gave up. Needed `McpToolExportPolicy::ExposeMcpOnly`; the framework default ignores `expose_mcp`. Tools: 35 → 33 (`serve` + framework-internal `spec`).
- **Tool parameters now carry descriptions.** 0.5.8 forwards `ArgSpec.help` into the JSON-Schema `description`, and 155/161 specs already had help text. Previously every property was a bare `{"type":"boolean"}` for the agent to guess at.

## 2. Command typos reported a missing skill

`fastskill <skill-id>` is shorthand for `read`, and the rewrite fired on *any* unrecognised positional:

```
$ fastskill insatll
Error: Skill 'insatll' not found          # before
```
```
$ fastskill insatll                        # after
error: unrecognized subcommand 'insatll'
  hint: Did you mean 'install'?
  hint: to read a skill by this name, run: fastskill read insatll
```

Damerau-Levenshtein at a budget of exactly 1: a transposition is the most common typo and costs 2 under plain Levenshtein, which would miss `insatll`/`serach`. Keeping the budget at 1 bounds the blast radius — `installer` is 2 edits from `install` and is still read as a skill. **An installed skill always wins**, so `fastskill repo` still reads a skill named `repo` even though `repos` is one edit away; the filesystem probe only runs for tokens that already look like a typo.

The suggestion is computed here rather than delegated to clap's suggester (which now reaches us via `suggest_corrections`): clap answers `init` for `insatll`, and acting on that would scaffold a project the user never asked for. A test pins the five cases where we beat it.

## 3. Dependency bump — 0.4.2 → 0.5.8

The workspace compiled **unchanged**; none of the breaking changes in that window apply (no `Command` struct literals, no `parse_with_clap`, no self-mounted `mcp_axum_router`).

- **OpenSSL is gone.** 0.5.8 switched reqwest to rustls-tls, the last edge pulling `hyper-tls → native-tls → openssl-sys`. The `vendored-openssl` feature existed only to work around this on musl, so it and `-F vendored-openssl` in `release.yml` are removed — the musl cross-build no longer compiles OpenSSL from source.
- **aikit is no longer resolved twice.** cli-framework required `goaikit/aikit.git` @ `435a1132859...` while this workspace asked for `goaikit/aikit` @ `435a1132` — the same commit spelled two ways, compiling two mutually-incompatible copies of `aikit-sdk`/`aikit-agent` into the binary. Specs now match exactly, with a comment recording why.
- `Cargo.lock` loses 274 lines.

## Testing

`cargo test --workspace`: **747 passed, 0 failed.**

New `tests/mcp_stdio_protocol_test.rs` drives a real stdio session and asserts stdout parses as JSON-RPC line by line, the result carries rendered output rather than `"OK"`, `serve` is absent from `tools/list`, and no parameter lacks a description. `shorthand.rs` adds 14 unit tests covering the distance metric, routing, skill-outranks-typo, probe laziness, and suggestion determinism across `HashSet` iteration orders.

Verified by hand against the built binary: MCP session shows **0 protocol leaks** and returns the real skill table; CLI output still streams; typo suggestions are accurate.