### PR TITLE
feat(cache): local skill cache + real `repos refresh` semantics

### DIFF
--- a/crates/fastskill-cli/src/commands/cache.rs
+++ b/crates/fastskill-cli/src/commands/cache.rs
@@ -1,0 +1,392 @@
+//! `fastskill cache` subcommand (PRD 006 "Local Skill Cache", US-006):
+//! inspect and reclaim the on-disk, machine-global skill content cache that
+//! `add`/`install`/`update` populate for git, registry, and local origins
+//! (`fastskill_core::core::cache::SkillCache`).
+//!
+//! `cache info` and `cache clean` both work directly against
+//! [`SkillCache::from_env`] -- like `repos refresh` (US-005), neither needs a
+//! full `FastSkillService`, just the resolved cache root.
+
+use crate::commands::common::validate_format_args;
+use crate::error::{CliError, CliResult};
+use crate::utils::messages;
+use cli_framework::command::{FromArgValueMap, IntoCommandSpec};
+use cli_framework::spec::arg_spec::{ArgKind, ArgSpec, ArgValueType, Cardinality};
+use cli_framework::spec::command_tree::CommandSpec;
+use cli_framework::spec::value::ArgValue;
+use fastskill_core::core::cache::{CacheStats, CleanReport, ContentSourceKind, SkillCache};
+use fastskill_core::OutputFormat;
+use std::collections::HashMap;
+use std::str::FromStr;
+
+/// Restrict `cache info`'s `--format` to `table`/`json`, mirroring
+/// `validate_eval_format_args`: there is no per-source-kind grid/XML layout
+/// to render, so `grid`/`xml` are rejected with a clear error rather than
+/// silently collapsing to `table`.
+fn validate_cache_info_format_args(
+    format: &Option<OutputFormat>,
+    json: bool,
+) -> CliResult<OutputFormat> {
+    let resolved = validate_format_args(format, json)?;
+    match resolved {
+        OutputFormat::Grid | OutputFormat::Xml => Err(CliError::Config(
+            "Error: cache info supports only --format table or json (grid/xml are not \
+             implemented for cache output). Use --format json for machine-readable output."
+                .to_string(),
+        )),
+        other => Ok(other),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// cache info
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct CacheInfoArgs {
+    pub format: Option<OutputFormat>,
+    pub json: bool,
+}
+
+impl IntoCommandSpec for CacheInfoArgs {
+    fn command_spec() -> CommandSpec {
+        CommandSpec {
+            summary: "Show the skill content cache location, entry counts, and disk usage",
+            syntax: Some("cache info [OPTIONS]"),
+            category: Some("cache"),
+            args: vec![
+                ArgSpec {
+                    name: "format",
+                    kind: ArgKind::Option,
+                    long: Some("format"),
+                    value_type: ArgValueType::String,
+                    cardinality: Cardinality::Optional,
+                    help: "Output format: table or json (default: table)",
+                    ..Default::default()
+                },
+                ArgSpec {
+                    name: "json",
+                    kind: ArgKind::Flag,
+                    long: Some("json"),
+                    value_type: ArgValueType::Bool,
+                    cardinality: Cardinality::Optional,
+                    help: "Shorthand for --format json",
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+    }
+}
+
+impl FromArgValueMap for CacheInfoArgs {
+    fn from_arg_value_map(map: &HashMap<String, ArgValue>) -> Self {
+        Self {
+            format: map
+                .get("format")
+                .and_then(|v| {
+                    if let ArgValue::Str(s) = v {
+                        Some(s.as_str())
+                    } else {
+                        None
+                    }
+                })
+                .and_then(|s| OutputFormat::from_str(s).ok()),
+            json: matches!(map.get("json"), Some(ArgValue::Bool(true))),
+        }
+    }
+}
+
+pub async fn execute_cache_info(args: CacheInfoArgs) -> CliResult<()> {
+    let resolved_format = validate_cache_info_format_args(&args.format, args.json)?;
+    let cache = SkillCache::from_env()?;
+    let stats = cache.stats()?;
+
+    match resolved_format {
+        OutputFormat::Json => {
+            let json_output = serde_json::to_string_pretty(&stats)
+                .map_err(|e| CliError::Config(format!("Failed to serialize JSON: {}", e)))?;
+            crate::outln!("{}", json_output);
+        }
+        _ => crate::outln!("{}", format_info_table(&stats)),
+    }
+    Ok(())
+}
+
+fn format_info_table(stats: &CacheStats) -> String {
+    let mut output = format!("Cache location: {}\n\n", stats.root.display());
+    for kind in ContentSourceKind::ALL {
+        let s = stats.for_kind(kind);
+        output.push_str(&format!(
+            "  • {:<8} {} {}, {}\n",
+            kind.to_string(),
+            s.entry_count,
+            if s.entry_count == 1 {
+                "entry"
+            } else {
+                "entries"
+            },
+            format_bytes(s.total_bytes),
+        ));
+    }
+    let total = stats.total();
+    output.push_str(&format!(
+        "\nTotal: {} {}, {}\n",
+        total.entry_count,
+        if total.entry_count == 1 {
+            "entry"
+        } else {
+            "entries"
+        },
+        format_bytes(total.total_bytes),
+    ));
+    output
+}
+
+// ---------------------------------------------------------------------------
+// cache clean
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct CacheCleanArgs {
+    pub source: Option<String>,
+    pub json: bool,
+}
+
+impl IntoCommandSpec for CacheCleanArgs {
+    fn command_spec() -> CommandSpec {
+        CommandSpec {
+            summary: "Remove cached skill content and print bytes reclaimed",
+            syntax: Some("cache clean [--source <git|registry|local>]"),
+            category: Some("cache"),
+            args: vec![
+                ArgSpec {
+                    name: "source",
+                    kind: ArgKind::Option,
+                    long: Some("source"),
+                    value_type: ArgValueType::Enum(vec!["git", "registry", "local"]),
+                    cardinality: Cardinality::Optional,
+                    help: "Limit cleaning to one source kind: git, registry, or local \
+                           (default: all)",
+                    ..Default::default()
+                },
+                ArgSpec {
+                    name: "json",
+                    kind: ArgKind::Flag,
+                    long: Some("json"),
+                    value_type: ArgValueType::Bool,
+                    cardinality: Cardinality::Optional,
+                    help: "Print the result as JSON",
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+    }
+}
+
+impl FromArgValueMap for CacheCleanArgs {
+    fn from_arg_value_map(map: &HashMap<String, ArgValue>) -> Self {
+        Self {
+            source: map.get("source").and_then(|v| match v {
+                ArgValue::Str(s) | ArgValue::Enum(s) => Some(s.clone()),
+                _ => None,
+            }),
+            json: matches!(map.get("json"), Some(ArgValue::Bool(true))),
+        }
+    }
+}
+
+/// `cache clean` (US-006). Content only -- the index cache (`index/`,
+/// including `repos refresh`'s per-source listings and the git-resolutions
+/// map) is left untouched, per the PRD's "removes all content entries"
+/// wording and its "no v1 TTL/GC" stance on the index: cleaning content is a
+/// disk-reclaim operation, not a "forget what I know" operation, and the
+/// only thing that invalidates the index is an explicit `repos refresh`.
+pub async fn execute_cache_clean(args: CacheCleanArgs) -> CliResult<()> {
+    let source = args
+        .source
+        .as_deref()
+        .map(ContentSourceKind::from_str)
+        .transpose()?;
+
+    let cache = SkillCache::from_env()?;
+    let report = cache.clean(source)?;
+
+    if args.json {
+        let payload = serde_json::json!({
+            "root": cache.root().display().to_string(),
+            "source": source.map(|k| k.to_string()).unwrap_or_else(|| "all".to_string()),
+            "entries_removed": report.entries_removed,
+            "bytes_reclaimed": report.bytes_reclaimed,
+        });
+        let json_output = serde_json::to_string_pretty(&payload)
+            .map_err(|e| CliError::Config(format!("Failed to serialize JSON: {}", e)))?;
+        crate::outln!("{}", json_output);
+    } else {
+        crate::outln!("{}", format_clean_message(source, &report));
+    }
+    Ok(())
+}
+
+fn format_clean_message(source: Option<ContentSourceKind>, report: &CleanReport) -> String {
+    let scope = source
+        .map(|k| k.to_string())
+        .unwrap_or_else(|| "all sources".to_string());
+    messages::ok(&format!(
+        "Cleaned {}: removed {} {}, reclaimed {}",
+        scope,
+        report.entries_removed,
+        if report.entries_removed == 1 {
+            "entry"
+        } else {
+            "entries"
+        },
+        format_bytes(report.bytes_reclaimed),
+    ))
+}
+
+/// Human-readable byte size, e.g. `"1.2 MB"`, `"45.6 KB"` (STYLE.md's number
+/// formatting example).
+fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
+    let mut value = bytes as f64;
+    let mut unit_idx = 0usize;
+    while value >= 1024.0 && unit_idx < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit_idx += 1;
+    }
+    if unit_idx == 0 {
+        format!("{bytes} {}", UNITS[0])
+    } else {
+        format!("{value:.1} {}", UNITS[unit_idx])
+    }
+}
+
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::await_holding_lock)]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// RAII guard restoring `FASTSKILL_CACHE_DIR` to whatever it was before
+    /// the test set it (mirrors `repo_ops.rs`'s `CacheDirEnvGuard`), so these
+    /// tests never leak into the real platform cache dir nor race other
+    /// tests sharing this process.
+    struct CacheDirEnvGuard(Option<String>);
+    impl Drop for CacheDirEnvGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(v) => std::env::set_var("FASTSKILL_CACHE_DIR", v),
+                None => std::env::remove_var("FASTSKILL_CACHE_DIR"),
+            }
+        }
+    }
+
+    #[test]
+    fn format_bytes_renders_human_units() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(1536), "1.5 KB");
+        assert_eq!(format_bytes(45 * 1024 + 600), "45.6 KB");
+        assert_eq!(format_bytes(12 * 1024 * 1024), "12.0 MB");
+    }
+
+    #[tokio::test]
+    async fn cache_info_on_an_empty_cache_reports_zero_entries() {
+        let _lock = fastskill_core::test_utils::DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let cache_dir = TempDir::new().unwrap();
+        let _env_guard = CacheDirEnvGuard(std::env::var("FASTSKILL_CACHE_DIR").ok());
+        std::env::set_var("FASTSKILL_CACHE_DIR", cache_dir.path());
+
+        let result = execute_cache_info(CacheInfoArgs {
+            format: None,
+            json: false,
+        })
+        .await;
+        assert!(
+            result.is_ok(),
+            "cache info should succeed: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_info_rejects_grid_format() {
+        let err = validate_cache_info_format_args(&Some(OutputFormat::Grid), false)
+            .expect_err("grid must be rejected");
+        assert!(err.to_string().contains("table or json"));
+    }
+
+    #[tokio::test]
+    async fn cache_clean_rejects_an_unknown_source() {
+        let _lock = fastskill_core::test_utils::DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let cache_dir = TempDir::new().unwrap();
+        let _env_guard = CacheDirEnvGuard(std::env::var("FASTSKILL_CACHE_DIR").ok());
+        std::env::set_var("FASTSKILL_CACHE_DIR", cache_dir.path());
+
+        let result = execute_cache_clean(CacheCleanArgs {
+            source: Some("bogus".to_string()),
+            json: false,
+        })
+        .await;
+        let err = result.expect_err("unknown source must be rejected");
+        assert!(err.to_string().contains("git, registry, local"));
+    }
+
+    #[tokio::test]
+    async fn cache_clean_on_a_never_used_cache_is_a_harmless_noop() {
+        let _lock = fastskill_core::test_utils::DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let cache_dir = TempDir::new().unwrap();
+        let _env_guard = CacheDirEnvGuard(std::env::var("FASTSKILL_CACHE_DIR").ok());
+        std::env::set_var("FASTSKILL_CACHE_DIR", cache_dir.path().join("unused"));
+
+        let result = execute_cache_clean(CacheCleanArgs {
+            source: None,
+            json: true,
+        })
+        .await;
+        assert!(result.is_ok(), "clean should succeed: {:?}", result.err());
+    }
+
+    #[tokio::test]
+    async fn cache_info_then_clean_round_trip_reflects_removed_content() {
+        let _lock = fastskill_core::test_utils::DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let cache_dir = TempDir::new().unwrap();
+        let _env_guard = CacheDirEnvGuard(std::env::var("FASTSKILL_CACHE_DIR").ok());
+        std::env::set_var("FASTSKILL_CACHE_DIR", cache_dir.path());
+
+        let cache = SkillCache::from_env().unwrap();
+        let src = TempDir::new().unwrap();
+        std::fs::write(src.path().join("SKILL.md"), "---\nname: demo\n---\nbody\n").unwrap();
+        cache
+            .put(
+                &fastskill_core::core::cache::CacheIdentity::Local {
+                    tree_hash: "abc123".to_string(),
+                },
+                src.path(),
+            )
+            .unwrap();
+
+        let stats_before = cache.stats().unwrap();
+        assert_eq!(stats_before.local.entry_count, 1);
+
+        let clean_result = execute_cache_clean(CacheCleanArgs {
+            source: Some("local".to_string()),
+            json: false,
+        })
+        .await;
+        assert!(clean_result.is_ok(), "{:?}", clean_result.err());
+
+        let stats_after = cache.stats().unwrap();
+        assert_eq!(stats_after.local.entry_count, 0);
+    }
+}

--- a/crates/fastskill-cli/src/commands/mod.rs
+++ b/crates/fastskill-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod add;
 pub mod analyze;
+pub mod cache;
 pub mod common;
 pub mod doctor;
 pub mod eval;

--- a/crates/fastskill-cli/src/commands/registry/repo_ops.rs
+++ b/crates/fastskill-cli/src/commands/registry/repo_ops.rs
@@ -179,16 +179,80 @@ pub async fn execute_test(name: String) -> CliResult<()> {
     Ok(())
 }
 
+/// `repos refresh [name]` (PRD 006 "Local Skill Cache", US-005): refresh the
+/// on-disk index cache for one repository, or every configured repository,
+/// via [`fastskill_core::core::repository::RepositoryManager::refresh_index`].
+///
+/// An explicit `name` for a repository that does not exist is a fast, honest
+/// error — never fake success. When refreshing "all" repositories, one
+/// source's failure does not stop the rest: every source is attempted, each
+/// prints its own outcome, and the command exits non-zero if any failed
+/// (FR-5). Index only — this never fetches or caches skill content.
 pub async fn execute_refresh(name: Option<String>) -> CliResult<()> {
-    if let Some(repo_name) = name {
+    let repo_manager = super::helpers::load_repo_manager().await?;
+    let cache = fastskill_core::core::cache::SkillCache::from_env()?;
+
+    let targets: Vec<String> = match name {
+        Some(repo_name) => {
+            repo_manager
+                .get_repository(&repo_name)
+                .ok_or_else(|| CliError::Config(format!("Repository '{}' not found", repo_name)))?;
+            vec![repo_name]
+        }
+        None => repo_manager
+            .list_repositories()
+            .into_iter()
+            .map(|r| r.name.clone())
+            .collect(),
+    };
+
+    if targets.is_empty() {
         crate::outln!(
             "{}",
-            messages::ok(&format!("Refreshed cache for repository: {}", repo_name))
+            messages::info("No repositories configured to refresh")
         );
-    } else {
-        crate::outln!("{}", messages::ok("Refreshed cache for all repositories"));
+        return Ok(());
     }
-    Ok(())
+
+    let mut failed: Vec<(String, String)> = Vec::new();
+    for target in &targets {
+        match repo_manager.refresh_index(&cache, target).await {
+            Ok(count) => {
+                crate::outln!(
+                    "{}",
+                    messages::ok(&format!(
+                        "Refreshed {}: {} skill{}",
+                        target,
+                        count,
+                        if count == 1 { "" } else { "s" }
+                    ))
+                );
+            }
+            Err(e) => {
+                eprintln!(
+                    "{}",
+                    messages::error(&format!("Failed to refresh {}: {}", target, e))
+                );
+                failed.push((target.clone(), e.to_string()));
+            }
+        }
+    }
+
+    if failed.is_empty() {
+        return Ok(());
+    }
+
+    Err(CliError::Validation(format!(
+        "{} of {} repositor{} failed to refresh:\n{}",
+        failed.len(),
+        targets.len(),
+        if targets.len() == 1 { "y" } else { "ies" },
+        failed
+            .iter()
+            .map(|(n, e)| format!("  - {}: {}", n, e))
+            .collect::<Vec<_>>()
+            .join("\n")
+    )))
 }
 
 pub async fn execute_add(
@@ -390,5 +454,197 @@ skills_directory = ".claude/skills"
 
         let list_result = execute_list_with_json(false).await;
         assert!(list_result.is_ok());
+    }
+
+    // ── PRD 006 "Local Skill Cache", US-005: `repos refresh` real semantics ──
+
+    /// RAII guard restoring `FASTSKILL_CACHE_DIR` to whatever it was before
+    /// the test set it, so these tests never leak into the real platform
+    /// cache dir nor into other tests sharing this process.
+    struct CacheDirEnvGuard(Option<String>);
+    impl Drop for CacheDirEnvGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(v) => std::env::set_var("FASTSKILL_CACHE_DIR", v),
+                None => std::env::remove_var("FASTSKILL_CACHE_DIR"),
+            }
+        }
+    }
+
+    fn write_skill(dir: &std::path::Path, id: &str, version: &str) {
+        let skill_dir = dir.join(id);
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {id}\nversion: \"{version}\"\ndescription: a skill\n---\nBody\n"),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_execute_refresh_unknown_repository_fails() {
+        let _lock = fastskill_core::test_utils::DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        let temp_dir = TempDir::new().unwrap();
+        let original_dir = std::env::current_dir().ok();
+
+        struct DirGuard(Option<std::path::PathBuf>);
+        impl Drop for DirGuard {
+            fn drop(&mut self) {
+                if let Some(dir) = &self.0 {
+                    let _ = std::env::set_current_dir(dir);
+                }
+            }
+        }
+        let _guard = DirGuard(original_dir);
+        std::env::set_current_dir(temp_dir.path()).unwrap();
+
+        let manifest_content = "[tool.fastskill]\nskills_directory = \".claude/skills\"\n";
+        fs::write(temp_dir.path().join("skill-project.toml"), manifest_content).unwrap();
+
+        let cache_dir = TempDir::new().unwrap();
+        let _env_guard = CacheDirEnvGuard(std::env::var("FASTSKILL_CACHE_DIR").ok());
+        std::env::set_var("FASTSKILL_CACHE_DIR", cache_dir.path());
+
+        let err = execute_refresh(Some("does-not-exist".to_string()))
+            .await
+            .expect_err("refresh of an unknown repository must fail, not fake success");
+        let message = err.to_string();
+        assert!(message.contains("does-not-exist"));
+        assert!(message.contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_refresh_writes_index_and_reports_skill_count() {
+        let _lock = fastskill_core::test_utils::DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        let temp_dir = TempDir::new().unwrap();
+        let original_dir = std::env::current_dir().ok();
+
+        struct DirGuard(Option<std::path::PathBuf>);
+        impl Drop for DirGuard {
+            fn drop(&mut self) {
+                if let Some(dir) = &self.0 {
+                    let _ = std::env::set_current_dir(dir);
+                }
+            }
+        }
+        let _guard = DirGuard(original_dir);
+        std::env::set_current_dir(temp_dir.path()).unwrap();
+
+        let manifest_content = "[tool.fastskill]\nskills_directory = \".claude/skills\"\n";
+        fs::write(temp_dir.path().join("skill-project.toml"), manifest_content).unwrap();
+
+        let repo_path = temp_dir.path().join("indexed-repo");
+        write_skill(&repo_path, "indexed-skill", "2.3.4");
+
+        let add_result = execute_add(
+            "idx-repo".to_string(),
+            "local".to_string(),
+            repo_path.display().to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(add_result.is_ok());
+
+        let cache_dir = TempDir::new().unwrap();
+        let _env_guard = CacheDirEnvGuard(std::env::var("FASTSKILL_CACHE_DIR").ok());
+        std::env::set_var("FASTSKILL_CACHE_DIR", cache_dir.path());
+
+        let result = execute_refresh(Some("idx-repo".to_string())).await;
+        assert!(result.is_ok(), "refresh should succeed: {:?}", result.err());
+
+        let index_path = cache_dir.path().join("index").join("idx-repo.json");
+        let index_contents = fs::read_to_string(&index_path)
+            .unwrap_or_else(|e| panic!("expected index file at {}: {e}", index_path.display()));
+        assert!(index_contents.contains("indexed-skill"));
+        assert!(index_contents.contains("2.3.4"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_refresh_all_partial_failure_refreshes_others_and_errors() {
+        let _lock = fastskill_core::test_utils::DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
+        let temp_dir = TempDir::new().unwrap();
+        let original_dir = std::env::current_dir().ok();
+
+        struct DirGuard(Option<std::path::PathBuf>);
+        impl Drop for DirGuard {
+            fn drop(&mut self) {
+                if let Some(dir) = &self.0 {
+                    let _ = std::env::set_current_dir(dir);
+                }
+            }
+        }
+        let _guard = DirGuard(original_dir);
+        std::env::set_current_dir(temp_dir.path()).unwrap();
+
+        let manifest_content = "[tool.fastskill]\nskills_directory = \".claude/skills\"\n";
+        fs::write(temp_dir.path().join("skill-project.toml"), manifest_content).unwrap();
+
+        let good_repo_path = temp_dir.path().join("good-repo");
+        write_skill(&good_repo_path, "healthy-skill", "1.0.0");
+        let add_good = execute_add(
+            "healthy".to_string(),
+            "local".to_string(),
+            good_repo_path.display().to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(add_good.is_ok());
+
+        let broken_repo_path = temp_dir.path().join("this-path-does-not-exist");
+        let add_bad = execute_add(
+            "broken".to_string(),
+            "local".to_string(),
+            broken_repo_path.display().to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+        assert!(add_bad.is_ok());
+
+        let cache_dir = TempDir::new().unwrap();
+        let _env_guard = CacheDirEnvGuard(std::env::var("FASTSKILL_CACHE_DIR").ok());
+        std::env::set_var("FASTSKILL_CACHE_DIR", cache_dir.path());
+
+        let result = execute_refresh(None).await;
+        assert!(
+            result.is_err(),
+            "overall refresh must fail non-zero when any source fails"
+        );
+        let message = result.unwrap_err().to_string();
+        assert!(message.contains("broken"));
+
+        // The healthy source still refreshed despite the other's failure.
+        assert!(cache_dir
+            .path()
+            .join("index")
+            .join("healthy.json")
+            .is_file());
+        assert!(!cache_dir.path().join("index").join("broken.json").exists());
     }
 }

--- a/crates/fastskill-cli/src/main.rs
+++ b/crates/fastskill-cli/src/main.rs
@@ -93,8 +93,8 @@ fn ctx_skills_dir(ctx: &dyn AppContext) -> Option<std::path::PathBuf> {
 }
 
 use commands::{
-    add, analyze, doctor, eval, init, install, list, marketplace, read, reindex, remove, repos,
-    search, serve, skillopt, update,
+    add, analyze, cache, doctor, eval, init, install, list, marketplace, read, reindex, remove,
+    repos, search, serve, skillopt, update,
 };
 
 #[tokio::main]
@@ -385,6 +385,35 @@ fn build_app(builder: AppBuilder, state: Arc<FsState>) -> anyhow::Result<AppBuil
                 path!["repos", "versions"],
                 |_ctx, args: repos::ReposVersionsArgs| async move {
                     repos::execute_repos_versions(args)
+                        .await
+                        .map_err(anyhow::Error::from)
+                },
+            )?
+    };
+
+    // ── cache: inspect/reclaim the on-disk skill content cache (PRD 006 US-006) ──
+    let builder = {
+        use cli_framework::spec::command_tree::GroupMetadata;
+        builder
+            .register_group(
+                &path!["cache"],
+                GroupMetadata {
+                    summary: "Inspect and reclaim the on-disk skill content cache",
+                    hidden: false,
+                },
+            )?
+            .register_out(
+                path!["cache", "info"],
+                |_ctx, args: cache::CacheInfoArgs| async move {
+                    cache::execute_cache_info(args)
+                        .await
+                        .map_err(anyhow::Error::from)
+                },
+            )?
+            .register_out(
+                path!["cache", "clean"],
+                |_ctx, args: cache::CacheCleanArgs| async move {
+                    cache::execute_cache_clean(args)
                         .await
                         .map_err(anyhow::Error::from)
                 },

--- a/crates/fastskill-core/src/core/cache/index.rs
+++ b/crates/fastskill-core/src/core/cache/index.rs
@@ -1,0 +1,236 @@
+//! The on-disk index-cache schema (PRD 006, US-001 — "this story owns the
+//! index schema"). These serde types, and the read/write functions below,
+//! are the **only** way any code should touch `<cache-root>/index/*.json`.
+//! Later stories read/write through here rather than hand-rolling JSON at
+//! their own call sites:
+//!
+//! - US-003/US-005 read and write [`SourceIndex`] — what a source currently
+//!   advertises (skills + versions), one file per source.
+//! - US-002 reads and writes [`GitResolutions`] — the `url+ref -> sha` map
+//!   that lets an offline install proceed from a previously-resolved ref.
+
+use crate::core::cache::validate_component;
+use crate::core::service::ServiceError;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+const INDEX_DIR_NAME: &str = "index";
+const GIT_RESOLUTIONS_FILE_NAME: &str = "git-resolutions.json";
+
+/// `<cache-root>/index/<source>.json` — what a single configured source
+/// currently advertises: which skills, at which versions. Written by a real
+/// `repos refresh` (US-005); read by version resolution (US-002/US-003).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SourceIndex {
+    pub fetched_at: DateTime<Utc>,
+    #[serde(default)]
+    pub entries: Vec<SourceIndexEntry>,
+}
+
+/// One skill's advertised versions within a [`SourceIndex`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SourceIndexEntry {
+    pub skill: String,
+    #[serde(default)]
+    pub versions: Vec<String>,
+}
+
+/// A single git ref resolution: the commit SHA `url+ref` resolved to, and
+/// when. Stored inside [`GitResolutions`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GitResolution {
+    pub sha: String,
+    pub resolved_at: DateTime<Utc>,
+}
+
+/// `<cache-root>/index/git-resolutions.json` — `url+ref -> {sha,
+/// resolved_at}`. A newtype over the map (rather than a bare
+/// `HashMap<String, GitResolution>` alias) so the `url+ref` key composition
+/// lives in exactly one place instead of being reformatted ad hoc at each
+/// call site. Serialized `#[serde(transparent)]`, so the file on disk is
+/// just the flat JSON object the PRD specifies — no extra wrapper field.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct GitResolutions(HashMap<String, GitResolution>);
+
+impl GitResolutions {
+    fn key(url: &str, git_ref: &str) -> String {
+        format!("{url}#{git_ref}")
+    }
+
+    /// Canonical ref-key encoding for a plain branch/tag/default selection —
+    /// shared between `install::fetch_git` (PRD 006 US-002, resolving a
+    /// skill's own git origin) and `RepositoryManager::refresh_index` (US-005,
+    /// resolving a configured `GitMarketplace` source's branch/tag) so both
+    /// read and write compatible entries in this map. A `GitRef::Commit` has
+    /// no branch/tag form and is encoded separately by its only caller.
+    pub fn branch_or_tag_key(branch: Option<&str>, tag: Option<&str>) -> String {
+        match (branch, tag) {
+            (Some(b), _) => format!("branch:{b}"),
+            (None, Some(t)) => format!("tag:{t}"),
+            (None, None) => "HEAD".to_string(),
+        }
+    }
+
+    /// Look up a previously-recorded resolution for `url` at `git_ref`.
+    pub fn get(&self, url: &str, git_ref: &str) -> Option<&GitResolution> {
+        self.0.get(&Self::key(url, git_ref))
+    }
+
+    /// Record (or replace) the resolution for `url` at `git_ref`.
+    pub fn insert(&mut self, url: &str, git_ref: &str, sha: String, resolved_at: DateTime<Utc>) {
+        self.0
+            .insert(Self::key(url, git_ref), GitResolution { sha, resolved_at });
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+fn index_dir(root: &Path) -> PathBuf {
+    root.join(INDEX_DIR_NAME)
+}
+
+fn source_index_path(root: &Path, source: &str) -> Result<PathBuf, ServiceError> {
+    let source = validate_component(source)?;
+    Ok(index_dir(root).join(format!("{source}.json")))
+}
+
+pub(super) fn read_source_index(
+    root: &Path,
+    source: &str,
+) -> Result<Option<SourceIndex>, ServiceError> {
+    read_json(&source_index_path(root, source)?)
+}
+
+pub(super) fn write_source_index(
+    root: &Path,
+    source: &str,
+    idx: &SourceIndex,
+) -> Result<(), ServiceError> {
+    write_json(&source_index_path(root, source)?, idx)
+}
+
+pub(super) fn read_git_resolutions(root: &Path) -> Result<GitResolutions, ServiceError> {
+    let path = index_dir(root).join(GIT_RESOLUTIONS_FILE_NAME);
+    Ok(read_json(&path)?.unwrap_or_default())
+}
+
+pub(super) fn write_git_resolutions(
+    root: &Path,
+    resolutions: &GitResolutions,
+) -> Result<(), ServiceError> {
+    let path = index_dir(root).join(GIT_RESOLUTIONS_FILE_NAME);
+    write_json(&path, resolutions)
+}
+
+fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> Result<Option<T>, ServiceError> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(path)?;
+    let value = serde_json::from_str(&content).map_err(|e| {
+        ServiceError::Validation(format!("failed to parse {}: {e}", path.display()))
+    })?;
+    Ok(Some(value))
+}
+
+fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), ServiceError> {
+    let json = serde_json::to_vec_pretty(value).map_err(|e| {
+        ServiceError::Validation(format!("failed to serialize {}: {e}", path.display()))
+    })?;
+    crate::utils::atomic_write(path, &json)?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn source_index_round_trips_through_disk() {
+        let root = TempDir::new().unwrap();
+        let idx = SourceIndex {
+            fetched_at: Utc::now(),
+            entries: vec![SourceIndexEntry {
+                skill: "demo".to_string(),
+                versions: vec!["1.0.0".to_string(), "1.1.0".to_string()],
+            }],
+        };
+
+        write_source_index(root.path(), "acme", &idx).unwrap();
+        let read_back = read_source_index(root.path(), "acme").unwrap();
+
+        assert_eq!(read_back, Some(idx));
+    }
+
+    #[test]
+    fn source_index_missing_file_is_none() {
+        let root = TempDir::new().unwrap();
+        assert_eq!(read_source_index(root.path(), "nope").unwrap(), None);
+    }
+
+    #[test]
+    fn source_index_rejects_invalid_source_name() {
+        let root = TempDir::new().unwrap();
+        let idx = SourceIndex {
+            fetched_at: Utc::now(),
+            entries: vec![],
+        };
+
+        let err = write_source_index(root.path(), "../escape", &idx).unwrap_err();
+        assert!(matches!(err, ServiceError::Validation(_)));
+    }
+
+    #[test]
+    fn git_resolutions_round_trip_and_key_on_url_plus_ref() {
+        let root = TempDir::new().unwrap();
+        let mut resolutions = GitResolutions::default();
+        let now = Utc::now();
+        resolutions.insert(
+            "https://example.com/repo.git",
+            "main",
+            "abc123".to_string(),
+            now,
+        );
+        resolutions.insert(
+            "https://example.com/repo.git",
+            "v1.0",
+            "def456".to_string(),
+            now,
+        );
+
+        write_git_resolutions(root.path(), &resolutions).unwrap();
+        let read_back = read_git_resolutions(root.path()).unwrap();
+
+        assert_eq!(
+            read_back
+                .get("https://example.com/repo.git", "main")
+                .map(|r| r.sha.as_str()),
+            Some("abc123")
+        );
+        assert_eq!(
+            read_back
+                .get("https://example.com/repo.git", "v1.0")
+                .map(|r| r.sha.as_str()),
+            Some("def456")
+        );
+        assert_eq!(read_back.len(), 2);
+    }
+
+    #[test]
+    fn git_resolutions_missing_file_is_empty() {
+        let root = TempDir::new().unwrap();
+        let resolutions = read_git_resolutions(root.path()).unwrap();
+        assert!(resolutions.is_empty());
+    }
+}

--- a/crates/fastskill-core/src/core/cache/mod.rs
+++ b/crates/fastskill-core/src/core/cache/mod.rs
@@ -1,0 +1,1131 @@
+//! Local skill cache (PRD 006 "Local Skill Cache", US-001; see RFQ 004 for
+//! the architecture rationale).
+//!
+//! A machine-global, content-addressed store for fetched skill content, plus
+//! the per-source index it is checked against. [`SkillCache`] is the single
+//! seam later stories (US-002 git, US-003 registry, US-004 local, US-005
+//! `repos refresh`) go through to read or write the on-disk cache — this
+//! story has **no production callers yet**; it only builds and tests the
+//! store itself.
+//!
+//! ## On-disk layout
+//!
+//! ```text
+//! <cache-root>/
+//!   git/<sha>/                             content, keyed by commit SHA
+//!   registry/<source>/<skill>/<version>/   content, keyed by pinned version
+//!   local/<tree-hash>/                     content, keyed by tree/archive hash
+//!   index/<source>.json                    what a source currently advertises
+//!   index/git-resolutions.json             url+ref -> resolved sha (see `index`)
+//!   tmp/                                   private staging area for atomic writes
+//!   CACHEDIR.TAG                           https://bford.info/cachedir/ marker
+//! ```
+//!
+//! `fastskill cache info`/`clean` (US-006) are the read/delete side of this
+//! store: [`SkillCache::stats`] reports entry counts and disk usage per
+//! [`ContentSourceKind`]; [`SkillCache::clean`] removes content entries
+//! (never `index/`) with the same crash-safety posture as `put` and several
+//! independent checks against deleting outside the cache root — see
+//! `clean`'s own docs for the adversarial argument.
+//!
+//! `<cache-root>` defaults to the platform cache dir (`dirs::cache_dir()`,
+//! e.g. `~/.cache/fastskill` on Linux) and is overridable via the
+//! `FASTSKILL_CACHE_DIR` env var (FR-1).
+//!
+//! ## Crash- and concurrency-safety
+//!
+//! Every `put` assembles the new content in a private, uniquely-named
+//! staging directory under `tmp/`, then publishes it with a single atomic
+//! rename into its final, identity-keyed path. [`SkillCache::get`] only ever
+//! looks at that final path, so:
+//!
+//! - a reader can never observe a partially-written entry (a crash between
+//!   "assembled in staging" and "renamed into place" just leaves inert,
+//!   never-looked-at bytes under `tmp/`);
+//! - a concurrent duplicate `put` of the same identity degrades to a
+//!   harmless no-op: whichever writer's rename lands first wins, and the
+//!   loser simply observes the identity is now published and returns it.
+//!
+//! On Windows, a rename can transiently fail with `PermissionDenied` if
+//! another process has briefly opened the source or target (e.g. an AV
+//! scanner) — `publish` retries that case a bounded number of times before
+//! giving up, per the PRD's "Resolved Defaults".
+
+pub mod index;
+
+pub use index::{GitResolution, GitResolutions, SourceIndex, SourceIndexEntry};
+
+use crate::core::service::ServiceError;
+use serde::Serialize;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Environment variable that overrides the cache root (FR-1).
+pub const FASTSKILL_CACHE_DIR_ENV: &str = "FASTSKILL_CACHE_DIR";
+
+/// Directory (under the cache root) new content is assembled in before
+/// being published via atomic rename.
+const STAGING_DIR_NAME: &str = "tmp";
+
+/// Prefix for staging directories, so any leftover from an interrupted
+/// process is trivially recognizable as cache-internal scratch space.
+const STAGING_DIR_PREFIX: &str = ".fastskill-cache-tmp-";
+
+/// [`SkillCache::put`] best-effort marks the cache root with a
+/// [CACHEDIR.TAG](https://bford.info/cachedir/) — the same convention backup
+/// tools and `du`-style utilities already recognize — so a cache root is
+/// self-identifying even before `fastskill cache clean` (PRD 006, US-006)
+/// needs to reason about whether a directory "looks like" a fastskill cache.
+const CACHE_TAG_FILE_NAME: &str = "CACHEDIR.TAG";
+const CACHE_TAG_CONTENTS: &[u8] = b"Signature: 8a477f597d28d172789f06886806bc55\n\
+# This file is a cache directory tag created by fastskill.\n\
+# For information about cache directory tags, see https://bford.info/cachedir/\n";
+
+/// Top-level entries `fastskill cache clean` (PRD 006, US-006) will accept
+/// finding directly under a resolved cache root before it will touch
+/// anything inside it. Anything else there means the directory does not
+/// look like a fastskill cache root — most plausibly `FASTSKILL_CACHE_DIR`
+/// pointing somewhere unintended (a home directory, a project checkout) —
+/// and `clean` refuses outright rather than guessing. See
+/// [`verify_looks_like_cache_root`].
+const CACHE_ROOT_ALLOWED_ENTRIES: &[&str] = &[
+    "git",
+    "registry",
+    "local",
+    "index",
+    STAGING_DIR_NAME,
+    CACHE_TAG_FILE_NAME,
+];
+
+/// Bounded retry count for the Windows rename-over-a-briefly-open-target
+/// dance (PRD 006, "Resolved Defaults: Windows atomicity").
+#[cfg(windows)]
+const WINDOWS_RENAME_MAX_RETRIES: u32 = 10;
+#[cfg(windows)]
+const WINDOWS_RENAME_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// The immutable identity a piece of skill content is cached under. Modeled
+/// as a sum type — not a formatted string — so an unrepresentable identity
+/// (e.g. a git entry with no SHA) cannot be constructed, and each source
+/// type carries exactly the fields it needs.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CacheIdentity {
+    /// `git/<sha>/` — a resolved git commit (US-002).
+    Git { sha: String },
+    /// `registry/<source>/<skill>/<version>/` — a pinned registry artifact (US-003).
+    Registry {
+        source: String,
+        skill: String,
+        version: String,
+    },
+    /// `local/<tree-hash>/` — a local directory or `.zip`, content-hashed (US-004).
+    Local { tree_hash: String },
+}
+
+impl CacheIdentity {
+    /// This identity's path, relative to the cache root. Every component is
+    /// validated so a malformed SHA/source/skill/version/hash can never
+    /// escape its identity subtree (path traversal).
+    fn relative_path(&self) -> Result<PathBuf, ServiceError> {
+        match self {
+            CacheIdentity::Git { sha } => Ok(PathBuf::from("git").join(validate_component(sha)?)),
+            CacheIdentity::Registry {
+                source,
+                skill,
+                version,
+            } => Ok(PathBuf::from("registry")
+                .join(validate_component(source)?)
+                .join(validate_component(skill)?)
+                .join(validate_component(version)?)),
+            CacheIdentity::Local { tree_hash } => {
+                Ok(PathBuf::from("local").join(validate_component(tree_hash)?))
+            }
+        }
+    }
+}
+
+/// Validate a single identity path component: non-empty, no separators, no
+/// `..`. Reuses the same seam every other user-controlled path component in
+/// this codebase goes through (`crate::security::path`).
+pub(crate) fn validate_component(component: &str) -> Result<&str, ServiceError> {
+    if component.is_empty() {
+        return Err(ServiceError::Validation(
+            "cache identity component must not be empty".to_string(),
+        ));
+    }
+    crate::security::path::validate_path_component(component)
+        .map_err(|e| ServiceError::Validation(format!("invalid cache identity component: {e}")))?;
+    Ok(component)
+}
+
+/// A cache hit: the on-disk directory holding cached skill content for some
+/// [`CacheIdentity`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CachedContent {
+    pub identity: CacheIdentity,
+    /// Absolute path to the published content directory. Always the final,
+    /// identity-keyed path — never a path inside the cache's own staging
+    /// area — so callers can copy out of it immediately.
+    pub path: PathBuf,
+}
+
+/// The three top-level content kinds a [`CacheIdentity`] belongs to — also
+/// its on-disk directory name directly under the cache root (`git`,
+/// `registry`, `local`; see the module docs' on-disk layout). `fastskill
+/// cache info`/`clean` (PRD 006, US-006) report and scope by this rather
+/// than a free-form string, so an invalid `--source` can never be turned
+/// into a path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ContentSourceKind {
+    Git,
+    Registry,
+    Local,
+}
+
+impl ContentSourceKind {
+    /// All three kinds, in the order `fastskill cache info` reports them.
+    pub const ALL: [ContentSourceKind; 3] = [
+        ContentSourceKind::Git,
+        ContentSourceKind::Registry,
+        ContentSourceKind::Local,
+    ];
+
+    /// This kind's directory name directly under the cache root.
+    pub fn dir_name(self) -> &'static str {
+        match self {
+            ContentSourceKind::Git => "git",
+            ContentSourceKind::Registry => "registry",
+            ContentSourceKind::Local => "local",
+        }
+    }
+
+    /// Depth (in directories) from `<cache-root>/<dir_name>/` down to a leaf
+    /// identity directory — the unit `stats`/`clean` count and delete as one
+    /// entry. `git/<sha>/` and `local/<tree-hash>/` are one level deep;
+    /// `registry/<source>/<skill>/<version>/` is three.
+    fn leaf_depth(self) -> u32 {
+        match self {
+            ContentSourceKind::Git | ContentSourceKind::Local => 1,
+            ContentSourceKind::Registry => 3,
+        }
+    }
+}
+
+impl std::fmt::Display for ContentSourceKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.dir_name())
+    }
+}
+
+impl std::str::FromStr for ContentSourceKind {
+    type Err = ServiceError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "git" => Ok(ContentSourceKind::Git),
+            "registry" => Ok(ContentSourceKind::Registry),
+            "local" => Ok(ContentSourceKind::Local),
+            other => Err(ServiceError::Validation(format!(
+                "unknown cache source '{other}'; expected one of: git, registry, local"
+            ))),
+        }
+    }
+}
+
+/// Entry count + total on-disk bytes for one [`ContentSourceKind`], as
+/// reported by [`SkillCache::stats`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub struct ContentSourceStats {
+    pub entry_count: usize,
+    pub total_bytes: u64,
+}
+
+/// `fastskill cache info` (PRD 006, US-006): the resolved cache root, plus
+/// per-[`ContentSourceKind`] entry counts and disk usage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CacheStats {
+    pub root: PathBuf,
+    pub git: ContentSourceStats,
+    pub registry: ContentSourceStats,
+    pub local: ContentSourceStats,
+}
+
+impl CacheStats {
+    /// The stats for one [`ContentSourceKind`].
+    pub fn for_kind(&self, kind: ContentSourceKind) -> ContentSourceStats {
+        match kind {
+            ContentSourceKind::Git => self.git,
+            ContentSourceKind::Registry => self.registry,
+            ContentSourceKind::Local => self.local,
+        }
+    }
+
+    /// Entry counts and bytes summed across all three kinds.
+    pub fn total(&self) -> ContentSourceStats {
+        ContentSourceStats {
+            entry_count: self.git.entry_count + self.registry.entry_count + self.local.entry_count,
+            total_bytes: self.git.total_bytes + self.registry.total_bytes + self.local.total_bytes,
+        }
+    }
+}
+
+/// Result of `fastskill cache clean` (PRD 006, US-006): content entries
+/// removed and bytes reclaimed. Never covers `index/` — see
+/// [`SkillCache::clean`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CleanReport {
+    pub entries_removed: usize,
+    pub bytes_reclaimed: u64,
+}
+
+/// The on-disk, machine-global skill cache (PRD 006 / RFQ 004). The single
+/// seam through which any code reads or writes cached skill content and
+/// index data — see the module docs for the on-disk layout and safety
+/// properties.
+#[derive(Debug, Clone)]
+pub struct SkillCache {
+    root: PathBuf,
+}
+
+impl SkillCache {
+    /// Construct a cache rooted at an explicit directory.
+    ///
+    /// Prefer this in tests — pointed at a `tempfile::TempDir` — over
+    /// [`SkillCache::from_env`]: `FASTSKILL_CACHE_DIR` is process-global, so
+    /// asserting on its resolution races against any other test in the same
+    /// process that also touches it. Test env-var resolution itself
+    /// separately (see `resolve_root`'s tests) rather than through this
+    /// constructor.
+    pub fn at_root(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Construct a cache rooted at [`SkillCache::resolve_root`] (env
+    /// override or the platform cache dir). What production call sites use.
+    pub fn from_env() -> Result<Self, ServiceError> {
+        Ok(Self::at_root(Self::resolve_root()?))
+    }
+
+    /// Resolve the cache root: `FASTSKILL_CACHE_DIR` if set to a non-blank
+    /// value, else the platform cache dir (`dirs::cache_dir()/fastskill`,
+    /// e.g. `~/.cache/fastskill` on Linux).
+    pub fn resolve_root() -> Result<PathBuf, ServiceError> {
+        if let Ok(dir) = std::env::var(FASTSKILL_CACHE_DIR_ENV) {
+            if !dir.trim().is_empty() {
+                return Ok(PathBuf::from(dir));
+            }
+        }
+        dirs::cache_dir()
+            .map(|d| d.join("fastskill"))
+            .ok_or_else(|| {
+                ServiceError::Config(format!(
+                    "could not determine the platform cache directory on this platform; set \
+                 {FASTSKILL_CACHE_DIR_ENV} to override"
+                ))
+            })
+    }
+
+    /// The cache root this instance is rooted at.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Look up `identity` in the content cache.
+    ///
+    /// Returns `None` on a miss, including when the identity is present but
+    /// not yet fully published — a torn/in-progress `put` never lives at the
+    /// final path (see module docs) — and also degrades I/O errors (e.g. a
+    /// permission problem reading the cache root) to a miss, since it is
+    /// always safe to treat a cache as absent and re-fetch.
+    pub fn get(&self, identity: &CacheIdentity) -> Option<CachedContent> {
+        let rel = identity.relative_path().ok()?;
+        let path = self.root.join(rel);
+        if path.is_dir() {
+            Some(CachedContent {
+                identity: identity.clone(),
+                path,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Publish `source_dir`'s contents into the cache under `identity`.
+    ///
+    /// Crash/concurrency-safe: `source_dir` is first copied into a private
+    /// staging directory under `<root>/tmp/`, then published with a single
+    /// atomic rename into the identity's final path. If another `put` for
+    /// the same identity has already published — or wins a race against
+    /// this call — this is a harmless no-op that returns the existing entry
+    /// rather than erroring or double-writing.
+    pub fn put(
+        &self,
+        identity: &CacheIdentity,
+        source_dir: &Path,
+    ) -> Result<CachedContent, ServiceError> {
+        let rel = identity.relative_path()?;
+        let final_path = self.root.join(&rel);
+
+        if final_path.is_dir() {
+            // Already cached: a previous put (this process or another)
+            // already published this identity. Harmless no-op.
+            return Ok(CachedContent {
+                identity: identity.clone(),
+                path: final_path,
+            });
+        }
+        if !source_dir.is_dir() {
+            return Err(ServiceError::Validation(format!(
+                "cache put source is not a directory: {}",
+                source_dir.display()
+            )));
+        }
+
+        let staging_root = self.root.join(STAGING_DIR_NAME);
+        fs::create_dir_all(&staging_root)?;
+        if let Err(e) = write_cache_tag(&self.root) {
+            // Cosmetic/self-identification only (see `verify_looks_like_cache_root`,
+            // which does not require it); must never fail a `put`.
+            tracing::warn!("failed to write cache directory tag: {}", e);
+        }
+        let staging = tempfile::Builder::new()
+            .prefix(STAGING_DIR_PREFIX)
+            .tempdir_in(&staging_root)?;
+
+        copy_dir_contents(source_dir, staging.path())?;
+
+        if let Some(parent) = final_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        match publish(staging.path(), &final_path) {
+            Ok(()) => Ok(CachedContent {
+                identity: identity.clone(),
+                path: final_path,
+            }),
+            Err(_) if final_path.is_dir() => {
+                // Lost a race to a concurrent `put` of the same identity —
+                // the other writer already published; treat as a hit
+                // instead of surfacing the rename failure as an error.
+                Ok(CachedContent {
+                    identity: identity.clone(),
+                    path: final_path,
+                })
+            }
+            Err(err) => Err(ServiceError::Io(err)),
+        }
+    }
+
+    // ---- Index read/write APIs. Schema owned by `index`; see its docs. ---
+
+    /// Read `<cache-root>/index/<source>.json`, or `None` if never written.
+    pub fn read_source_index(&self, source: &str) -> Result<Option<SourceIndex>, ServiceError> {
+        index::read_source_index(&self.root, source)
+    }
+
+    /// Atomically write `<cache-root>/index/<source>.json`.
+    pub fn write_source_index(&self, source: &str, idx: &SourceIndex) -> Result<(), ServiceError> {
+        index::write_source_index(&self.root, source, idx)
+    }
+
+    /// Read `<cache-root>/index/git-resolutions.json`, or an empty map if
+    /// never written.
+    pub fn read_git_resolutions(&self) -> Result<GitResolutions, ServiceError> {
+        index::read_git_resolutions(&self.root)
+    }
+
+    /// Atomically write `<cache-root>/index/git-resolutions.json`.
+    pub fn write_git_resolutions(&self, resolutions: &GitResolutions) -> Result<(), ServiceError> {
+        index::write_git_resolutions(&self.root, resolutions)
+    }
+
+    // ---- `fastskill cache info`/`clean` (PRD 006, US-006). --------------
+
+    /// Entry counts and on-disk bytes per [`ContentSourceKind`] (`fastskill
+    /// cache info`). A cache root that has never been used (no `put` has
+    /// ever run) reports all-zero stats rather than erroring.
+    pub fn stats(&self) -> Result<CacheStats, ServiceError> {
+        Ok(CacheStats {
+            root: self.root.clone(),
+            git: self.source_stats(ContentSourceKind::Git)?,
+            registry: self.source_stats(ContentSourceKind::Registry)?,
+            local: self.source_stats(ContentSourceKind::Local)?,
+        })
+    }
+
+    fn source_stats(&self, kind: ContentSourceKind) -> Result<ContentSourceStats, ServiceError> {
+        let dir = self.root.join(kind.dir_name());
+        if !dir.is_dir() {
+            return Ok(ContentSourceStats::default());
+        }
+        let mut stats = ContentSourceStats::default();
+        for leaf in leaf_identity_dirs(&dir, kind.leaf_depth())? {
+            stats.entry_count += 1;
+            stats.total_bytes += dir_size(&leaf)?;
+        }
+        Ok(stats)
+    }
+
+    /// Remove content entries (`fastskill cache clean`): every
+    /// [`ContentSourceKind`] when `source` is `None`, or just the given one.
+    /// Never touches `index/` — an explicit `repos refresh` (US-005) is the
+    /// only thing that invalidates the index cache, per the PRD's "removes
+    /// all content entries" (content, not index) and "Resolved Defaults"
+    /// (index has no v1 TTL/GC of its own). Never touches `tmp/` either:
+    /// that is another process's live staging area, not a content entry.
+    ///
+    /// Safe to run while another fastskill process is fetching (US-001's
+    /// locking + atomic publish already make a concurrent `get`/`put` race
+    /// with a delete safe — worst case the other process's copy-out of a
+    /// just-deleted entry fails and it re-fetches on retry, never a torn or
+    /// corrupt read).
+    ///
+    /// See the module's safety notes (and this function's private helpers)
+    /// for the adversarial argument: `clean` only ever descends into `git/`,
+    /// `registry/`, `local/` under the *resolved* cache root; it refuses
+    /// outright if that root contains anything it does not recognize
+    /// ([`verify_looks_like_cache_root`]); it never follows a symlink while
+    /// walking or deleting ([`leaf_identity_dirs`], [`remove_dir_no_symlinks`]);
+    /// and it re-canonicalizes every entry immediately before deleting it and
+    /// refuses to delete anything that no longer resolves back inside the
+    /// canonical root ([`SkillCache::clean`]'s loop below).
+    pub fn clean(&self, source: Option<ContentSourceKind>) -> Result<CleanReport, ServiceError> {
+        if !self.root.is_dir() {
+            // Nothing has ever been cached here (or it was already cleaned
+            // down to nothing and the root itself removed by something
+            // else): a no-op is the safe, honest outcome, not an error.
+            return Ok(CleanReport::default());
+        }
+        verify_looks_like_cache_root(&self.root)?;
+        // Canonicalized once, up front, as the trust anchor every candidate
+        // deletion below is re-checked against.
+        let canonical_root = self.root.canonicalize()?;
+
+        let kinds: &[ContentSourceKind] = match &source {
+            Some(kind) => std::slice::from_ref(kind),
+            None => &ContentSourceKind::ALL,
+        };
+
+        let mut report = CleanReport::default();
+        for &kind in kinds {
+            let dir = self.root.join(kind.dir_name());
+            if !dir.is_dir() {
+                continue;
+            }
+            for leaf in leaf_identity_dirs(&dir, kind.leaf_depth())? {
+                // Defense in depth: re-resolve the leaf's real path
+                // immediately before deleting it and refuse unless it is
+                // still inside the canonical cache root. Guards against a
+                // symlinked intermediate directory (planted between the
+                // walk above and this delete, or simply missed by the walk)
+                // silently redirecting the delete outside the cache.
+                let canonical_leaf = match leaf.canonicalize() {
+                    Ok(p) => p,
+                    // Vanished since the walk (e.g. a concurrent `clean`, or
+                    // the entry this replaced was just deleted): nothing
+                    // left to reclaim here, not an error.
+                    Err(_) => continue,
+                };
+                if !canonical_leaf.starts_with(&canonical_root) {
+                    tracing::warn!(
+                        "refusing to delete cache entry outside the cache root: {}",
+                        leaf.display()
+                    );
+                    continue;
+                }
+                let size = dir_size(&leaf).unwrap_or(0);
+                remove_dir_no_symlinks(&leaf)?;
+                report.entries_removed += 1;
+                report.bytes_reclaimed += size;
+            }
+        }
+        Ok(report)
+    }
+}
+
+/// Publish a fully-assembled staging directory at `to` via atomic rename.
+///
+/// On Windows, a rename can transiently fail (`PermissionDenied`, a sharing
+/// violation) if another process has briefly opened the source or target —
+/// e.g. an AV scanner or search indexer. Retry a bounded number of times
+/// before giving up. `fs::rename` is atomic on POSIX with no such caveat.
+fn publish(from: &Path, to: &Path) -> io::Result<()> {
+    #[cfg(not(windows))]
+    {
+        fs::rename(from, to)
+    }
+    #[cfg(windows)]
+    {
+        let mut attempt = 0;
+        loop {
+            match fs::rename(from, to) {
+                Ok(()) => return Ok(()),
+                Err(e)
+                    if attempt < WINDOWS_RENAME_MAX_RETRIES
+                        && e.kind() == io::ErrorKind::PermissionDenied =>
+                {
+                    attempt += 1;
+                    std::thread::sleep(WINDOWS_RENAME_RETRY_DELAY);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+}
+
+/// Recursively copy the *contents* of `src` into the already-existing `dst`
+/// directory. Rejects symlink entries — mirrors `install.rs`'s
+/// `copy_dir_recursive` (SEC-4): a symlink inside cached content must not be
+/// silently dereferenced and its target's contents pulled into the cache.
+fn copy_dir_contents(src: &Path, dst: &Path) -> io::Result<()> {
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+
+        if file_type.is_symlink() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("refusing to cache symlink: {}", src_path.display()),
+            ));
+        } else if file_type.is_dir() {
+            fs::create_dir_all(&dst_path)?;
+            copy_dir_contents(&src_path, &dst_path)?;
+        } else {
+            fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Write [`CACHE_TAG_FILE_NAME`] at `root` if it is not already there.
+/// Best-effort self-identification only — see the constant's docs and its
+/// only caller, [`SkillCache::put`].
+fn write_cache_tag(root: &Path) -> io::Result<()> {
+    let tag_path = root.join(CACHE_TAG_FILE_NAME);
+    if tag_path.is_file() {
+        return Ok(());
+    }
+    fs::write(tag_path, CACHE_TAG_CONTENTS)
+}
+
+/// `fastskill cache clean`'s (US-006) first line of defense: refuse to
+/// touch anything unless every entry directly under the resolved cache root
+/// is one this module itself would have created
+/// ([`CACHE_ROOT_ALLOWED_ENTRIES`]). If `FASTSKILL_CACHE_DIR` is
+/// misconfigured to point at, say, a home directory or a project checkout,
+/// that directory will almost certainly contain *something* unrecognized
+/// (`.bashrc`, `Documents`, `src`, ...), and `clean` fails closed before it
+/// ever lists — let alone deletes — anything inside `git/`, `registry/`, or
+/// `local/`.
+fn verify_looks_like_cache_root(root: &Path) -> Result<(), ServiceError> {
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !CACHE_ROOT_ALLOWED_ENTRIES.contains(&name.as_ref()) {
+            return Err(ServiceError::Validation(format!(
+                "refusing to clean '{}': it does not look like a fastskill cache root (found \
+                 unexpected entry '{}'). If this is really your cache directory, remove any \
+                 unrelated files from it first; otherwise check FASTSKILL_CACHE_DIR",
+                root.display(),
+                name,
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Collect every directory exactly `depth` levels below `base` — the leaf
+/// identity directories `stats`/`clean` treat as one content entry (see
+/// [`ContentSourceKind::leaf_depth`]).
+///
+/// Never follows a symlink: a symlinked entry anywhere in the walk is
+/// skipped outright (neither descended into nor returned as a leaf), the
+/// same SEC-4 stance [`copy_dir_contents`] takes for cache *writes*. A
+/// non-directory entry at an intermediate level (unexpected, but not this
+/// function's job to interpret) is likewise skipped rather than errored on.
+fn leaf_identity_dirs(base: &Path, depth: u32) -> Result<Vec<PathBuf>, ServiceError> {
+    let mut out = Vec::new();
+    collect_dirs_at_depth(base, depth, &mut out)?;
+    Ok(out)
+}
+
+fn collect_dirs_at_depth(
+    dir: &Path,
+    depth: u32,
+    out: &mut Vec<PathBuf>,
+) -> Result<(), ServiceError> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() || !file_type.is_dir() {
+            continue;
+        }
+        if depth <= 1 {
+            out.push(entry.path());
+        } else {
+            collect_dirs_at_depth(&entry.path(), depth - 1, out)?;
+        }
+    }
+    Ok(())
+}
+
+/// Recursively sum the size of regular files under `dir`. Symlinks are
+/// skipped rather than followed (mirrors [`copy_dir_contents`]'s stance);
+/// `put` never writes one into the cache, but this stays honest even if
+/// something else did.
+fn dir_size(dir: &Path) -> Result<u64, ServiceError> {
+    let mut total = 0u64;
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            continue;
+        } else if file_type.is_dir() {
+            total += dir_size(&entry.path())?;
+        } else {
+            total += entry.metadata()?.len();
+        }
+    }
+    Ok(total)
+}
+
+/// Recursively delete `dir` and its contents without ever dereferencing a
+/// symlink: a symlink entry is unlinked directly (never followed into its
+/// target), matching [`copy_dir_contents`]'s SEC-4 stance for cache writes.
+/// `dir` itself must not be a symlink (callers only ever pass leaves found
+/// by [`leaf_identity_dirs`], which already excludes symlinked entries).
+///
+/// Deliberately does not use `std::fs::remove_dir_all`: this walks and
+/// unlinks entries itself so the "never follow a symlink" guarantee is
+/// explicit and auditable here rather than resting on `remove_dir_all`'s
+/// platform-specific internals.
+fn remove_dir_no_symlinks(dir: &Path) -> Result<(), ServiceError> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_symlink() {
+            fs::remove_file(&path)?;
+        } else if file_type.is_dir() {
+            remove_dir_no_symlinks(&path)?;
+        } else {
+            fs::remove_file(&path)?;
+        }
+    }
+    fs::remove_dir(dir)?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use tempfile::TempDir;
+
+    fn write_file(dir: &Path, name: &str, contents: &str) {
+        std::fs::write(dir.join(name), contents).unwrap();
+    }
+
+    /// A small, realistic skill directory used as a `put` source.
+    fn sample_source_dir(root: &Path) -> PathBuf {
+        let src = root.join("source");
+        std::fs::create_dir_all(src.join("nested")).unwrap();
+        write_file(&src, "SKILL.md", "---\nname: demo\n---\nbody\n");
+        write_file(&src.join("nested"), "helper.py", "print('hi')\n");
+        src
+    }
+
+    #[test]
+    fn get_misses_when_identity_never_put() {
+        let root = TempDir::new().unwrap();
+        let cache = SkillCache::at_root(root.path());
+        let identity = CacheIdentity::Git {
+            sha: "deadbeef".to_string(),
+        };
+
+        assert!(cache.get(&identity).is_none());
+    }
+
+    #[test]
+    fn put_then_get_is_a_hit_with_matching_content() {
+        let root = TempDir::new().unwrap();
+        let cache = SkillCache::at_root(root.path());
+        let source = sample_source_dir(root.path());
+        let identity = CacheIdentity::Registry {
+            source: "acme".to_string(),
+            skill: "demo".to_string(),
+            version: "1.0.0".to_string(),
+        };
+
+        let put = cache.put(&identity, &source).unwrap();
+        assert!(put.path.is_dir());
+        assert_eq!(put.path, root.path().join("registry/acme/demo/1.0.0"));
+
+        let hit = cache
+            .get(&identity)
+            .expect("expected a cache hit after put");
+        assert_eq!(hit.path, put.path);
+        assert_eq!(
+            std::fs::read_to_string(hit.path.join("SKILL.md")).unwrap(),
+            "---\nname: demo\n---\nbody\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(hit.path.join("nested/helper.py")).unwrap(),
+            "print('hi')\n"
+        );
+    }
+
+    /// Env-var resolution logic, tested in isolation (per PRD guidance) so
+    /// no other test's cache-root assumptions can race against it.
+    #[test]
+    fn env_var_override_changes_the_resolved_root() {
+        let dir = TempDir::new().unwrap();
+        let previous = std::env::var(FASTSKILL_CACHE_DIR_ENV).ok();
+
+        std::env::set_var(FASTSKILL_CACHE_DIR_ENV, dir.path());
+        let resolved = SkillCache::resolve_root().unwrap();
+
+        match previous {
+            Some(v) => std::env::set_var(FASTSKILL_CACHE_DIR_ENV, v),
+            None => std::env::remove_var(FASTSKILL_CACHE_DIR_ENV),
+        }
+
+        assert_eq!(resolved, dir.path().to_path_buf());
+    }
+
+    #[test]
+    fn concurrent_duplicate_put_is_a_harmless_noop() {
+        let root = TempDir::new().unwrap();
+        let cache = Arc::new(SkillCache::at_root(root.path()));
+        let source = sample_source_dir(root.path());
+        let identity = CacheIdentity::Local {
+            tree_hash: "abc123".to_string(),
+        };
+
+        let barrier = Arc::new(Barrier::new(2));
+        let handles: Vec<_> = (0..2)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                let source = source.clone();
+                let identity = identity.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    cache.put(&identity, &source)
+                })
+            })
+            .collect();
+
+        let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        for result in &results {
+            assert!(
+                result.is_ok(),
+                "concurrent put must never error: {result:?}"
+            );
+        }
+
+        let paths: Vec<_> = results.into_iter().map(|r| r.unwrap().path).collect();
+        assert_eq!(
+            paths[0], paths[1],
+            "both callers converge on one final path"
+        );
+        assert_eq!(
+            std::fs::read_to_string(paths[0].join("SKILL.md")).unwrap(),
+            "---\nname: demo\n---\nbody\n"
+        );
+
+        // No leftover staging directories after the race resolves.
+        let staging_root = root.path().join(STAGING_DIR_NAME);
+        if staging_root.is_dir() {
+            let leftovers: Vec<_> = std::fs::read_dir(&staging_root).unwrap().collect();
+            assert!(
+                leftovers.is_empty(),
+                "no staging leftovers should remain once a race resolves"
+            );
+        }
+    }
+
+    #[test]
+    fn torn_staged_write_is_never_visible_via_get() {
+        let root = TempDir::new().unwrap();
+        let cache = SkillCache::at_root(root.path());
+        let identity = CacheIdentity::Git {
+            sha: "cafefeed".to_string(),
+        };
+
+        // Simulate a crash between "assembled in staging" and "atomic
+        // rename": content exists on disk, but only inside `tmp/`, never at
+        // the identity's final path.
+        let staging_root = root.path().join(STAGING_DIR_NAME);
+        let torn = staging_root.join(format!("{STAGING_DIR_PREFIX}torn"));
+        std::fs::create_dir_all(&torn).unwrap();
+        write_file(&torn, "SKILL.md", "incomplete\n");
+
+        assert!(cache.get(&identity).is_none());
+        assert!(!root.path().join("git/cafefeed").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn put_rejects_a_symlink_in_the_source_tree() {
+        let root = TempDir::new().unwrap();
+        let cache = SkillCache::at_root(root.path());
+        let source = sample_source_dir(root.path());
+        std::os::unix::fs::symlink(root.path(), source.join("evil-link")).unwrap();
+
+        let identity = CacheIdentity::Local {
+            tree_hash: "haslink".to_string(),
+        };
+
+        assert!(cache.put(&identity, &source).is_err());
+        assert!(cache.get(&identity).is_none());
+    }
+
+    #[test]
+    fn cache_identity_rejects_path_traversal_components() {
+        let identity = CacheIdentity::Registry {
+            source: "../escape".to_string(),
+            skill: "demo".to_string(),
+            version: "1.0.0".to_string(),
+        };
+
+        assert!(identity.relative_path().is_err());
+    }
+
+    // ── `fastskill cache info`/`clean` (PRD 006, US-006) ──────────────────
+
+    /// `put` a small sample skill under `identity`. The source lives in its
+    /// own throwaway temp dir -- never inside `cache`'s root -- so tests
+    /// that go on to call `clean` (which refuses a root containing anything
+    /// it does not recognize) are not tripped up by their own fixture data.
+    fn put_sample(cache: &SkillCache, identity: &CacheIdentity, marker: &str) {
+        let src = TempDir::new().unwrap();
+        write_file(
+            src.path(),
+            "SKILL.md",
+            &format!("---\nname: {marker}\n---\nbody\n"),
+        );
+        cache.put(identity, src.path()).unwrap();
+    }
+
+    #[test]
+    fn stats_on_a_never_used_root_is_all_zero() {
+        let root = TempDir::new().unwrap();
+        // Never call `put`: the root directory itself does not even exist.
+        let cache = SkillCache::at_root(root.path().join("never-created"));
+
+        let stats = cache.stats().unwrap();
+        assert_eq!(stats.git, ContentSourceStats::default());
+        assert_eq!(stats.registry, ContentSourceStats::default());
+        assert_eq!(stats.local, ContentSourceStats::default());
+    }
+
+    #[test]
+    fn stats_counts_entries_and_bytes_per_source_kind() {
+        let root = TempDir::new().unwrap();
+        let cache = SkillCache::at_root(root.path());
+
+        put_sample(
+            &cache,
+            &CacheIdentity::Git {
+                sha: "a".repeat(40),
+            },
+            "git-a",
+        );
+        put_sample(
+            &cache,
+            &CacheIdentity::Registry {
+                source: "acme".to_string(),
+                skill: "demo".to_string(),
+                version: "1.0.0".to_string(),
+            },
+            "reg-a",
+        );
+        put_sample(
+            &cache,
+            &CacheIdentity::Registry {
+                source: "acme".to_string(),
+                skill: "demo".to_string(),
+                version: "2.0.0".to_string(),
+            },
+            "reg-b",
+        );
+        put_sample(
+            &cache,
+            &CacheIdentity::Local {
+                tree_hash: "deadbeef".to_string(),
+            },
+            "local-a",
+        );
+
+        let stats = cache.stats().unwrap();
+        assert_eq!(stats.git.entry_count, 1);
+        assert_eq!(stats.registry.entry_count, 2);
+        assert_eq!(stats.local.entry_count, 1);
+        assert!(stats.git.total_bytes > 0);
+        assert!(stats.registry.total_bytes > 0);
+        assert!(stats.local.total_bytes > 0);
+        assert_eq!(stats.total().entry_count, 4);
+    }
+
+    #[test]
+    fn clean_with_no_source_filter_removes_every_kind_but_not_the_index() {
+        let root = TempDir::new().unwrap();
+        let cache = SkillCache::at_root(root.path());
+
+        put_sample(
+            &cache,
+            &CacheIdentity::Git {
+                sha: "b".repeat(40),
+            },
+            "git-b",
+        );
+        put_sample(
+            &cache,
+            &CacheIdentity::Local {
+                tree_hash: "cafef00d".to_string(),
+            },
+            "local-b",
+        );
+        cache
+            .write_source_index(
+                "acme",
+                &SourceIndex {
+                    fetched_at: chrono::Utc::now(),
+                    entries: vec![],
+                },
+            )
+            .unwrap();
+
+        let report = cache.clean(None).unwrap();
+        assert_eq!(report.entries_removed, 2);
+        assert!(report.bytes_reclaimed > 0);
+
+        let stats_after = cache.stats().unwrap();
+        assert_eq!(stats_after.total(), ContentSourceStats::default());
+        // The index cache is untouched by `clean` (PRD: "removes all content
+        // entries" -- content, not index).
+        assert!(cache.read_source_index("acme").unwrap().is_some());
+    }
+
+    #[test]
+    fn clean_with_source_filter_only_removes_that_kind() {
+        let root = TempDir::new().unwrap();
+        let cache = SkillCache::at_root(root.path());
+
+        put_sample(
+            &cache,
+            &CacheIdentity::Git {
+                sha: "c".repeat(40),
+            },
+            "git-c",
+        );
+        put_sample(
+            &cache,
+            &CacheIdentity::Local {
+                tree_hash: "0ff1ce".to_string(),
+            },
+            "local-c",
+        );
+
+        let report = cache.clean(Some(ContentSourceKind::Git)).unwrap();
+        assert_eq!(report.entries_removed, 1);
+
+        let stats_after = cache.stats().unwrap();
+        assert_eq!(stats_after.git, ContentSourceStats::default());
+        assert_eq!(stats_after.local.entry_count, 1, "local entry untouched");
+    }
+
+    #[test]
+    fn clean_on_a_never_used_root_is_a_harmless_noop() {
+        let root = TempDir::new().unwrap();
+        let cache = SkillCache::at_root(root.path().join("never-created"));
+
+        let report = cache.clean(None).unwrap();
+        assert_eq!(report, CleanReport::default());
+    }
+
+    #[test]
+    fn clean_refuses_a_root_that_does_not_look_like_a_fastskill_cache() {
+        let root = TempDir::new().unwrap();
+        // Simulate `FASTSKILL_CACHE_DIR` misconfigured to point at a real,
+        // unrelated directory (e.g. a home directory) rather than an actual
+        // cache root.
+        std::fs::write(root.path().join("Documents.txt"), "not a cache").unwrap();
+        let cache = SkillCache::at_root(root.path());
+
+        let err = cache
+            .clean(None)
+            .expect_err("clean must refuse a root with unrecognized entries");
+        assert!(matches!(err, ServiceError::Validation(_)));
+        // Nothing was touched.
+        assert!(root.path().join("Documents.txt").is_file());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn clean_never_follows_or_deletes_through_a_symlinked_entry() {
+        let root = TempDir::new().unwrap();
+        let cache = SkillCache::at_root(root.path());
+
+        // A real, legitimately cached entry.
+        put_sample(
+            &cache,
+            &CacheIdentity::Local {
+                tree_hash: "realentry".to_string(),
+            },
+            "local-real",
+        );
+
+        // A directory *outside* the cache root that a symlink could redirect
+        // deletion into, plus a sentinel file inside it.
+        let outside = TempDir::new().unwrap();
+        std::fs::write(outside.path().join("sentinel.txt"), "do not delete me").unwrap();
+
+        // Plant a symlink directly under `git/` masquerading as a cached SHA
+        // entry, pointing at the directory outside the cache root.
+        let git_dir = root.path().join("git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+        std::os::unix::fs::symlink(outside.path(), git_dir.join("evilsha")).unwrap();
+
+        let report = cache.clean(None).unwrap();
+
+        // The symlink itself is never treated as a leaf identity directory
+        // (skipped, not deleted, not followed) -- only the one real local
+        // entry is counted.
+        assert_eq!(report.entries_removed, 1);
+        assert!(
+            outside.path().join("sentinel.txt").is_file(),
+            "clean must never delete through a symlink outside the cache root"
+        );
+        assert!(
+            git_dir.join("evilsha").exists(),
+            "the symlink entry itself is left alone, not silently deleted"
+        );
+    }
+
+    #[test]
+    fn content_source_kind_from_str_round_trips_and_rejects_unknown() {
+        use std::str::FromStr;
+        assert_eq!(
+            ContentSourceKind::from_str("git").unwrap(),
+            ContentSourceKind::Git
+        );
+        assert_eq!(
+            ContentSourceKind::from_str("registry").unwrap(),
+            ContentSourceKind::Registry
+        );
+        assert_eq!(
+            ContentSourceKind::from_str("local").unwrap(),
+            ContentSourceKind::Local
+        );
+        assert!(ContentSourceKind::from_str("../etc").is_err());
+        assert!(ContentSourceKind::from_str("bogus").is_err());
+    }
+}

--- a/crates/fastskill-core/src/core/install.rs
+++ b/crates/fastskill-core/src/core/install.rs
@@ -6,6 +6,7 @@
 //! skills dir → upsert Manifest → write Lock → reindex-if-provider). `mode` only
 //! governs the id-conflict policy. `add`/`update` are one operation.
 
+use crate::core::cache::{CacheIdentity, SkillCache, SourceIndex, SourceIndexEntry};
 use crate::core::lock::{project_lock_path, ProjectSkillsLock};
 use crate::core::manifest::{
     DependenciesSection, DependencySpec, ProjectContext, SkillProjectToml,
@@ -17,8 +18,10 @@ use crate::core::repository::RepositoryManager;
 use crate::core::service::{FastSkillService, ServiceError, SkillId};
 use crate::core::skill_manager::SkillDefinition;
 use crate::core::version::{is_newer, newest_version, VersionConstraint};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tempfile::TempDir;
 
 /// Whether an install is a fresh add (409 on an existing id) or an update
@@ -113,7 +116,48 @@ impl FastSkillService {
             }
         };
 
-        let temp_dir = crate::storage::git::clone_repository(url, branch, tag, None).await?;
+        // PRD 006 / RFQ 004 (US-002): resolve the ref to a SHA before deciding
+        // whether to clone at all, so a repeat install of the same commit — even
+        // from a different project — never re-clones.
+        let cache = self.skill_cache();
+        let ref_key = git_ref_cache_key(git_ref);
+        let resolved_sha = resolve_git_sha(cache, url, &ref_key, branch, tag).await?;
+
+        let (temp_dir, commit_hash) = if let Some(cached) = cache.get(&CacheIdentity::Git {
+            sha: resolved_sha.clone(),
+        }) {
+            // Cache hit: copy the previously-cloned content out of the
+            // (immutable, shared) cache entry rather than cloning again.
+            let temp_dir = TempDir::new()?;
+            copy_dir_recursive(&cached.path, temp_dir.path()).await?;
+            (temp_dir, resolved_sha)
+        } else {
+            // Miss: clone as before. The commit actually landed on is the
+            // source of truth for both the cache key and the recorded
+            // resolved fact — it may differ from `resolved_sha` if the ref
+            // moved between the `ls_remote` above and this clone (a race,
+            // not an error); using it here self-heals the index instead of
+            // caching under a now-stale SHA.
+            let temp_dir = crate::storage::git::clone_repository(url, branch, tag, None).await?;
+            let actual_sha = git_head_commit(temp_dir.path()).await?;
+
+            if let Err(e) = cache.put(
+                &CacheIdentity::Git {
+                    sha: actual_sha.clone(),
+                },
+                temp_dir.path(),
+            ) {
+                // The clone already succeeded and is usable; a cache-write
+                // failure only costs this run the "install once per
+                // machine" win, so it must not fail the install.
+                tracing::warn!("failed to publish git clone to content cache: {}", e);
+            }
+            if let Err(e) = record_git_resolution(cache, url, &ref_key, &actual_sha) {
+                tracing::warn!("failed to record git ref resolution: {}", e);
+            }
+
+            (temp_dir, actual_sha)
+        };
 
         let skill_base = if let Some(subdir) = subdir {
             let joined = safe_subdir_join(temp_dir.path(), subdir)?;
@@ -129,7 +173,6 @@ impl FastSkillService {
         };
         let skill_path = crate::storage::git::validate_cloned_skill(&skill_base)?;
 
-        let commit_hash = git_head_commit(temp_dir.path()).await?;
         let frontmatter = read_skill_frontmatter(&skill_path).await?;
         let (_, version) = derive_skill_id_and_version(&skill_path, &frontmatter)?;
 
@@ -162,24 +205,18 @@ impl FastSkillService {
             && resolved_path.extension().and_then(|e| e.to_str()) == Some("zip");
 
         let skill_path = if is_zip {
-            let extract_path = temp_dir.path().join("extracted");
-            tokio::fs::create_dir_all(&extract_path).await?;
-            let zip_handler = crate::storage::zip::ZipHandler::new()?;
-            zip_handler.extract_to_dir(&resolved_path, &extract_path)?;
-            crate::storage::git::validate_cloned_skill(&extract_path)?
+            // A `.zip` is always extracted (never symlinked), matching the
+            // pre-cache behavior where `editable` had no effect on a zip
+            // source: there is no "live" directory to point a symlink at.
+            fetch_local_zip(self.skill_cache(), &resolved_path, temp_dir.path()).await?
         } else if editable {
+            // FR-7: an editable install bypasses the content cache entirely.
             // `commit` will symlink this path in place; the original directory
             // must survive untouched (it stays the live, user-owned source), so
             // `skill_path` points straight at it rather than a temp-dir copy.
             crate::storage::git::validate_cloned_skill(&resolved_path)?
         } else {
-            // Non-editable directory: copy into the (throwaway) temp dir so
-            // `commit`'s atomic-move step consumes the copy, never the caller's
-            // original source directory.
-            let validated_source = crate::storage::git::validate_cloned_skill(&resolved_path)?;
-            let copy_dest = temp_dir.path().join("copied");
-            copy_dir_recursive(&validated_source, &copy_dest).await?;
-            copy_dest
+            fetch_local_dir(self.skill_cache(), &resolved_path, temp_dir.path()).await?
         };
 
         let frontmatter = read_skill_frontmatter(&skill_path).await?;
@@ -247,42 +284,58 @@ impl FastSkillService {
             )
         })?;
         let repo_name = resolve_repo_name(repo_manager, repo)?;
-        let client = repo_manager.get_client(&repo_name).await?;
+        let cache = self.skill_cache();
 
-        let available = client
-            .get_versions(skill)
-            .await
-            .map_err(|e| ServiceError::Config(format!("Failed to get versions: {e}")))?;
-        let candidates: Vec<String> = match version {
-            Some(constraint) => available
-                .into_iter()
-                .filter(|v| constraint.satisfies(v).unwrap_or(false))
-                .collect(),
-            None => available,
+        // PRD 006 / RFQ 004 (US-003): resolve to a concrete version before
+        // touching the network at all. An exact pin needs no listing —
+        // `resolved_version` is already known — so the offline "a pinned,
+        // cached version installs with no network" criterion holds even
+        // before the content-cache check below. `newest`/a range constraint
+        // resolves via the on-disk index `repos refresh` populates (US-005),
+        // not a live listing call.
+        let resolved_version = resolve_registry_version(cache, &repo_name, skill, version)?;
+
+        let identity = CacheIdentity::Registry {
+            source: repo_name.clone(),
+            skill: skill.to_string(),
+            version: resolved_version.clone(),
         };
-        let resolved_version = newest_version(&candidates).ok_or_else(|| {
-            ServiceError::Config(format!(
-                "No version of '{skill}' satisfies the requested constraint in repository \
-                 '{repo_name}'"
-            ))
-        })?;
-
-        let zip_data = client
-            .download(skill, &resolved_version)
-            .await
-            .map_err(|e| ServiceError::Config(format!("Failed to download package: {e}")))?;
 
         let temp_dir = TempDir::new()?;
-        let extract_path = temp_dir.path().join("extracted");
-        tokio::fs::create_dir_all(&extract_path).await?;
-        let zip_path = temp_dir
-            .path()
-            .join(format!("package-{resolved_version}.zip"));
-        tokio::fs::write(&zip_path, &zip_data).await?;
+        let skill_path = if let Some(cached) = cache.get(&identity) {
+            // Cache hit: copy the previously-downloaded skill out of the
+            // (immutable, shared) cache entry rather than downloading again.
+            let dest = temp_dir.path().join("cached");
+            copy_dir_recursive(&cached.path, &dest).await?;
+            crate::storage::git::validate_cloned_skill(&dest)?
+        } else {
+            // Miss: download and extract as before, then publish into the
+            // content cache under the resolved version's identity.
+            let client = repo_manager.get_client(&repo_name).await?;
+            let zip_data = client
+                .download(skill, &resolved_version)
+                .await
+                .map_err(|e| ServiceError::Config(format!("Failed to download package: {e}")))?;
 
-        let zip_handler = crate::storage::zip::ZipHandler::new()?;
-        zip_handler.extract_to_dir(&zip_path, &extract_path)?;
-        let skill_path = crate::storage::git::validate_cloned_skill(&extract_path)?;
+            let extract_path = temp_dir.path().join("extracted");
+            tokio::fs::create_dir_all(&extract_path).await?;
+            let zip_path = temp_dir
+                .path()
+                .join(format!("package-{resolved_version}.zip"));
+            tokio::fs::write(&zip_path, &zip_data).await?;
+
+            let zip_handler = crate::storage::zip::ZipHandler::new()?;
+            zip_handler.extract_to_dir(&zip_path, &extract_path)?;
+            let skill_path = crate::storage::git::validate_cloned_skill(&extract_path)?;
+
+            if let Err(e) = cache.put(&identity, &skill_path) {
+                // The download already succeeded and is usable; a cache-write
+                // failure only costs this run the "download once per
+                // machine" win, so it must not fail the install.
+                tracing::warn!("failed to publish registry package to content cache: {}", e);
+            }
+            skill_path
+        };
 
         let frontmatter = read_skill_frontmatter(&skill_path).await?;
         // The registry-resolved version selected the package to download; the
@@ -538,6 +591,22 @@ impl FastSkillService {
                     .get_versions(skill)
                     .await
                     .map_err(|e| ServiceError::Config(format!("Failed to get versions: {e}")))?;
+
+                // PRD 006 (US-003, "Resolved Defaults": update implicitly
+                // refreshes just the sources it touches). This listing call
+                // already reached the network for the preflight decision below;
+                // persist it into the on-disk index so a same-invocation
+                // `add_from_origin(.., AddMode::Update, ..)` for a `newest`/range
+                // origin resolves through the content-cache path (US-003)
+                // instead of requiring a separate `repos refresh` the caller
+                // never ran. Best-effort: a write failure must not fail the
+                // preflight, which has already succeeded.
+                if let Err(e) =
+                    upsert_source_index_entry(self.skill_cache(), &repo_name, skill, &available)
+                {
+                    tracing::warn!("failed to update cached index for '{repo_name}': {}", e);
+                }
+
                 let candidates: Vec<String> = match version {
                     Some(constraint) => available
                         .into_iter()
@@ -587,6 +656,92 @@ fn resolve_repo_name(repo_manager: &RepositoryManager, repo: &str) -> Result<Str
     } else {
         Ok(repo.to_string())
     }
+}
+
+/// Resolve `(repo_name, skill, version)` to a concrete version string (PRD 006
+/// "Local Skill Cache", US-003), without ever calling the registry's live
+/// listing endpoint:
+///
+/// - An exact pin (bare `1.2.3`, or explicit `=1.2.3`) needs no listing at
+///   all — it *is* the resolved version. This is what makes "a pinned, cached
+///   version installs with no network" possible.
+/// - `None` ("newest") or a range constraint (`^`, `~`, `>=`, ...) resolves
+///   against the on-disk [`crate::core::cache::SourceIndex`] that `repos
+///   refresh` populates (US-005) — never a live call. With no cached index
+///   (or no matching entry/candidate), fails with an error naming `repos
+///   refresh` rather than silently falling back to the network.
+fn resolve_registry_version(
+    cache: &SkillCache,
+    repo_name: &str,
+    skill: &str,
+    version: Option<&VersionConstraint>,
+) -> Result<String, ServiceError> {
+    if let Some(exact) = version.and_then(VersionConstraint::as_exact) {
+        return Ok(exact);
+    }
+
+    let idx = cache.read_source_index(repo_name)?.ok_or_else(|| {
+        ServiceError::Config(format!(
+            "no cached index for repository '{repo_name}'; run `fastskill repos refresh \
+             {repo_name}` to resolve the newest version of '{skill}'"
+        ))
+    })?;
+    let entry = idx
+        .entries
+        .iter()
+        .find(|e| e.skill == skill)
+        .ok_or_else(|| {
+            ServiceError::Config(format!(
+                "skill '{skill}' not found in the cached index for repository '{repo_name}'; run \
+             `fastskill repos refresh {repo_name}` to refresh it"
+            ))
+        })?;
+    let candidates: Vec<String> = match version {
+        Some(constraint) => entry
+            .versions
+            .iter()
+            .filter(|v| constraint.satisfies(v).unwrap_or(false))
+            .cloned()
+            .collect(),
+        None => entry.versions.clone(),
+    };
+    newest_version(&candidates).ok_or_else(|| {
+        ServiceError::Config(format!(
+            "no version of '{skill}' in the cached index for repository '{repo_name}' satisfies \
+             the requested constraint; run `fastskill repos refresh {repo_name}` to refresh it"
+        ))
+    })
+}
+
+/// Upsert a single skill's versions into the on-disk [`SourceIndex`] for
+/// `repo_name`, leaving every other entry untouched (PRD 006 US-003,
+/// "Resolved Defaults": `update` implicitly refreshes just the sources it
+/// touches). Used by [`FastSkillService::preflight`]'s `Origin::Repository`
+/// branch to persist a listing call it already made live, so a
+/// same-invocation update can resolve through the index instead of needing a
+/// separate `repos refresh`.
+fn upsert_source_index_entry(
+    cache: &SkillCache,
+    repo_name: &str,
+    skill: &str,
+    versions: &[String],
+) -> Result<(), ServiceError> {
+    let mut idx = cache
+        .read_source_index(repo_name)?
+        .unwrap_or_else(|| SourceIndex {
+            fetched_at: chrono::Utc::now(),
+            entries: Vec::new(),
+        });
+    idx.fetched_at = chrono::Utc::now();
+    if let Some(entry) = idx.entries.iter_mut().find(|e| e.skill == skill) {
+        entry.versions = versions.to_vec();
+    } else {
+        idx.entries.push(SourceIndexEntry {
+            skill: skill.to_string(),
+            versions: versions.to_vec(),
+        });
+    }
+    cache.write_source_index(repo_name, &idx)
 }
 
 /// Read and parse `SKILL.md`'s frontmatter from a fetched skill directory.
@@ -688,13 +843,228 @@ fn safe_subdir_join(root: &Path, subdir: &Path) -> Result<PathBuf, ServiceError>
     Ok(joined)
 }
 
+/// A stable string key for a [`GitRef`] within the git-resolutions index,
+/// combined with `url` by [`crate::core::cache::GitResolutions`]. Not
+/// `GitRef`'s `Display` (it has none). The `Default`/`Branch`/`Tag` arms
+/// delegate to [`crate::core::cache::GitResolutions::branch_or_tag_key`] — the
+/// single place that encoding lives — so this stays interchangeable with the
+/// resolutions `repos refresh` records (PRD 006, US-005). `Commit` has no
+/// branch/tag form and is encoded here, its only caller.
+fn git_ref_cache_key(git_ref: &GitRef) -> String {
+    match git_ref {
+        GitRef::Default => crate::core::cache::GitResolutions::branch_or_tag_key(None, None),
+        GitRef::Branch(b) => crate::core::cache::GitResolutions::branch_or_tag_key(Some(b), None),
+        GitRef::Tag(t) => crate::core::cache::GitResolutions::branch_or_tag_key(None, Some(t)),
+        GitRef::Commit(c) => format!("commit:{c}"),
+    }
+}
+
+/// Resolve `url`+`ref_key` (via `branch`/`tag`) to a commit SHA (PRD 006, US-002).
+///
+/// Prefers a live [`crate::storage::git::ls_remote`] and records the result. If
+/// that fails — offline, DNS down, etc. — and a previous resolution for the
+/// same `url`+`ref_key` is recorded in the index cache, proceeds from it with a
+/// warning instead of failing outright; with no prior resolution, propagates
+/// the `ls_remote` error as-is (today's error).
+async fn resolve_git_sha(
+    cache: &SkillCache,
+    url: &str,
+    ref_key: &str,
+    branch: Option<&str>,
+    tag: Option<&str>,
+) -> Result<String, ServiceError> {
+    match crate::storage::git::ls_remote(url, branch, tag).await {
+        Ok(sha) => {
+            if let Err(e) = record_git_resolution(cache, url, ref_key, &sha) {
+                tracing::warn!("failed to record git ref resolution: {}", e);
+            }
+            Ok(sha)
+        }
+        Err(err) => {
+            let resolutions = cache.read_git_resolutions()?;
+            match resolutions.get(url, ref_key) {
+                Some(resolution) => {
+                    tracing::warn!(
+                        "could not resolve the latest commit for '{url}' ({err}); using the \
+                         resolution cached on {resolved_at} instead: {sha}",
+                        resolved_at = resolution.resolved_at,
+                        sha = resolution.sha,
+                    );
+                    Ok(resolution.sha.clone())
+                }
+                None => Err(err),
+            }
+        }
+    }
+}
+
+/// Record a successful `url`+`ref_key -> sha` resolution in the git-resolutions
+/// index, so a later offline install of the same ref can fall back to it.
+fn record_git_resolution(
+    cache: &SkillCache,
+    url: &str,
+    ref_key: &str,
+    sha: &str,
+) -> Result<(), ServiceError> {
+    let mut resolutions = cache.read_git_resolutions()?;
+    resolutions.insert(url, ref_key, sha.to_string(), chrono::Utc::now());
+    cache.write_git_resolutions(&resolutions)
+}
+
+// ── Local origin content cache (PRD 006 "Local Skill Cache", US-004) ──────────
+
+/// Number of times a local-origin fetch actually copied from the original
+/// source directory or extracted a `.zip` (rather than reusing the content
+/// cache). Instrumentation-only, kept for the same reason as
+/// `storage::git::CLONE_INVOCATIONS` / `registry::client::DOWNLOAD_INVOCATIONS`:
+/// proving a cache hit skipped the expensive step is otherwise only
+/// observable by timing. Deliberately not gated behind `#[cfg(test)]` —
+/// integration tests are a separate compilation unit and cannot see items
+/// scoped that way.
+#[doc(hidden)] // test instrumentation, not supported public API
+pub static LOCAL_COPY_INVOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+/// Fetch a non-editable, non-zip local directory through the content cache
+/// (US-004): hash the validated skill directory's tree, check the cache under
+/// that identity, and either copy the cached content out or copy from the
+/// source and `put` it for next time.
+async fn fetch_local_dir(
+    cache: &SkillCache,
+    resolved_path: &Path,
+    temp_dir: &Path,
+) -> Result<PathBuf, ServiceError> {
+    let validated_source = crate::storage::git::validate_cloned_skill(resolved_path)?;
+    let identity = CacheIdentity::Local {
+        tree_hash: compute_local_tree_hash(&validated_source)?,
+    };
+
+    if let Some(cached) = cache.get(&identity) {
+        let dest = temp_dir.join("cached");
+        copy_dir_recursive(&cached.path, &dest).await?;
+        return crate::storage::git::validate_cloned_skill(&dest);
+    }
+
+    LOCAL_COPY_INVOCATIONS.fetch_add(1, Ordering::SeqCst);
+    let dest = temp_dir.join("copied");
+    copy_dir_recursive(&validated_source, &dest).await?;
+    if let Err(e) = cache.put(&identity, &dest) {
+        // The copy already succeeded and is usable; a cache-write failure
+        // only costs this run the "install once per machine" win, so it must
+        // not fail the install.
+        tracing::warn!("failed to publish local source to content cache: {}", e);
+    }
+    Ok(dest)
+}
+
+/// Fetch a non-editable local `.zip` path through the content cache (US-004).
+/// Per FR-6's sibling rule for this story, a `.zip` is cached by the bytes of
+/// the archive itself, not a tree walk of its extracted contents — the
+/// archive's own bytes are its identity.
+async fn fetch_local_zip(
+    cache: &SkillCache,
+    resolved_path: &Path,
+    temp_dir: &Path,
+) -> Result<PathBuf, ServiceError> {
+    let bytes = tokio::fs::read(resolved_path).await?;
+    let identity = CacheIdentity::Local {
+        tree_hash: hash_bytes(&bytes),
+    };
+
+    if let Some(cached) = cache.get(&identity) {
+        let dest = temp_dir.join("cached");
+        copy_dir_recursive(&cached.path, &dest).await?;
+        return crate::storage::git::validate_cloned_skill(&dest);
+    }
+
+    LOCAL_COPY_INVOCATIONS.fetch_add(1, Ordering::SeqCst);
+    let extract_path = temp_dir.join("extracted");
+    tokio::fs::create_dir_all(&extract_path).await?;
+    let zip_handler = crate::storage::zip::ZipHandler::new()?;
+    zip_handler.extract_to_dir(resolved_path, &extract_path)?;
+    let skill_path = crate::storage::git::validate_cloned_skill(&extract_path)?;
+    if let Err(e) = cache.put(&identity, &skill_path) {
+        tracing::warn!(
+            "failed to publish local zip contents to content cache: {}",
+            e
+        );
+    }
+    Ok(skill_path)
+}
+
+/// Compute a deterministic tree-hash of a validated skill directory (US-004):
+/// every regular file's path (relative to `root`, with path separators
+/// normalized to `/` so the hash is stable across platforms) and its content
+/// bytes feed a SHA-256 digest, in a fixed (lexicographically sorted by
+/// relative path) order so directory-read order never affects the result.
+/// File mtimes and permissions are never read, so touching a file without
+/// changing its content produces the same hash. Rejects symlinks (mirrors
+/// `copy_dir_recursive`'s SEC-4 stance): a symlink inside the source tree
+/// must not be silently dereferenced and hashed by its target's contents.
+fn compute_local_tree_hash(root: &Path) -> Result<String, ServiceError> {
+    let mut entries = collect_tree_entries(root, root)?;
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut hasher = Sha256::new();
+    for (rel_path, content) in &entries {
+        // Length-prefix each field so no concatenation of adjacent
+        // path/content bytes can collide across different (path, content)
+        // splits.
+        hasher.update((rel_path.len() as u64).to_le_bytes());
+        hasher.update(rel_path.as_bytes());
+        hasher.update((content.len() as u64).to_le_bytes());
+        hasher.update(content);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Recursively collect `(relative_path, content)` pairs for every regular
+/// file under `dir`, relative to `root` with `/`-normalized separators.
+fn collect_tree_entries(dir: &Path, root: &Path) -> Result<Vec<(String, Vec<u8>)>, ServiceError> {
+    let mut entries = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+
+        if file_type.is_symlink() {
+            return Err(ServiceError::Validation(format!(
+                "refusing to hash symlink: {}",
+                path.display()
+            )));
+        } else if file_type.is_dir() {
+            entries.extend(collect_tree_entries(&path, root)?);
+        } else {
+            let rel = path
+                .strip_prefix(root)
+                .map_err(|e| ServiceError::Custom(format!("path escaped its root: {e}")))?;
+            let rel_str = rel
+                .components()
+                .map(|c| c.as_os_str().to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+                .join("/");
+            let content = std::fs::read(&path)?;
+            entries.push((rel_str, content));
+        }
+    }
+    Ok(entries)
+}
+
+/// SHA-256 hex digest of raw bytes.
+fn hash_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
 /// Resolve `HEAD`'s commit SHA in a freshly-cloned git repository.
 async fn git_head_commit(repo_dir: &Path) -> Result<String, ServiceError> {
-    let output = tokio::process::Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .current_dir(repo_dir)
-        .output()
-        .await?;
+    let mut cmd = tokio::process::Command::new("git");
+    cmd.args(["rev-parse", "HEAD"]).current_dir(repo_dir);
+    // `GIT_DIR` beats `current_dir`, so without this a fastskill run nested
+    // inside another git invocation (a hook, `rebase --exec`) would report the
+    // *enclosing* repo's HEAD as the commit we just cloned.
+    crate::storage::git::scrub_inherited_git_env(&mut cmd);
+    let output = cmd.output().await?;
     if !output.status.success() {
         return Err(ServiceError::Custom(format!(
             "git rev-parse HEAD failed: {}",
@@ -1322,6 +1692,367 @@ mod tests {
         copy_dir_recursive(&src, &dst).await.unwrap();
         assert!(dst.join("SKILL.md").exists());
         assert!(dst.join("nested/file.txt").exists());
+    }
+
+    // ── compute_local_tree_hash / hash_bytes (US-004) ─────────────────────────
+
+    #[test]
+    fn test_tree_hash_stable_across_mtime_touch() {
+        let tmp = TestTempDir::new().unwrap();
+        let src = tmp.path().join("src");
+        std::fs::create_dir_all(src.join("nested")).unwrap();
+        std::fs::write(src.join("SKILL.md"), "---\nname: x\n---\n").unwrap();
+        std::fs::write(src.join("nested/file.txt"), "data").unwrap();
+
+        let before = compute_local_tree_hash(&src).unwrap();
+
+        // Touch the file's mtime only, content untouched.
+        let file = std::fs::File::open(src.join("nested/file.txt")).unwrap();
+        let new_time = std::time::SystemTime::now() + std::time::Duration::from_secs(3600);
+        file.set_modified(new_time).unwrap();
+
+        let after = compute_local_tree_hash(&src).unwrap();
+        assert_eq!(
+            before, after,
+            "touching a file's mtime alone must not change the tree-hash"
+        );
+    }
+
+    #[test]
+    fn test_tree_hash_changes_when_content_changes() {
+        let tmp = TestTempDir::new().unwrap();
+        let src = tmp.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("SKILL.md"), "---\nname: x\n---\nv1\n").unwrap();
+
+        let before = compute_local_tree_hash(&src).unwrap();
+
+        std::fs::write(src.join("SKILL.md"), "---\nname: x\n---\nv2\n").unwrap();
+        let after = compute_local_tree_hash(&src).unwrap();
+
+        assert_ne!(
+            before, after,
+            "changing a file's content must change the tree-hash"
+        );
+    }
+
+    #[test]
+    fn test_tree_hash_independent_of_directory_read_order() {
+        let tmp = TestTempDir::new().unwrap();
+
+        // Same relative paths/contents, written in a different order.
+        let a = tmp.path().join("a");
+        std::fs::create_dir_all(a.join("nested")).unwrap();
+        std::fs::write(a.join("SKILL.md"), "one").unwrap();
+        std::fs::write(a.join("nested/file.txt"), "two").unwrap();
+
+        let b = tmp.path().join("b");
+        std::fs::create_dir_all(b.join("nested")).unwrap();
+        std::fs::write(b.join("nested/file.txt"), "two").unwrap();
+        std::fs::write(b.join("SKILL.md"), "one").unwrap();
+
+        assert_eq!(
+            compute_local_tree_hash(&a).unwrap(),
+            compute_local_tree_hash(&b).unwrap(),
+            "identical (path, content) pairs must hash the same regardless of write/read order"
+        );
+    }
+
+    #[test]
+    fn test_tree_hash_sensitive_to_path_not_just_content() {
+        let tmp = TestTempDir::new().unwrap();
+
+        let a = tmp.path().join("a");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::write(a.join("one.txt"), "same").unwrap();
+
+        let b = tmp.path().join("b");
+        std::fs::create_dir_all(&b).unwrap();
+        std::fs::write(b.join("two.txt"), "same").unwrap();
+
+        assert_ne!(
+            compute_local_tree_hash(&a).unwrap(),
+            compute_local_tree_hash(&b).unwrap(),
+            "renaming a file must change the tree-hash even with identical content"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_tree_hash_rejects_symlink() {
+        use std::os::unix::fs::symlink;
+        let tmp = TestTempDir::new().unwrap();
+        let src = tmp.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("SKILL.md"), "# skill\n").unwrap();
+        let secret = tmp.path().join("secret.txt");
+        std::fs::write(&secret, "TOP SECRET").unwrap();
+        symlink(&secret, src.join("creds")).unwrap();
+
+        let result = compute_local_tree_hash(&src);
+        assert!(matches!(result, Err(ServiceError::Validation(_))));
+    }
+
+    #[test]
+    fn test_hash_bytes_is_deterministic_and_content_sensitive() {
+        let h1 = hash_bytes(b"hello");
+        let h2 = hash_bytes(b"hello");
+        let h3 = hash_bytes(b"world");
+        assert_eq!(h1, h2);
+        assert_ne!(h1, h3);
+    }
+
+    // ── fetch_local: content-cache hit/miss (US-004) ──────────────────────────
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_fetch_local_dir_second_install_hits_cache_not_source() {
+        let _lock = crate::test_utils::DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let (tmp, _guard, skills_dir) = setup_project();
+        let src = write_valid_skill(tmp.path(), "src-skill");
+        let cache_root = TestTempDir::new().unwrap();
+        let config = ServiceConfig {
+            skill_storage_path: skills_dir.clone(),
+            skill_cache_root: Some(cache_root.path().to_path_buf()),
+            ..Default::default()
+        };
+        let mut service = FastSkillService::new(config).await.unwrap();
+        service.initialize().await.unwrap();
+
+        let origin = Origin::Local {
+            path: src.clone(),
+            editable: false,
+        };
+
+        let baseline = LOCAL_COPY_INVOCATIONS.load(Ordering::SeqCst);
+        service
+            .add_from_origin(origin.clone(), AddMode::Fresh, vec![])
+            .await
+            .expect("first add should succeed (cache miss)");
+        assert_eq!(
+            LOCAL_COPY_INVOCATIONS.load(Ordering::SeqCst) - baseline,
+            1,
+            "first install must copy from the source (cache miss)"
+        );
+
+        // Mutate the *original* source path so a re-copy would be observable
+        // as different content -- proving a hit never touches it again.
+        std::fs::write(
+            src.join("SKILL.md"),
+            "---\nname: test-skill\nversion: \"1.0.0\"\ndescription: A test skill\n---\nMUTATED\n",
+        )
+        .unwrap();
+
+        // Re-install (Update) from a *content-identical-to-the-original*
+        // copy of the source at a different path, so it resolves to the
+        // same tree-hash identity as the first install without ever
+        // re-reading the (now mutated) original.
+        let src2 = write_valid_skill(tmp.path(), "src-skill-2");
+        let origin2 = Origin::Local {
+            path: src2,
+            editable: false,
+        };
+        let outcome = service
+            .add_from_origin(origin2, AddMode::Update, vec![])
+            .await
+            .expect("second add should succeed (cache hit)");
+        assert_eq!(
+            LOCAL_COPY_INVOCATIONS.load(Ordering::SeqCst) - baseline,
+            1,
+            "second install of the same identity must hit the cache, not copy again"
+        );
+
+        let installed =
+            std::fs::read_to_string(skills_dir.join(&outcome.id).join("SKILL.md")).unwrap();
+        assert_eq!(
+            installed, VALID_SKILL_MD,
+            "cache hit must be byte-identical (FR-8)"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_fetch_local_editable_bypasses_cache() {
+        let _lock = crate::test_utils::DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let (tmp, _guard, skills_dir) = setup_project();
+        let src = write_valid_skill(tmp.path(), "src-skill");
+        let cache_root = TestTempDir::new().unwrap();
+        let config = ServiceConfig {
+            skill_storage_path: skills_dir.clone(),
+            skill_cache_root: Some(cache_root.path().to_path_buf()),
+            ..Default::default()
+        };
+        let mut service = FastSkillService::new(config).await.unwrap();
+        service.initialize().await.unwrap();
+
+        let origin = Origin::Local {
+            path: src.clone(),
+            editable: true,
+        };
+        service
+            .add_from_origin(origin, AddMode::Fresh, vec![])
+            .await
+            .expect("editable add should succeed");
+
+        // FR-7: nothing gets published to the content cache for an editable install.
+        let identity = CacheIdentity::Local {
+            tree_hash: compute_local_tree_hash(&src).unwrap(),
+        };
+        assert!(
+            service.skill_cache().get(&identity).is_none(),
+            "editable install must bypass the content cache entirely"
+        );
+    }
+
+    // ── fetch_local: `.zip` content-cache (US-004) ─────────────────────────────
+
+    fn build_local_skill_zip(compression: zip::CompressionMethod) -> Vec<u8> {
+        use std::io::Write;
+        use zip::write::FileOptions;
+        let mut buf = Vec::new();
+        {
+            let cursor = std::io::Cursor::new(&mut buf);
+            let mut writer = zip::ZipWriter::new(cursor);
+            let opts = FileOptions::default().compression_method(compression);
+            writer.start_file("test-skill/SKILL.md", opts).unwrap();
+            writer.write_all(VALID_SKILL_MD.as_bytes()).unwrap();
+            writer.finish().unwrap();
+        }
+        buf
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_fetch_local_zip_second_install_hits_cache_not_source() {
+        let _lock = crate::test_utils::DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let (tmp, _guard, skills_dir) = setup_project();
+        let cache_root = TestTempDir::new().unwrap();
+        let config = ServiceConfig {
+            skill_storage_path: skills_dir.clone(),
+            skill_cache_root: Some(cache_root.path().to_path_buf()),
+            ..Default::default()
+        };
+        let mut service = FastSkillService::new(config).await.unwrap();
+        service.initialize().await.unwrap();
+
+        let zip_bytes = build_local_skill_zip(zip::CompressionMethod::Stored);
+        let zip_a = tmp.path().join("a.zip");
+        std::fs::write(&zip_a, &zip_bytes).unwrap();
+
+        let baseline = LOCAL_COPY_INVOCATIONS.load(Ordering::SeqCst);
+        service
+            .add_from_origin(
+                Origin::Local {
+                    path: zip_a,
+                    editable: false,
+                },
+                AddMode::Fresh,
+                vec![],
+            )
+            .await
+            .expect("first zip add should succeed (cache miss)");
+        assert_eq!(
+            LOCAL_COPY_INVOCATIONS.load(Ordering::SeqCst) - baseline,
+            1,
+            "first install must extract the zip (cache miss)"
+        );
+
+        // Byte-identical zip at a different path -- same archive identity.
+        let zip_b = tmp.path().join("b.zip");
+        std::fs::write(&zip_b, &zip_bytes).unwrap();
+        service
+            .add_from_origin(
+                Origin::Local {
+                    path: zip_b,
+                    editable: false,
+                },
+                AddMode::Update,
+                vec![],
+            )
+            .await
+            .expect("second zip add should succeed (cache hit)");
+        assert_eq!(
+            LOCAL_COPY_INVOCATIONS.load(Ordering::SeqCst) - baseline,
+            1,
+            "second install of a byte-identical zip must hit the cache, not re-extract"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn test_local_zip_identity_hashes_archive_bytes_not_extracted_tree() {
+        let _lock = crate::test_utils::DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let (tmp, _guard, skills_dir) = setup_project();
+        let cache_root = TestTempDir::new().unwrap();
+        let config = ServiceConfig {
+            skill_storage_path: skills_dir.clone(),
+            skill_cache_root: Some(cache_root.path().to_path_buf()),
+            ..Default::default()
+        };
+        let mut service = FastSkillService::new(config).await.unwrap();
+        service.initialize().await.unwrap();
+
+        // Two archives that extract to byte-identical content, but whose own
+        // bytes differ (different compression method). If identity were based
+        // on the extracted tree, the second install would be a cache hit; per
+        // FR (US-004), a `.zip` hashes the archive's own bytes, so it must not
+        // be.
+        let stored = tmp.path().join("stored.zip");
+        std::fs::write(
+            &stored,
+            build_local_skill_zip(zip::CompressionMethod::Stored),
+        )
+        .unwrap();
+        let deflated = tmp.path().join("deflated.zip");
+        std::fs::write(
+            &deflated,
+            build_local_skill_zip(zip::CompressionMethod::Deflated),
+        )
+        .unwrap();
+        assert_ne!(
+            std::fs::read(&stored).unwrap(),
+            std::fs::read(&deflated).unwrap(),
+            "test fixture sanity: the two archives must differ at the byte level"
+        );
+
+        let baseline = LOCAL_COPY_INVOCATIONS.load(Ordering::SeqCst);
+        service
+            .add_from_origin(
+                Origin::Local {
+                    path: stored,
+                    editable: false,
+                },
+                AddMode::Fresh,
+                vec![],
+            )
+            .await
+            .expect("stored-compression zip add should succeed");
+        service
+            .add_from_origin(
+                Origin::Local {
+                    path: deflated,
+                    editable: false,
+                },
+                AddMode::Update,
+                vec![],
+            )
+            .await
+            .expect("deflated-compression zip add should succeed");
+
+        assert_eq!(
+            LOCAL_COPY_INVOCATIONS.load(Ordering::SeqCst) - baseline,
+            2,
+            "differently-encoded archives with identical extracted content must be \
+             distinct cache identities (archive bytes, not the extracted tree)"
+        );
     }
 
     // ── derive_skill_id_and_version ────────────────────────────────────────────

--- a/crates/fastskill-core/src/core/mod.rs
+++ b/crates/fastskill-core/src/core/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod analysis;
 pub mod build_cache;
+pub mod cache;
 pub mod change_detection;
 pub mod context_resolver;
 pub mod dependencies;
@@ -35,6 +36,15 @@ pub mod version_bump;
 // Re-export main types for convenience
 // Note: Selective re-exports to avoid conflicts
 pub use build_cache::{BuildCache, SkillCacheEntry};
+// cache (PRD 006 / RFQ 004): on-disk skill content + index cache. `SkillCache`
+// is the single seam for it -- `install.rs` (US-002/003/004) fetches through
+// it, `repos refresh` (US-005) writes its index through it, and `fastskill
+// cache info`/`clean` (US-006) read/delete through it.
+pub use cache::{
+    CacheIdentity, CacheStats, CachedContent, CleanReport, ContentSourceKind, ContentSourceStats,
+    GitResolution, GitResolutions, SkillCache, SourceIndex, SourceIndexEntry,
+    FASTSKILL_CACHE_DIR_ENV,
+};
 pub use change_detection::{
     calculate_skill_hash, detect_changed_skills_git, detect_changed_skills_hash,
 };

--- a/crates/fastskill-core/src/core/registry/client.rs
+++ b/crates/fastskill-core/src/core/registry/client.rs
@@ -9,6 +9,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Registry client for querying and downloading skills
 pub struct RegistryClient {
@@ -36,6 +37,17 @@ pub struct IndexEntry {
 // IndexMetadata is defined in registry_index.rs
 
 // Dependency is defined in registry_index.rs
+
+/// Number of times [`RegistryClient::download`] has actually performed an HTTP
+/// GET for a package's bytes (PRD 006 "Local Skill Cache", US-003).
+/// Instrumentation-only, kept for the same reason as
+/// `storage::git::CLONE_INVOCATIONS`: the content cache should make a repeat
+/// pinned-version install skip the network entirely, and counting real
+/// downloads is the reliable way to prove that in an integration test.
+/// Deliberately not gated behind `#[cfg(test)]` — integration tests are a
+/// separate compilation unit and cannot see items scoped that way.
+#[doc(hidden)] // test instrumentation, not supported public API
+pub static DOWNLOAD_INVOCATIONS: AtomicUsize = AtomicUsize::new(0);
 
 impl RegistryClient {
     /// Create a new registry client
@@ -217,6 +229,7 @@ impl RegistryClient {
 
     /// Download skill package
     pub async fn download(&self, name: &str, version: &str) -> Result<Vec<u8>, ServiceError> {
+        DOWNLOAD_INVOCATIONS.fetch_add(1, Ordering::SeqCst);
         let entry = self.get_version(name, version).await?.ok_or_else(|| {
             ServiceError::Custom(format!(
                 "Skill {} version {} not found in registry",

--- a/crates/fastskill-core/src/core/repository.rs
+++ b/crates/fastskill-core/src/core/repository.rs
@@ -435,4 +435,190 @@ impl RepositoryManager {
         repos.sort_by_key(|r| r.priority);
         repos.first().copied()
     }
+
+    /// Refresh the on-disk index cache for a single repository (PRD 006 /
+    /// RFQ 004, US-005). Two independent steps:
+    ///
+    /// 1. For a `GitMarketplace` repository, resolve its configured branch/tag
+    ///    to the remote's current commit SHA via [`crate::storage::git::ls_remote`]
+    ///    and record it in the git-resolutions index — the same cache
+    ///    `install::fetch_git` reads for offline resolution (US-002). An
+    ///    unreachable remote fails the refresh here, before step 2.
+    /// 2. Fetch the repository's current skill listing via [`Self::get_client`]
+    ///    and persist it as a [`crate::core::cache::SourceIndex`].
+    ///
+    /// A step-2 listing failure (e.g. no reachable marketplace.json) does not
+    /// unwind a step-1 resolution already recorded — the two are independently
+    /// useful and the ref-resolution index should stay warm even if the
+    /// listing itself is temporarily broken.
+    ///
+    /// Index only: this never fetches or caches skill *content* (RFQ 004's
+    /// "does not pre-warm content" default).
+    ///
+    /// Returns the number of distinct skills recorded in the refreshed index.
+    pub async fn refresh_index(
+        &self,
+        cache: &crate::core::cache::SkillCache,
+        name: &str,
+    ) -> Result<usize, ServiceError> {
+        let repo = self
+            .get_repository(name)
+            .ok_or_else(|| ServiceError::Custom(format!("Repository '{}' not found", name)))?;
+
+        // Ref resolution first and independent of the listing below: a
+        // `GitMarketplace` repository's branch/tag resolves via `ls_remote`
+        // against the git remote directly, not via whatever serves
+        // marketplace.json, so recording it does not depend on the listing
+        // step succeeding. An unreachable remote fails the whole refresh
+        // fast, before attempting a listing that would fail anyway.
+        if let RepositoryConfig::GitMarketplace { url, branch, tag } = &repo.config {
+            let sha = crate::storage::git::ls_remote(url, branch.as_deref(), tag.as_deref())
+                .await
+                .map_err(|e| {
+                    ServiceError::Custom(format!(
+                        "failed to resolve current ref for '{}': {}",
+                        name, e
+                    ))
+                })?;
+            let ref_key = crate::core::cache::GitResolutions::branch_or_tag_key(
+                branch.as_deref(),
+                tag.as_deref(),
+            );
+            let mut resolutions = cache.read_git_resolutions()?;
+            resolutions.insert(url, &ref_key, sha, chrono::Utc::now());
+            cache.write_git_resolutions(&resolutions)?;
+        }
+
+        let client = self.get_client(name).await.map_err(|e| {
+            ServiceError::Custom(format!("failed to connect to repository '{}': {}", name, e))
+        })?;
+        let skills = client.list_skills().await.map_err(|e| {
+            ServiceError::Custom(format!("failed to list skills for '{}': {}", name, e))
+        })?;
+
+        // Group by skill id, deduping versions — `list_skills()` currently
+        // advertises one (the current/latest) version per skill for every
+        // repository type, but this stays correct if that ever changes.
+        let mut by_id: std::collections::BTreeMap<String, std::collections::BTreeSet<String>> =
+            std::collections::BTreeMap::new();
+        for skill in &skills {
+            by_id
+                .entry(skill.id.to_string())
+                .or_default()
+                .insert(skill.version.clone());
+        }
+        let entries: Vec<crate::core::cache::SourceIndexEntry> = by_id
+            .into_iter()
+            .map(|(skill, versions)| crate::core::cache::SourceIndexEntry {
+                skill,
+                versions: versions.into_iter().collect(),
+            })
+            .collect();
+        let entry_count = entries.len();
+
+        let idx = crate::core::cache::SourceIndex {
+            fetched_at: chrono::Utc::now(),
+            entries,
+        };
+        cache.write_source_index(name, &idx)?;
+
+        Ok(entry_count)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod refresh_index_tests {
+    //! `RepositoryManager::refresh_index` (PRD 006 / RFQ 004, US-005). Uses
+    //! `Local` repositories exclusively — no network involved — so git-source
+    //! ref resolution (which needs a real `ls_remote`) is covered separately
+    //! by `tests/repo_index_refresh_git_test.rs` against a local git daemon.
+
+    use super::*;
+    use crate::core::cache::SkillCache;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn local_repo(name: &str, path: PathBuf) -> RepositoryDefinition {
+        RepositoryDefinition {
+            name: name.to_string(),
+            repo_type: RepositoryType::Local,
+            priority: 0,
+            config: RepositoryConfig::Local { path },
+            auth: None,
+            storage: None,
+        }
+    }
+
+    fn write_skill(dir: &Path, id: &str, version: &str) {
+        let skill_dir = dir.join(id);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {id}\nversion: \"{version}\"\ndescription: a skill\n---\nBody\n"),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn refresh_index_writes_source_index_and_returns_skill_count() {
+        let source_dir = TempDir::new().unwrap();
+        write_skill(source_dir.path(), "alpha", "1.0.0");
+        write_skill(source_dir.path(), "beta", "2.0.0");
+
+        let mut manager = RepositoryManager::new(PathBuf::new());
+        manager
+            .add_repository(
+                "local-src".to_string(),
+                local_repo("local-src", source_dir.path().to_path_buf()),
+            )
+            .unwrap();
+
+        let cache_root = TempDir::new().unwrap();
+        let cache = SkillCache::at_root(cache_root.path());
+
+        let count = manager.refresh_index(&cache, "local-src").await.unwrap();
+        assert_eq!(count, 2);
+
+        let idx = cache
+            .read_source_index("local-src")
+            .unwrap()
+            .expect("index file must be written");
+        let mut skills: Vec<&str> = idx.entries.iter().map(|e| e.skill.as_str()).collect();
+        skills.sort();
+        assert_eq!(skills, vec!["alpha", "beta"]);
+        let alpha = idx.entries.iter().find(|e| e.skill == "alpha").unwrap();
+        assert_eq!(alpha.versions, vec!["1.0.0".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn refresh_index_unknown_repository_is_an_error() {
+        let manager = RepositoryManager::new(PathBuf::new());
+        let cache_root = TempDir::new().unwrap();
+        let cache = SkillCache::at_root(cache_root.path());
+
+        let err = manager.refresh_index(&cache, "nope").await.unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn refresh_index_propagates_a_listing_failure_without_writing_an_index() {
+        let mut manager = RepositoryManager::new(PathBuf::new());
+        manager
+            .add_repository(
+                "missing-path".to_string(),
+                local_repo(
+                    "missing-path",
+                    std::env::temp_dir().join("fastskill-does-not-exist-72f1"),
+                ),
+            )
+            .unwrap();
+
+        let cache_root = TempDir::new().unwrap();
+        let cache = SkillCache::at_root(cache_root.path());
+
+        let result = manager.refresh_index(&cache, "missing-path").await;
+        assert!(result.is_err());
+        assert!(cache.read_source_index("missing-path").unwrap().is_none());
+    }
 }

--- a/crates/fastskill-core/src/core/service.rs
+++ b/crates/fastskill-core/src/core/service.rs
@@ -42,6 +42,15 @@ pub struct ServiceConfig {
 
     /// HTTP server configuration
     pub http_server: Option<HttpServerConfig>,
+
+    /// Override for the on-disk skill content/index cache root (PRD 006 /
+    /// RFQ 004). `None` resolves it via [`crate::core::cache::SkillCache::from_env`]
+    /// (the `FASTSKILL_CACHE_DIR` env var, else the platform cache dir) — what
+    /// production call sites want. Tests should always set this to a
+    /// `tempfile::TempDir` path rather than rely on the env-var default: that
+    /// default is process-global, so asserting on it races against any other
+    /// test in the same process that also touches the cache.
+    pub skill_cache_root: Option<PathBuf>,
 }
 
 impl Default for ServiceConfig {
@@ -55,6 +64,7 @@ impl Default for ServiceConfig {
             security: SecurityConfig::default(),
             registry_index_path: None,
             http_server: None,
+            skill_cache_root: None,
         }
     }
 }
@@ -311,6 +321,10 @@ pub struct FastSkillService {
     /// Hot reload manager
     hot_reload_manager: Option<Arc<crate::storage::hot_reload::HotReloadManager>>,
 
+    /// On-disk skill content/index cache (PRD 006 / RFQ 004). Rooted per
+    /// `config.skill_cache_root` (env-resolved when unset).
+    skill_cache: crate::core::cache::SkillCache,
+
     /// Service state
     initialized: bool,
 }
@@ -366,6 +380,11 @@ impl FastSkillService {
             None
         };
 
+        let skill_cache = match &config.skill_cache_root {
+            Some(root) => crate::core::cache::SkillCache::at_root(root.clone()),
+            None => crate::core::cache::SkillCache::from_env()?,
+        };
+
         Ok(Self {
             config,
             skill_manager,
@@ -376,6 +395,7 @@ impl FastSkillService {
             project_root: None,
             storage,
             hot_reload_manager,
+            skill_cache,
             initialized: false,
         })
     }
@@ -408,6 +428,14 @@ impl FastSkillService {
     /// The injected repository manager, if any.
     pub fn repository_manager(&self) -> Option<&Arc<crate::core::repository::RepositoryManager>> {
         self.repository_manager.as_ref()
+    }
+
+    /// The on-disk skill content/index cache (PRD 006 / RFQ 004). `fetch_git`
+    /// (US-002) goes through it before any clone; later stories (US-003
+    /// registry, US-004 local) wire their own fetch paths through the same
+    /// seam.
+    pub fn skill_cache(&self) -> &crate::core::cache::SkillCache {
+        &self.skill_cache
     }
 
     /// Inject the project root the install seam writes Manifest/Lock under (the

--- a/crates/fastskill-core/src/core/version.rs
+++ b/crates/fastskill-core/src/core/version.rs
@@ -84,6 +84,34 @@ impl VersionConstraint {
         })?;
         Ok(self.req.matches(&ver))
     }
+
+    /// If this constraint pins to exactly one version — a bare `MAJOR.MINOR.PATCH`
+    /// (normalized to `=MAJOR.MINOR.PATCH` per ADR-0004) or an explicit
+    /// `=MAJOR.MINOR.PATCH[-pre]` — return that version string. `None` for any
+    /// range (`^`, `~`, `>`, `<`, comma ranges, `*`), which needs a list of
+    /// available versions to resolve against.
+    ///
+    /// PRD 006 (US-003, "Local Skill Cache"): registry version resolution uses
+    /// this to skip both the on-disk index and the network entirely for an
+    /// already-known exact version — the offline "a pinned, cached version
+    /// installs with no network" acceptance criterion depends on never needing
+    /// a versions listing for this case.
+    pub fn as_exact(&self) -> Option<String> {
+        let [comparator] = self.req.comparators.as_slice() else {
+            return None;
+        };
+        if comparator.op != semver::Op::Exact {
+            return None;
+        }
+        let minor = comparator.minor?;
+        let patch = comparator.patch?;
+        let pre = if comparator.pre.is_empty() {
+            String::new()
+        } else {
+            format!("-{}", comparator.pre)
+        };
+        Some(format!("{}.{}.{}{}", comparator.major, minor, patch, pre))
+    }
 }
 
 impl std::fmt::Display for VersionConstraint {
@@ -200,6 +228,38 @@ mod tests {
     fn test_is_newer() {
         assert!(is_newer("1.2.4", "1.2.3").unwrap());
         assert!(!is_newer("1.2.3", "1.2.4").unwrap());
+    }
+
+    // --- as_exact (PRD 006 US-003: registry version resolution) ---
+
+    #[test]
+    fn test_as_exact_bare_version() {
+        let constraint = VersionConstraint::parse("1.2.3").unwrap();
+        assert_eq!(constraint.as_exact().as_deref(), Some("1.2.3"));
+    }
+
+    #[test]
+    fn test_as_exact_explicit_equals() {
+        let constraint = VersionConstraint::parse("=1.2.3").unwrap();
+        assert_eq!(constraint.as_exact().as_deref(), Some("1.2.3"));
+    }
+
+    #[test]
+    fn test_as_exact_prerelease() {
+        let constraint = VersionConstraint::parse("=1.2.3-beta.1").unwrap();
+        assert_eq!(constraint.as_exact().as_deref(), Some("1.2.3-beta.1"));
+    }
+
+    #[test]
+    fn test_as_exact_none_for_ranges() {
+        assert_eq!(VersionConstraint::parse("^1.2.3").unwrap().as_exact(), None);
+        assert_eq!(VersionConstraint::parse("~1.2.0").unwrap().as_exact(), None);
+        assert_eq!(
+            VersionConstraint::parse(">=1.0.0").unwrap().as_exact(),
+            None
+        );
+        assert_eq!(VersionConstraint::parse("*").unwrap().as_exact(), None);
+        assert_eq!(VersionConstraint::parse("").unwrap().as_exact(), None);
     }
 
     // --- Regression tests for BUG-2/3/4/5 + ADR-0004 ---

--- a/crates/fastskill-core/src/storage/git.rs
+++ b/crates/fastskill-core/src/storage/git.rs
@@ -2,7 +2,9 @@
 
 use crate::core::service::ServiceError;
 use crate::core::sources::SourceAuth;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::OnceLock;
 use std::time::Duration;
 use tempfile::TempDir;
@@ -43,6 +45,12 @@ pub enum GitError {
 
     #[error("Authentication failed for {url}: {stderr}")]
     AuthenticationFailed { url: String, stderr: String },
+
+    #[error("Failed to resolve ref for {url}: {stderr}")]
+    LsRemoteFailed { url: String, stderr: String },
+
+    #[error("Ref '{ref_name}' not found on {url}")]
+    RefNotFound { url: String, ref_name: String },
 }
 
 impl From<GitError> for ServiceError {
@@ -234,9 +242,24 @@ pub(crate) fn build_clone_args<'a>(
 
 /// Build the argument vector for `git checkout` (SEC-12).
 ///
-/// `--` terminates options so a ref beginning with `-` cannot be read as a flag.
-pub(crate) fn build_checkout_args(ref_name: &str) -> Vec<&str> {
-    vec!["checkout", "--", ref_name]
+/// Fully-qualifies `ref_name` as `refs/heads/<name>` or `refs/tags/<name>`
+/// (per `is_branch`) rather than using a bare `--` end-of-options separator.
+/// This is deliberate, not just a style choice: `git checkout -- <name>`
+/// (the `build_clone_args`-style guard) means "restore the *pathspec*
+/// `<name>` from the index", not "switch to the ref `<name>`" — it fails with
+/// `pathspec '<name>' did not match any file(s)` for every real branch/tag,
+/// since checkout only treats an argument as a revision when it is *not*
+/// preceded by `--`. Prefixing with a fixed, non-attacker-controlled
+/// `refs/heads/`/`refs/tags/` gives the same SEC-12 protection (the full
+/// argument can never begin with `-`, so it can never be read as a flag)
+/// while keeping correct ref (not path) semantics.
+pub(crate) fn build_checkout_args(ref_name: &str, is_branch: bool) -> Vec<String> {
+    let qualified = if is_branch {
+        format!("refs/heads/{ref_name}")
+    } else {
+        format!("refs/tags/{ref_name}")
+    };
+    vec!["checkout".to_string(), qualified]
 }
 
 /// Command output structure
@@ -245,6 +268,38 @@ pub(crate) struct CommandOutput {
     stdout: String,
     stderr: String,
     exit_code: i32,
+}
+
+/// Environment variables git exports to its own subprocesses (hooks, `rebase
+/// --exec`, aliases, filters) to pin them to *the invoking repository*.
+///
+/// If `fastskill` is itself run from such a context, these are inherited, and
+/// every `git` we spawn silently retargets the caller's repo instead of the
+/// path we asked for — `clone` writes objects into the wrong `GIT_DIR`, and a
+/// `commit` in a scratch directory can even fire the caller's hooks. Clear
+/// them so our invocations always mean what the arguments say.
+const INHERITED_GIT_ENV_VARS: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_COMMON_DIR",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_PREFIX",
+    "GIT_NAMESPACE",
+    "GIT_CEILING_DIRECTORIES",
+];
+
+/// Remove the repository-pinning variables listed in
+/// [`INHERITED_GIT_ENV_VARS`] from `cmd`'s environment.
+///
+/// Note `GIT_DIR` *overrides* `Command::current_dir`, so setting a working
+/// directory is not on its own enough to target a repository — any git spawn
+/// that relies on cwd must go through here too.
+pub(crate) fn scrub_inherited_git_env(cmd: &mut Command) {
+    for var in INHERITED_GIT_ENV_VARS {
+        cmd.env_remove(var);
+    }
 }
 
 /// Execute git command with timeout
@@ -258,6 +313,7 @@ pub(crate) async fn execute_git_command(
     if let Some(cwd) = cwd {
         cmd.current_dir(cwd);
     }
+    scrub_inherited_git_env(&mut cmd);
 
     // Execute with timeout
     let args_str = args.join(" ");
@@ -360,6 +416,126 @@ pub(crate) async fn execute_git_command_with_retry(
     }
 }
 
+/// Number of times [`clone_repository`] has actually run a `git clone`.
+///
+/// Instrumentation-only (PRD 006 "Local Skill Cache", US-002): the content
+/// cache should make most installs skip cloning entirely, and the only
+/// reliable way to assert that in an integration test — without a full mock
+/// git layer — is to count real invocations. Deliberately not gated behind
+/// `#[cfg(test)]`: integration tests are a separate compilation unit and
+/// cannot see items scoped that way. The cost of an uncontended atomic
+/// increment per clone is negligible in production.
+#[doc(hidden)] // test instrumentation, not supported public API
+pub static CLONE_INVOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+/// Resolve a branch or tag name on the remote at `url` to its commit SHA,
+/// without cloning (PRD 006 "Local Skill Cache", US-002).
+///
+/// `branch` and `tag` are mutually exclusive, mirroring [`clone_repository`];
+/// when both are `None`, resolves `HEAD` (the remote's default branch). For an
+/// annotated tag, resolves to the commit the tag *points at* (the peeled
+/// object) — never the tag object's own SHA — so this matches what a
+/// `clone` + `checkout` of that tag lands on.
+///
+/// Follows the same conventions as [`clone_repository`]: shells out via
+/// `Command::new("git")`, the protocol allowlist + `--` end-of-options guard
+/// (SEC-11), credential redaction in logs, the git-version check, and the
+/// shared retry wrapper.
+///
+/// # Errors
+///
+/// Returns `ServiceError` if git is not installed, the version is too old, the
+/// remote could not be reached, or `branch`/`tag`/`HEAD` does not exist on it.
+pub async fn ls_remote(
+    url: &str,
+    branch: Option<&str>,
+    tag: Option<&str>,
+) -> Result<String, ServiceError> {
+    check_git_version().await?;
+
+    let safe_url = redact_url_credentials(url);
+    let query_refs = ls_remote_query_refs(branch, tag);
+    debug!("Resolving ref for {}: {:?}", safe_url, query_refs);
+
+    let args = build_ls_remote_args(url, &query_refs);
+    let ls_remote_timeout = Duration::from_secs(30);
+    let output = execute_git_command_with_retry(&args, ls_remote_timeout, None, 3)
+        .await
+        .map_err(|e| GitError::LsRemoteFailed {
+            url: safe_url.clone(),
+            stderr: e.to_string(),
+        })?;
+
+    let refs = parse_ls_remote_output(&output.stdout);
+    resolve_sha_from_refs(&refs, &query_refs, &safe_url).map_err(Into::into)
+}
+
+/// The ref patterns to query for a given branch/tag/default selection: exactly
+/// one fully-qualified ref for a branch or `HEAD`; two for a tag (the tag ref
+/// itself, and its peeled `^{}` form) so an annotated tag resolves to the
+/// commit it points at rather than the tag object.
+fn ls_remote_query_refs(branch: Option<&str>, tag: Option<&str>) -> Vec<String> {
+    match (branch, tag) {
+        (Some(b), _) => vec![format!("refs/heads/{b}")],
+        (None, Some(t)) => vec![format!("refs/tags/{t}"), format!("refs/tags/{t}^{{}}")],
+        (None, None) => vec!["HEAD".to_string()],
+    }
+}
+
+/// Build the argument vector for `git ls-remote`.
+///
+/// Hardening (SEC-11): same protocol allowlist as [`build_clone_args`], plus
+/// `--` end-of-options before `url`/`refs` so neither can be read as a flag.
+pub(crate) fn build_ls_remote_args<'a>(url: &'a str, refs: &'a [String]) -> Vec<&'a str> {
+    let mut args = vec![
+        "-c",
+        "protocol.ext.allow=never",
+        "-c",
+        "protocol.file.allow=never",
+        "ls-remote",
+        "--",
+        url,
+    ];
+    args.extend(refs.iter().map(String::as_str));
+    args
+}
+
+/// Parse `git ls-remote` output (`<sha>\t<ref>` per line) into a `ref -> sha` map.
+fn parse_ls_remote_output(stdout: &str) -> HashMap<String, String> {
+    stdout
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.splitn(2, '\t');
+            let sha = parts.next()?.trim();
+            let ref_name = parts.next()?.trim();
+            if sha.is_empty() || ref_name.is_empty() {
+                return None;
+            }
+            Some((ref_name.to_string(), sha.to_string()))
+        })
+        .collect()
+}
+
+/// Pick the resolved SHA out of a parsed `ls-remote` ref map. Prefers the
+/// peeled form (`query_refs[1]`, e.g. `refs/tags/v1^{}`) when present — the
+/// commit an annotated tag points at — falling back to the direct ref.
+fn resolve_sha_from_refs(
+    refs: &HashMap<String, String>,
+    query_refs: &[String],
+    safe_url: &str,
+) -> Result<String, GitError> {
+    if let Some(peeled) = query_refs.get(1).and_then(|r| refs.get(r)) {
+        return Ok(peeled.clone());
+    }
+    if let Some(direct) = query_refs.first().and_then(|r| refs.get(r)) {
+        return Ok(direct.clone());
+    }
+    Err(GitError::RefNotFound {
+        url: safe_url.to_string(),
+        ref_name: query_refs.first().cloned().unwrap_or_default(),
+    })
+}
+
 /// Clone a git repository to a temporary directory.
 ///
 /// This function uses the system git binary to clone a repository. It performs shallow clones
@@ -408,6 +584,8 @@ pub async fn clone_repository(
     tag: Option<&str>,
     auth: Option<&SourceAuth>,
 ) -> Result<TempDir, ServiceError> {
+    CLONE_INVOCATIONS.fetch_add(1, Ordering::SeqCst);
+
     // Log deprecation warning if auth is provided
     if auth.is_some() {
         warn!(
@@ -471,7 +649,7 @@ pub async fn clone_repository(
 ///
 /// * `repo_path` - Path to the git repository
 /// * `ref_name` - Branch or tag name to checkout
-/// * `_is_branch` - Whether the reference is a branch (kept for API compatibility)
+/// * `is_branch` - Whether `ref_name` is a branch (`refs/heads/`) or a tag (`refs/tags/`)
 ///
 /// # Errors
 ///
@@ -493,10 +671,11 @@ pub async fn clone_repository(
 pub async fn checkout_branch_or_tag(
     repo_path: &Path,
     ref_name: &str,
-    _is_branch: bool,
+    is_branch: bool,
 ) -> Result<(), ServiceError> {
-    // Build checkout command (`--` end-of-options separator, SEC-12)
-    let args = build_checkout_args(ref_name);
+    // Build checkout command (fully-qualified ref, SEC-12 — see build_checkout_args).
+    let args = build_checkout_args(ref_name, is_branch);
+    let args: Vec<&str> = args.iter().map(String::as_str).collect();
 
     // Execute checkout (1 minute timeout)
     let checkout_timeout = Duration::from_secs(60); // 1 minute
@@ -628,14 +807,24 @@ mod tests {
     }
 
     #[test]
-    fn test_build_checkout_args_has_end_of_options() {
-        // SEC-12: `--` before ref_name so a "--foo" ref is a positional, not a flag.
-        assert_eq!(build_checkout_args("main"), vec!["checkout", "--", "main"]);
-        let args = build_checkout_args("--evil-flag");
-        assert_eq!(args, vec!["checkout", "--", "--evil-flag"]);
-        // ref sits strictly after the separator.
-        let dd = args.iter().position(|a| *a == "--").unwrap();
-        assert_eq!(args[dd + 1], "--evil-flag");
+    fn test_build_checkout_args_qualifies_branch_and_tag_refs() {
+        assert_eq!(
+            build_checkout_args("main", true),
+            vec!["checkout".to_string(), "refs/heads/main".to_string()]
+        );
+        assert_eq!(
+            build_checkout_args("v1.0.0", false),
+            vec!["checkout".to_string(), "refs/tags/v1.0.0".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_build_checkout_args_ref_cannot_be_read_as_flag() {
+        // SEC-12: the fixed `refs/heads/`/`refs/tags/` prefix means the final
+        // argument can never begin with `-`, however `ref_name` is chosen.
+        let args = build_checkout_args("--evil-flag", true);
+        assert_eq!(args[1], "refs/heads/--evil-flag");
+        assert!(!args[1].starts_with('-'));
     }
 
     #[test]
@@ -868,5 +1057,105 @@ mod tests {
         // Should fail after retries (not a network error, so won't retry)
         // Or if it is a network error, should fail after 3 attempts
         assert!(result.is_err() || result.as_ref().unwrap().exit_code != 0);
+    }
+
+    // ── ls-remote helpers ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_ls_remote_query_refs_branch_is_fully_qualified() {
+        assert_eq!(
+            ls_remote_query_refs(Some("main"), None),
+            vec!["refs/heads/main".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_ls_remote_query_refs_tag_includes_peeled_form() {
+        assert_eq!(
+            ls_remote_query_refs(None, Some("v1.0.0")),
+            vec![
+                "refs/tags/v1.0.0".to_string(),
+                "refs/tags/v1.0.0^{}".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_ls_remote_query_refs_default_is_head() {
+        assert_eq!(ls_remote_query_refs(None, None), vec!["HEAD".to_string()]);
+    }
+
+    #[test]
+    fn test_build_ls_remote_args_protocol_flags_and_end_of_options() {
+        let refs = vec!["HEAD".to_string()];
+        let args = build_ls_remote_args("https://example.com/repo.git", &refs);
+
+        assert!(args
+            .windows(2)
+            .any(|w| w == ["-c", "protocol.ext.allow=never"]));
+        assert!(args
+            .windows(2)
+            .any(|w| w == ["-c", "protocol.file.allow=never"]));
+
+        let dd = args.iter().position(|a| *a == "--").unwrap();
+        assert_eq!(args[dd + 1], "https://example.com/repo.git");
+        assert_eq!(args[dd + 2], "HEAD");
+    }
+
+    #[test]
+    fn test_build_ls_remote_args_url_cannot_be_read_as_flag() {
+        let refs = vec!["HEAD".to_string()];
+        let args = build_ls_remote_args("--upload-pack=evil", &refs);
+        let dd = args.iter().position(|a| *a == "--").unwrap();
+        assert_eq!(args[dd + 1], "--upload-pack=evil");
+    }
+
+    #[test]
+    fn test_parse_ls_remote_output_multiple_lines() {
+        let stdout = "abc123\trefs/heads/main\ndef456\trefs/tags/v1.0.0\n";
+        let refs = parse_ls_remote_output(stdout);
+        assert_eq!(
+            refs.get("refs/heads/main").map(String::as_str),
+            Some("abc123")
+        );
+        assert_eq!(
+            refs.get("refs/tags/v1.0.0").map(String::as_str),
+            Some("def456")
+        );
+    }
+
+    #[test]
+    fn test_parse_ls_remote_output_empty_is_empty_map() {
+        assert!(parse_ls_remote_output("").is_empty());
+    }
+
+    #[test]
+    fn test_resolve_sha_from_refs_prefers_peeled_tag() {
+        let mut refs = HashMap::new();
+        refs.insert("refs/tags/v1.0.0".to_string(), "tagobj".to_string());
+        refs.insert("refs/tags/v1.0.0^{}".to_string(), "commitsha".to_string());
+        let query_refs = ls_remote_query_refs(None, Some("v1.0.0"));
+
+        let sha = resolve_sha_from_refs(&refs, &query_refs, "url").unwrap();
+        assert_eq!(sha, "commitsha");
+    }
+
+    #[test]
+    fn test_resolve_sha_from_refs_lightweight_tag_falls_back_to_direct() {
+        let mut refs = HashMap::new();
+        refs.insert("refs/tags/v1.0.0".to_string(), "commitsha".to_string());
+        let query_refs = ls_remote_query_refs(None, Some("v1.0.0"));
+
+        let sha = resolve_sha_from_refs(&refs, &query_refs, "url").unwrap();
+        assert_eq!(sha, "commitsha");
+    }
+
+    #[test]
+    fn test_resolve_sha_from_refs_missing_ref_errors() {
+        let refs = HashMap::new();
+        let query_refs = ls_remote_query_refs(Some("nope"), None);
+
+        let err = resolve_sha_from_refs(&refs, &query_refs, "url").unwrap_err();
+        assert!(matches!(err, GitError::RefNotFound { .. }));
     }
 }

--- a/crates/fastskill-core/tests/git_content_cache_test.rs
+++ b/crates/fastskill-core/tests/git_content_cache_test.rs
@@ -1,0 +1,384 @@
+//! Integration tests for the git content cache (PRD 006 "Local Skill Cache",
+//! US-002): git installs resolve their ref to a SHA and use the content
+//! cache, so a repeated install of the same commit — even across different
+//! projects — clones at most once per machine.
+//!
+//! The primary fixture is a real `git daemon` serving a bare repo over
+//! `git://127.0.0.1` on a loopback port. This is not "the network": no DNS,
+//! no external host, nothing that can be flaky in CI — it is the only way to
+//! exercise the real `ls_remote`/`clone_repository` code paths without a
+//! local filesystem path, which SEC-11 refuses outright
+//! (`protocol.file.allow=never`; see `storage::git::build_clone_args`).
+//! "Exactly one clone" is proven via `storage::git::CLONE_INVOCATIONS`, a
+//! counting seam kept for exactly this purpose.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use fastskill_core::core::cache::{CacheIdentity, GitResolutions, SkillCache};
+use fastskill_core::core::{AddMode, GitRef, Origin};
+use fastskill_core::storage::git::CLONE_INVOCATIONS;
+use fastskill_core::test_utils::{DirGuard, DIR_MUTEX};
+use fastskill_core::{FastSkillService, ServiceConfig};
+use std::net::{TcpListener, TcpStream};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+const VALID_SKILL_MD: &str =
+    "---\nname: cached-git-skill\nversion: \"1.0.0\"\ndescription: A test skill\n---\nBody\n";
+
+// ── git daemon fixture ──────────────────────────────────────────────────────
+
+/// A local `git daemon` exporting every repo under its base path (no
+/// `git-daemon-export-ok` marker required), bound to an OS-assigned loopback
+/// port. Killed on drop.
+struct GitDaemonFixture {
+    child: Child,
+    port: u16,
+    _base: TempDir,
+}
+
+impl GitDaemonFixture {
+    fn start(base: TempDir) -> Self {
+        // `free_loopback_port` can only *suggest* a port: it binds :0, reads the
+        // number, then drops the listener so `git daemon` can take it. Under a
+        // parallel test run another process can win that gap, and the daemon
+        // then dies immediately with "address already in use". Retry on a fresh
+        // port instead of failing the test for an unlucky race.
+        const MAX_ATTEMPTS: u32 = 10;
+        for attempt in 1..=MAX_ATTEMPTS {
+            let port = free_loopback_port();
+            let mut child = git_command()
+                .args([
+                    "daemon",
+                    "--reuseaddr",
+                    "--export-all",
+                    "--listen=127.0.0.1",
+                    &format!("--port={port}"),
+                    &format!("--base-path={}", base.path().display()),
+                ])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("failed to start `git daemon`; is git installed with daemon support?");
+
+            if wait_for_port(port, &mut child) {
+                return Self {
+                    child,
+                    port,
+                    _base: base,
+                };
+            }
+
+            // Did not come up: reap this attempt before trying another port.
+            let _ = child.kill();
+            let _ = child.wait();
+            assert!(
+                attempt < MAX_ATTEMPTS,
+                "git daemon failed to start listening after {MAX_ATTEMPTS} attempts"
+            );
+        }
+        unreachable!("loop either returns or asserts on the final attempt")
+    }
+
+    fn repo_url(&self, repo_name: &str) -> String {
+        format!("git://127.0.0.1:{}/{repo_name}", self.port)
+    }
+}
+
+impl Drop for GitDaemonFixture {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// `git` exports these to its own subprocesses (hooks, `rebase --exec`) to pin
+/// them to the invoking repository. A test run *from* such a context — most
+/// obviously this repo's own `pre-push` hook — would otherwise inherit them,
+/// and every `git` below would retarget the real repo instead of the scratch
+/// one, firing the real hooks. Always spawn git through this.
+fn git_command() -> Command {
+    let mut cmd = Command::new("git");
+    for var in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_COMMON_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_PREFIX",
+        "GIT_NAMESPACE",
+        "GIT_CEILING_DIRECTORIES",
+    ] {
+        cmd.env_remove(var);
+    }
+    cmd
+}
+
+fn free_loopback_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind ephemeral port");
+    listener
+        .local_addr()
+        .expect("failed to read local addr")
+        .port()
+}
+
+/// Poll until `port` accepts connections. Returns `false` (rather than
+/// panicking) if the daemon exits first or the deadline passes, so the caller
+/// can retry on a different port.
+fn wait_for_port(port: u16, child: &mut Child) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return true;
+        }
+        // A daemon that already exited is never going to listen -- fail this
+        // attempt immediately instead of burning the whole deadline.
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            return false;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Run a git command in `dir`, panicking with stderr on failure.
+fn run_git(dir: &Path, args: &[&str]) {
+    let output = git_command()
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to execute `git {}`: {e}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "`git {}` failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Seed a bare repo at `base/<repo_name>.git` with a single commit containing
+/// `SKILL.md` on `branch`. Returns the seeded commit's SHA.
+fn seed_bare_repo(base: &Path, repo_name: &str, branch: &str) -> String {
+    let bare_path = base.join(format!("{repo_name}.git"));
+    run_git(
+        base,
+        &["init", "--bare", "--quiet", bare_path.to_str().unwrap()],
+    );
+
+    let work = base.join(format!("{repo_name}-work"));
+    std::fs::create_dir_all(&work).unwrap();
+    run_git(&work, &["init", "--quiet"]);
+    run_git(&work, &["config", "user.email", "test@example.com"]);
+    run_git(&work, &["config", "user.name", "test"]);
+    std::fs::write(work.join("SKILL.md"), VALID_SKILL_MD).unwrap();
+    run_git(&work, &["add", "-A"]);
+    run_git(&work, &["commit", "--quiet", "-m", "init"]);
+    run_git(&work, &["branch", "-M", branch]);
+    run_git(
+        &work,
+        &["remote", "add", "origin", bare_path.to_str().unwrap()],
+    );
+    run_git(&work, &["push", "--quiet", "origin", branch]);
+
+    let output = git_command()
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&work)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+// ── project fixture ──────────────────────────────────────────────────────
+
+/// A minimal fastskill project directory: `skill-project.toml` + an empty
+/// skills directory, ready for `add_from_origin`.
+fn setup_project(root: &Path) -> std::path::PathBuf {
+    std::fs::write(
+        root.join("skill-project.toml"),
+        "[tool.fastskill]\nskills_directory = \".claude/skills\"\n\n[dependencies]\n",
+    )
+    .unwrap();
+    let skills_dir = root.join(".claude/skills");
+    std::fs::create_dir_all(&skills_dir).unwrap();
+    skills_dir
+}
+
+async fn make_service(storage: &Path, cache_root: &Path) -> FastSkillService {
+    let config = ServiceConfig {
+        skill_storage_path: storage.to_path_buf(),
+        skill_cache_root: Some(cache_root.to_path_buf()),
+        ..Default::default()
+    };
+    let mut service = FastSkillService::new(config).await.unwrap();
+    service.initialize().await.unwrap();
+    service
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+/// Two installs of the same git ref, into two different project directories,
+/// must perform exactly one `git clone` — the second is served from the
+/// shared content cache (PRD 006, US-002 acceptance criterion).
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn two_installs_of_the_same_ref_clone_exactly_once() {
+    let _lock = DIR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+
+    let daemon_base = TempDir::new().unwrap();
+    let expected_sha = seed_bare_repo(daemon_base.path(), "repo", "main");
+    let daemon = GitDaemonFixture::start(daemon_base);
+    let repo_url = daemon.repo_url("repo");
+
+    let shared_cache = TempDir::new().unwrap();
+    let origin = Origin::Git {
+        url: repo_url,
+        r#ref: GitRef::Branch("main".to_string()),
+        subdir: None,
+    };
+
+    let baseline_clones = CLONE_INVOCATIONS.load(Ordering::SeqCst);
+
+    // Project A: fresh clone (cache miss).
+    let project_a = TempDir::new().unwrap();
+    let original_dir = std::env::current_dir().ok();
+    std::env::set_current_dir(project_a.path()).unwrap();
+    let _guard_a = DirGuard(original_dir);
+    let skills_a = setup_project(project_a.path());
+    let storage_a = TempDir::new().unwrap();
+    let service_a = make_service(storage_a.path(), shared_cache.path()).await;
+    let outcome_a = service_a
+        .add_from_origin(origin.clone(), AddMode::Fresh, vec![])
+        .await
+        .expect("project A install should succeed");
+    assert_eq!(
+        outcome_a.resolved.commit_hash.as_deref(),
+        Some(expected_sha.as_str())
+    );
+    let _ = skills_a;
+
+    // Project B: same ref, different project dir — must be a cache hit.
+    let project_b = TempDir::new().unwrap();
+    std::env::set_current_dir(project_b.path()).unwrap();
+    let skills_b = setup_project(project_b.path());
+    let storage_b = TempDir::new().unwrap();
+    let service_b = make_service(storage_b.path(), shared_cache.path()).await;
+    let outcome_b = service_b
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await
+        .expect("project B install should succeed");
+    assert_eq!(
+        outcome_b.resolved.commit_hash.as_deref(),
+        Some(expected_sha.as_str())
+    );
+    let _ = skills_b;
+
+    let clones_performed = CLONE_INVOCATIONS.load(Ordering::SeqCst) - baseline_clones;
+    assert_eq!(
+        clones_performed, 1,
+        "two installs of the same ref must perform exactly one clone"
+    );
+
+    // Both projects ended up with byte-identical installed content (FR-8).
+    let content_a =
+        std::fs::read_to_string(storage_a.path().join("cached-git-skill").join("SKILL.md"))
+            .unwrap();
+    let content_b =
+        std::fs::read_to_string(storage_b.path().join("cached-git-skill").join("SKILL.md"))
+            .unwrap();
+    assert_eq!(content_a, content_b);
+    assert_eq!(content_a, VALID_SKILL_MD);
+}
+
+/// When `ls_remote` fails (offline / unreachable remote) but a previous
+/// resolution for the same `url`+`ref` is recorded in the index cache, install
+/// proceeds from the cached content with a warning rather than failing.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn offline_install_falls_back_to_previously_resolved_sha() {
+    let _lock = DIR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+
+    // A URL nothing is listening on (port 1 is reserved/unprivileged-unbindable),
+    // so `ls_remote` fails fast without ever touching the real network.
+    let unreachable_url = "git://127.0.0.1:1/does-not-exist.git";
+    let sha = "1111111111111111111111111111111111111a";
+
+    let cache_root = TempDir::new().unwrap();
+    let cache = SkillCache::at_root(cache_root.path());
+
+    // Prime the content cache with the "previously fetched" skill content.
+    let content_dir = TempDir::new().unwrap();
+    std::fs::write(content_dir.path().join("SKILL.md"), VALID_SKILL_MD).unwrap();
+    cache
+        .put(
+            &CacheIdentity::Git {
+                sha: sha.to_string(),
+            },
+            content_dir.path(),
+        )
+        .unwrap();
+
+    // Prime the git-resolutions index as if a prior online install had
+    // resolved this exact url+ref. The key format (`branch:<name>`) mirrors
+    // `install.rs`'s private `git_ref_cache_key` encoding.
+    let mut resolutions = GitResolutions::default();
+    resolutions.insert(
+        unreachable_url,
+        "branch:main",
+        sha.to_string(),
+        chrono::Utc::now(),
+    );
+    cache.write_git_resolutions(&resolutions).unwrap();
+
+    let project = TempDir::new().unwrap();
+    let original_dir = std::env::current_dir().ok();
+    std::env::set_current_dir(project.path()).unwrap();
+    let _guard = DirGuard(original_dir);
+    setup_project(project.path());
+    let storage = TempDir::new().unwrap();
+    let service = make_service(storage.path(), cache_root.path()).await;
+
+    let origin = Origin::Git {
+        url: unreachable_url.to_string(),
+        r#ref: GitRef::Branch("main".to_string()),
+        subdir: None,
+    };
+    let outcome = service
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await
+        .expect("offline install with a cached resolution should succeed");
+
+    assert_eq!(outcome.resolved.commit_hash.as_deref(), Some(sha));
+    let installed =
+        std::fs::read_to_string(storage.path().join("cached-git-skill").join("SKILL.md")).unwrap();
+    assert_eq!(installed, VALID_SKILL_MD);
+}
+
+/// With no prior resolution recorded, an unreachable remote fails the install
+/// (no silent staleness, no panic).
+#[tokio::test]
+async fn offline_install_with_no_prior_resolution_fails() {
+    let unreachable_url = "git://127.0.0.1:1/does-not-exist.git";
+    let cache_root = TempDir::new().unwrap();
+    let storage = TempDir::new().unwrap();
+    let service = make_service(storage.path(), cache_root.path()).await;
+
+    let origin = Origin::Git {
+        url: unreachable_url.to_string(),
+        r#ref: GitRef::Branch("main".to_string()),
+        subdir: None,
+    };
+    let result = service
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await;
+    assert!(
+        result.is_err(),
+        "install must fail without a cached resolution"
+    );
+}

--- a/crates/fastskill-core/tests/offline_verification_sweep_test.rs
+++ b/crates/fastskill-core/tests/offline_verification_sweep_test.rs
@@ -1,0 +1,678 @@
+//! Offline verification sweep (PRD 006 "Local Skill Cache", US-007): for
+//! each of the three v1 cached origin kinds -- git (pinned/tag resolution),
+//! registry (pinned version), and local -- populate the content cache while
+//! "online" via the same real fixtures the per-story tests use (a local
+//! `git daemon`, a `wiremock` HTTP registry), then make network egress to
+//! the *original* source actually fail (kill the daemon; point the registry
+//! client at an unreachable loopback port that nothing ever listens on,
+//! `127.0.0.1:1`; delete the local source directory outright) and re-run
+//! `add_from_origin` into a *different* project sharing the same on-disk
+//! cache. Every one of those re-runs must succeed purely from cache and
+//! produce byte-identical installed content to the original online install
+//! (FR-8).
+//!
+//! The same suite also proves the two paths that must fail loudly instead
+//! of silently serving stale data or panicking: a registry `newest`
+//! resolution with no cached index (actionable error naming `repos
+//! refresh`), and a git ref with no prior resolution (actionable error, not
+//! a panic).
+//!
+//! "Network made to fail" is always either a real process that has been
+//! killed (the git daemon, via `Drop`) or a fixed, reserved loopback address
+//! nothing listens on (`127.0.0.1:1`) -- deterministic and fast, never
+//! dependent on the environment actually lacking internet access. This
+//! mirrors `git_content_cache_test.rs` / `registry_content_cache_test.rs`
+//! (US-002/US-003), whose fixtures and counting seams
+//! (`storage::git::CLONE_INVOCATIONS`, `core::registry::client::DOWNLOAD_INVOCATIONS`,
+//! `core::install::LOCAL_COPY_INVOCATIONS`) this file reuses.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use fastskill_core::core::install::LOCAL_COPY_INVOCATIONS;
+use fastskill_core::core::registry::client::{IndexEntry, DOWNLOAD_INVOCATIONS};
+use fastskill_core::core::repository::{
+    RepositoryConfig, RepositoryDefinition, RepositoryManager, RepositoryType,
+};
+use fastskill_core::core::version::VersionConstraint;
+use fastskill_core::core::{AddMode, GitRef, Origin};
+use fastskill_core::storage::git::CLONE_INVOCATIONS;
+use fastskill_core::{FastSkillService, ServiceConfig};
+use std::net::{TcpListener, TcpStream};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path as wm_path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// A URL nothing is listening on. Port 1 is a reserved, unprivileged-unbindable
+/// port, so a connection attempt fails immediately (connection refused) rather
+/// than timing out -- deterministic and fast, no dependence on the test
+/// environment actually lacking internet access.
+const UNREACHABLE_GIT_URL: &str = "git://127.0.0.1:1/does-not-exist.git";
+const UNREACHABLE_INDEX_URL: &str = "http://127.0.0.1:1/index";
+
+// ── shared fixtures (mirror git_content_cache_test.rs / registry_content_cache_test.rs) ──
+
+struct GitDaemonFixture {
+    child: Child,
+    port: u16,
+    _base: TempDir,
+}
+
+impl GitDaemonFixture {
+    fn start(base: TempDir) -> Self {
+        // `free_loopback_port` can only *suggest* a port: it binds :0, reads the
+        // number, then drops the listener so `git daemon` can take it. Under a
+        // parallel test run another process can win that gap, and the daemon
+        // then dies immediately with "address already in use". Retry on a fresh
+        // port instead of failing the test for an unlucky race.
+        const MAX_ATTEMPTS: u32 = 10;
+        for attempt in 1..=MAX_ATTEMPTS {
+            let port = free_loopback_port();
+            let mut child = git_command()
+                .args([
+                    "daemon",
+                    "--reuseaddr",
+                    "--export-all",
+                    "--listen=127.0.0.1",
+                    &format!("--port={port}"),
+                    &format!("--base-path={}", base.path().display()),
+                ])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("failed to start `git daemon`; is git installed with daemon support?");
+
+            if wait_for_port(port, &mut child) {
+                return Self {
+                    child,
+                    port,
+                    _base: base,
+                };
+            }
+
+            // Did not come up: reap this attempt before trying another port.
+            let _ = child.kill();
+            let _ = child.wait();
+            assert!(
+                attempt < MAX_ATTEMPTS,
+                "git daemon failed to start listening after {MAX_ATTEMPTS} attempts"
+            );
+        }
+        unreachable!("loop either returns or asserts on the final attempt")
+    }
+
+    fn repo_url(&self, repo_name: &str) -> String {
+        format!("git://127.0.0.1:{}/{repo_name}", self.port)
+    }
+
+    /// Kill the daemon -- including the `git-daemon` child it re-execs into,
+    /// which is what actually holds the listening socket, separate from the
+    /// pid `spawn` hands back (plain `child.kill()`, as every other fixture
+    /// in this repo uses, leaves that child running and the port still
+    /// accepting connections) -- and wait for the port to actually stop
+    /// accepting connections. This is the "network egress made to fail"
+    /// step for the git scenario: deterministic (polls a local condition,
+    /// no sleep-and-hope) and fast, with no reliance on the test
+    /// environment actually lacking internet access.
+    ///
+    /// Deliberately kills each descendant PID individually by exact number
+    /// (via `/proc/<pid>/task/<pid>/children`, Linux-only) rather than a
+    /// process-group-wide `kill -9 -PID`: this test process was not itself
+    /// given a fresh process group, so a group-wide signal risks hitting
+    /// far more than the daemon it is scoped to.
+    fn kill_and_wait(mut self) {
+        #[cfg(target_os = "linux")]
+        {
+            let mut victims = descendant_pids(self.child.id());
+            victims.push(self.child.id());
+            for pid in victims {
+                let _ = Command::new("kill").args(["-9", &pid.to_string()]).status();
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while TcpStream::connect(("127.0.0.1", self.port)).is_ok() {
+            if Instant::now() >= deadline {
+                panic!(
+                    "git daemon on port {} did not stop accepting connections",
+                    self.port
+                );
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+/// Every descendant pid of `pid` (children, grandchildren, ...), read from
+/// procfs. Linux-only; `kill_and_wait`'s only caller falls back to a plain
+/// `child.kill()` everywhere else.
+#[cfg(target_os = "linux")]
+fn descendant_pids(pid: u32) -> Vec<u32> {
+    let mut result = Vec::new();
+    let mut frontier = vec![pid];
+    while let Some(p) = frontier.pop() {
+        let children_path = format!("/proc/{p}/task/{p}/children");
+        if let Ok(contents) = std::fs::read_to_string(&children_path) {
+            for token in contents.split_whitespace() {
+                if let Ok(child) = token.parse::<u32>() {
+                    result.push(child);
+                    frontier.push(child);
+                }
+            }
+        }
+    }
+    result
+}
+
+impl Drop for GitDaemonFixture {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// `git` exports these to its own subprocesses (hooks, `rebase --exec`) to pin
+/// them to the invoking repository. A test run *from* such a context — most
+/// obviously this repo's own `pre-push` hook — would otherwise inherit them,
+/// and every `git` below would retarget the real repo instead of the scratch
+/// one, firing the real hooks. Always spawn git through this.
+fn git_command() -> Command {
+    let mut cmd = Command::new("git");
+    for var in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_COMMON_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_PREFIX",
+        "GIT_NAMESPACE",
+        "GIT_CEILING_DIRECTORIES",
+    ] {
+        cmd.env_remove(var);
+    }
+    cmd
+}
+
+fn free_loopback_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind ephemeral port");
+    listener
+        .local_addr()
+        .expect("failed to read local addr")
+        .port()
+}
+
+/// Poll until `port` accepts connections. Returns `false` (rather than
+/// panicking) if the daemon exits first or the deadline passes, so the caller
+/// can retry on a different port.
+fn wait_for_port(port: u16, child: &mut Child) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return true;
+        }
+        // A daemon that already exited is never going to listen -- fail this
+        // attempt immediately instead of burning the whole deadline.
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            return false;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let output = git_command()
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to execute `git {}`: {e}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "`git {}` failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+const GIT_SKILL_MD: &str =
+    "---\nname: offline-git-skill\nversion: \"1.0.0\"\ndescription: A test skill\n---\nBody\n";
+
+/// Seed a bare repo at `base/<repo_name>.git` with a single commit tagged
+/// `tag_name`. Returns the tagged commit's SHA.
+fn seed_bare_repo_with_tag(base: &Path, repo_name: &str, tag_name: &str) -> String {
+    let bare_path = base.join(format!("{repo_name}.git"));
+    run_git(
+        base,
+        &["init", "--bare", "--quiet", bare_path.to_str().unwrap()],
+    );
+
+    let work = base.join(format!("{repo_name}-work"));
+    std::fs::create_dir_all(&work).unwrap();
+    run_git(&work, &["init", "--quiet"]);
+    run_git(&work, &["config", "user.email", "test@example.com"]);
+    run_git(&work, &["config", "user.name", "test"]);
+    std::fs::write(work.join("SKILL.md"), GIT_SKILL_MD).unwrap();
+    run_git(&work, &["add", "-A"]);
+    run_git(&work, &["commit", "--quiet", "-m", "init"]);
+    run_git(&work, &["tag", tag_name]);
+    run_git(&work, &["branch", "-M", "main"]);
+    run_git(
+        &work,
+        &["remote", "add", "origin", bare_path.to_str().unwrap()],
+    );
+    run_git(&work, &["push", "--quiet", "origin", "main"]);
+    run_git(&work, &["push", "--quiet", "origin", tag_name]);
+
+    let output = git_command()
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&work)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn setup_project(root: &Path) -> std::path::PathBuf {
+    std::fs::write(
+        root.join("skill-project.toml"),
+        "[tool.fastskill]\nskills_directory = \".claude/skills\"\n\n[dependencies]\n",
+    )
+    .unwrap();
+    let skills_dir = root.join(".claude/skills");
+    std::fs::create_dir_all(&skills_dir).unwrap();
+    skills_dir
+}
+
+async fn make_service(storage: &Path, cache_root: &Path) -> FastSkillService {
+    let config = ServiceConfig {
+        skill_storage_path: storage.to_path_buf(),
+        skill_cache_root: Some(cache_root.to_path_buf()),
+        ..Default::default()
+    };
+    let mut service = FastSkillService::new(config).await.unwrap();
+    service.initialize().await.unwrap();
+    service
+}
+
+async fn make_service_with_repos(
+    project_root: &Path,
+    storage: &Path,
+    cache_root: &Path,
+    manager: RepositoryManager,
+) -> FastSkillService {
+    make_service(storage, cache_root)
+        .await
+        .with_project_root(project_root.to_path_buf())
+        .with_repository_manager(Arc::new(manager))
+}
+
+fn read_installed_skill_md(storage: &Path, skill_id: &str) -> String {
+    std::fs::read_to_string(storage.join(skill_id).join("SKILL.md"))
+        .unwrap_or_else(|e| panic!("expected installed SKILL.md for '{skill_id}': {e}"))
+}
+
+// ── US-007: git, pinned (tag) resolution, fully offline after the daemon dies ──
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn git_tag_install_succeeds_offline_after_daemon_dies_and_is_byte_identical() {
+    let _lock = fastskill_core::test_utils::DIR_MUTEX
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
+    let daemon_base = TempDir::new().unwrap();
+    let expected_sha = seed_bare_repo_with_tag(daemon_base.path(), "repo", "v1.0.0");
+    let daemon = GitDaemonFixture::start(daemon_base);
+    let repo_url = daemon.repo_url("repo");
+
+    let shared_cache = TempDir::new().unwrap();
+    let origin = Origin::Git {
+        url: repo_url,
+        r#ref: GitRef::Tag("v1.0.0".to_string()),
+        subdir: None,
+    };
+
+    let baseline_clones = CLONE_INVOCATIONS.load(Ordering::SeqCst);
+
+    // "Online": project A installs while the daemon is alive, populating the
+    // content cache and recording the tag's resolution.
+    let project_a = TempDir::new().unwrap();
+    let original_dir = std::env::current_dir().ok();
+    std::env::set_current_dir(project_a.path()).unwrap();
+    let _guard_a = fastskill_core::test_utils::DirGuard(original_dir);
+    setup_project(project_a.path());
+    let storage_a = TempDir::new().unwrap();
+    let service_a = make_service(storage_a.path(), shared_cache.path()).await;
+    let outcome_a = service_a
+        .add_from_origin(origin.clone(), AddMode::Fresh, vec![])
+        .await
+        .expect("online install should succeed");
+    assert_eq!(
+        outcome_a.resolved.commit_hash.as_deref(),
+        Some(expected_sha.as_str())
+    );
+
+    // Network egress made to fail: kill the daemon and confirm the port has
+    // actually stopped accepting connections before proceeding.
+    daemon.kill_and_wait();
+
+    // "Offline": project B, same tag, same shared cache -- the daemon is
+    // dead, so `ls_remote` cannot possibly succeed live; this must fall back
+    // to the recorded resolution and install purely from the content cache.
+    let project_b = TempDir::new().unwrap();
+    std::env::set_current_dir(project_b.path()).unwrap();
+    setup_project(project_b.path());
+    let storage_b = TempDir::new().unwrap();
+    let service_b = make_service(storage_b.path(), shared_cache.path()).await;
+    let outcome_b = service_b
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await
+        .expect("offline install from cache should succeed after the daemon is gone");
+    assert_eq!(
+        outcome_b.resolved.commit_hash.as_deref(),
+        Some(expected_sha.as_str())
+    );
+
+    let clones_performed = CLONE_INVOCATIONS.load(Ordering::SeqCst) - baseline_clones;
+    assert_eq!(
+        clones_performed, 1,
+        "the offline re-run must not have cloned again"
+    );
+
+    // FR-8: byte-identical installed content.
+    let content_a = read_installed_skill_md(storage_a.path(), "offline-git-skill");
+    let content_b = read_installed_skill_md(storage_b.path(), "offline-git-skill");
+    assert_eq!(content_a, content_b);
+    assert_eq!(content_a, GIT_SKILL_MD);
+}
+
+// ── US-007: registry, pinned version, fully offline against an unreachable index ──
+
+const SKILL_ID: &str = "widget";
+const REPO_NAME: &str = "myreg";
+
+fn skill_md(version: &str) -> String {
+    format!(
+        "---\nname: {SKILL_ID}\nversion: \"{version}\"\ndescription: A registry skill\n---\nBody\n"
+    )
+}
+
+fn build_zip(version: &str) -> Vec<u8> {
+    use std::io::Write;
+    use zip::write::FileOptions;
+    let mut buf = Vec::new();
+    {
+        let cursor = std::io::Cursor::new(&mut buf);
+        let mut writer = zip::ZipWriter::new(cursor);
+        let opts = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        writer
+            .start_file(format!("{SKILL_ID}/SKILL.md"), opts)
+            .unwrap();
+        writer.write_all(skill_md(version).as_bytes()).unwrap();
+        writer.finish().unwrap();
+    }
+    buf
+}
+
+async fn mount_version(server: &MockServer, version: &str) {
+    let zip_bytes = build_zip(version);
+    let cksum = format!("sha256:{:x}", sha2::Sha256::digest(&zip_bytes));
+    use sha2::Digest;
+    let entry = IndexEntry {
+        name: SKILL_ID.to_string(),
+        vers: version.to_string(),
+        deps: vec![],
+        cksum,
+        features: std::collections::HashMap::new(),
+        yanked: false,
+        links: None,
+        download_url: format!("{}/dl/{version}", server.uri()),
+        metadata: None,
+    };
+
+    Mock::given(method("GET"))
+        .and(wm_path(format!("/index/{SKILL_ID}")))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(serde_json::to_string(&entry).unwrap()),
+        )
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(wm_path(format!("/dl/{version}")))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(zip_bytes))
+        .mount(server)
+        .await;
+}
+
+fn repo_manager(index_url: String) -> RepositoryManager {
+    RepositoryManager::from_definitions(vec![RepositoryDefinition {
+        name: REPO_NAME.to_string(),
+        repo_type: RepositoryType::HttpRegistry,
+        priority: 0,
+        config: RepositoryConfig::HttpRegistry { index_url },
+        auth: None,
+        storage: None,
+    }])
+}
+
+#[tokio::test]
+async fn registry_pinned_version_install_succeeds_offline_and_is_byte_identical() {
+    let server = MockServer::start().await;
+    mount_version(&server, "1.0.0").await;
+
+    let shared_cache = TempDir::new().unwrap();
+    let origin = Origin::Repository {
+        repo: REPO_NAME.to_string(),
+        skill: SKILL_ID.to_string(),
+        version: Some(VersionConstraint::parse("1.0.0").unwrap()),
+    };
+
+    let baseline = DOWNLOAD_INVOCATIONS.load(Ordering::SeqCst);
+
+    // "Online": project A downloads from the real (mock) registry.
+    let project_a = TempDir::new().unwrap();
+    setup_project(project_a.path());
+    let storage_a = TempDir::new().unwrap();
+    let manager_a = repo_manager(format!("{}/index", server.uri()));
+    let service_a = make_service_with_repos(
+        project_a.path(),
+        storage_a.path(),
+        shared_cache.path(),
+        manager_a,
+    )
+    .await;
+    let outcome_a = service_a
+        .add_from_origin(origin.clone(), AddMode::Fresh, vec![])
+        .await
+        .expect("online install should succeed");
+    assert_eq!(outcome_a.resolved.version, "1.0.0");
+
+    // "Offline": project B is wired to a registry index that nothing is
+    // listening on -- any live call fails fast. Same shared cache root, same
+    // pinned version.
+    let project_b = TempDir::new().unwrap();
+    setup_project(project_b.path());
+    let storage_b = TempDir::new().unwrap();
+    let manager_b = repo_manager(UNREACHABLE_INDEX_URL.to_string());
+    let service_b = make_service_with_repos(
+        project_b.path(),
+        storage_b.path(),
+        shared_cache.path(),
+        manager_b,
+    )
+    .await;
+    let outcome_b = service_b
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await
+        .expect("offline install of a pinned, cached version should succeed");
+    assert_eq!(outcome_b.resolved.version, "1.0.0");
+
+    let downloads = DOWNLOAD_INVOCATIONS.load(Ordering::SeqCst) - baseline;
+    assert_eq!(
+        downloads, 1,
+        "the offline re-run must not have downloaded again"
+    );
+
+    let content_a = read_installed_skill_md(storage_a.path(), SKILL_ID);
+    let content_b = read_installed_skill_md(storage_b.path(), SKILL_ID);
+    assert_eq!(content_a, content_b);
+    assert_eq!(content_a, skill_md("1.0.0"));
+}
+
+// ── US-007: local, source removed entirely between the two installs ───────
+
+const LOCAL_SKILL_ID: &str = "offline-local-skill";
+
+fn write_local_skill(dir: &Path) {
+    std::fs::write(
+        dir.join("SKILL.md"),
+        format!(
+            "---\nname: {LOCAL_SKILL_ID}\nversion: \"1.0.0\"\ndescription: local skill\n---\nBody\n"
+        ),
+    )
+    .unwrap();
+}
+
+/// Local origins never touch the network at all, so there is nothing to
+/// "make fail" the way git/registry have a remote to sever. The closest
+/// meaningful analogue -- and the one this test proves -- is that the
+/// *original source path* can vanish entirely (deleted, unmounted, a
+/// different machine) once its content has been cached, and a second
+/// install of byte-identical content at a *different* path still resolves
+/// to the same cached identity and completes without re-copying anything
+/// from a source ([`LOCAL_COPY_INVOCATIONS`] delta of zero).
+#[tokio::test]
+async fn local_install_succeeds_after_original_source_is_removed_and_is_byte_identical() {
+    let shared_cache = TempDir::new().unwrap();
+
+    let source_a = TempDir::new().unwrap();
+    write_local_skill(source_a.path());
+
+    let baseline = LOCAL_COPY_INVOCATIONS.load(Ordering::SeqCst);
+
+    // "Online": project A installs from `source_a`, populating the content
+    // cache under `source_a`'s tree-hash.
+    let project_a = TempDir::new().unwrap();
+    setup_project(project_a.path());
+    let storage_a = TempDir::new().unwrap();
+    let service_a = make_service(storage_a.path(), shared_cache.path())
+        .await
+        .with_project_root(project_a.path().to_path_buf());
+    let outcome_a = service_a
+        .add_from_origin(
+            Origin::Local {
+                path: source_a.path().to_path_buf(),
+                editable: false,
+            },
+            AddMode::Fresh,
+            vec![],
+        )
+        .await
+        .expect("online install should succeed");
+    assert_eq!(outcome_a.resolved.version, "1.0.0");
+
+    // A byte-identical copy of the source at a *different* path, made before
+    // the original is removed -- the tree-hash identity depends only on
+    // relative paths and content, never on where the tree lives.
+    let source_b = TempDir::new().unwrap();
+    write_local_skill(source_b.path());
+
+    // The original source is now gone entirely -- project B's install must
+    // not need it.
+    drop(source_a);
+
+    let project_b = TempDir::new().unwrap();
+    setup_project(project_b.path());
+    let storage_b = TempDir::new().unwrap();
+    let service_b = make_service(storage_b.path(), shared_cache.path())
+        .await
+        .with_project_root(project_b.path().to_path_buf());
+    let outcome_b = service_b
+        .add_from_origin(
+            Origin::Local {
+                path: source_b.path().to_path_buf(),
+                editable: false,
+            },
+            AddMode::Fresh,
+            vec![],
+        )
+        .await
+        .expect("second install of byte-identical content should succeed from cache");
+    assert_eq!(outcome_b.resolved.version, "1.0.0");
+
+    let copies_performed = LOCAL_COPY_INVOCATIONS.load(Ordering::SeqCst) - baseline;
+    assert_eq!(
+        copies_performed, 1,
+        "the second install must have been served from the content cache, not re-copied"
+    );
+
+    let content_a = read_installed_skill_md(storage_a.path(), LOCAL_SKILL_ID);
+    let content_b = read_installed_skill_md(storage_b.path(), LOCAL_SKILL_ID);
+    assert_eq!(content_a, content_b);
+}
+
+// ── US-007: `update`/`newest`-resolution fail loudly instead of silently ──
+
+/// `newest` (`version: None`) with no cached index, against an unreachable
+/// registry, fails with an actionable error naming `repos refresh` -- never
+/// a panic, never silently serving stale/no data.
+#[tokio::test]
+async fn newest_resolution_offline_with_no_index_fails_naming_repos_refresh() {
+    let project = TempDir::new().unwrap();
+    setup_project(project.path());
+    let storage = TempDir::new().unwrap();
+    let cache_root = TempDir::new().unwrap();
+    let manager = repo_manager(UNREACHABLE_INDEX_URL.to_string());
+    let service =
+        make_service_with_repos(project.path(), storage.path(), cache_root.path(), manager).await;
+
+    let origin = Origin::Repository {
+        repo: REPO_NAME.to_string(),
+        skill: SKILL_ID.to_string(),
+        version: None,
+    };
+    let err = service
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await
+        .expect_err("`newest` offline with no cached index must fail, not panic or go stale");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("repos refresh"),
+        "error must name `repos refresh` as the fix, got: {message}"
+    );
+}
+
+/// A git branch `update` offline (unreachable remote) with no prior
+/// resolution recorded fails with a real error -- not a panic, not a
+/// silent no-op reusing whatever happened to be installed before.
+#[tokio::test]
+async fn git_branch_update_offline_with_no_prior_resolution_fails() {
+    let cache_root = TempDir::new().unwrap();
+    let storage = TempDir::new().unwrap();
+    let service = make_service(storage.path(), cache_root.path()).await;
+
+    let origin = Origin::Git {
+        url: UNREACHABLE_GIT_URL.to_string(),
+        r#ref: GitRef::Branch("main".to_string()),
+        subdir: None,
+    };
+    let result = service
+        .add_from_origin(origin, AddMode::Update, vec![])
+        .await;
+    assert!(
+        result.is_err(),
+        "an offline git update with no prior resolution must fail, not panic or go stale"
+    );
+}

--- a/crates/fastskill-core/tests/registry_content_cache_test.rs
+++ b/crates/fastskill-core/tests/registry_content_cache_test.rs
@@ -1,0 +1,381 @@
+//! Integration tests for the registry content cache (PRD 006 "Local Skill
+//! Cache", US-003): registry installs resolve to a concrete version and use
+//! the content cache, so a repeated install of the same pinned version --
+//! even across different projects -- downloads at most once per machine, and
+//! `newest` resolution never depends on a live listing call.
+//!
+//! The fixture is a `wiremock` `MockServer` bound to a loopback port -- this
+//! is not "the network" (no DNS, no external host, nothing flaky in CI), the
+//! same posture `git_content_cache_test.rs` takes with a local `git daemon`
+//! for the analogous git case. "Exactly one download" is proven via
+//! `core::registry::client::DOWNLOAD_INVOCATIONS`, a counting seam kept for
+//! exactly this purpose (mirrors `storage::git::CLONE_INVOCATIONS`).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use fastskill_core::core::cache::{CacheIdentity, SkillCache, SourceIndex, SourceIndexEntry};
+use fastskill_core::core::registry::client::{IndexEntry, DOWNLOAD_INVOCATIONS};
+use fastskill_core::core::repository::{
+    RepositoryConfig, RepositoryDefinition, RepositoryManager, RepositoryType,
+};
+use fastskill_core::core::version::VersionConstraint;
+use fastskill_core::core::{AddMode, Origin};
+use fastskill_core::{FastSkillService, ServiceConfig};
+use sha2::Digest;
+use std::path::Path;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const SKILL_ID: &str = "widget";
+const REPO_NAME: &str = "myreg";
+
+fn skill_md(version: &str) -> String {
+    format!(
+        "---\nname: {SKILL_ID}\nversion: \"{version}\"\ndescription: A registry skill\n---\nBody\n"
+    )
+}
+
+fn build_zip(version: &str) -> Vec<u8> {
+    use std::io::Write;
+    use zip::write::FileOptions;
+    let mut buf = Vec::new();
+    {
+        let cursor = std::io::Cursor::new(&mut buf);
+        let mut writer = zip::ZipWriter::new(cursor);
+        let opts = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        writer
+            .start_file(format!("{SKILL_ID}/SKILL.md"), opts)
+            .unwrap();
+        writer.write_all(skill_md(version).as_bytes()).unwrap();
+        writer.finish().unwrap();
+    }
+    buf
+}
+
+/// Mount an index entry + download endpoint for `version` on `server`.
+async fn mount_version(server: &MockServer, version: &str) {
+    let zip_bytes = build_zip(version);
+    let cksum = format!("sha256:{:x}", sha2::Sha256::digest(&zip_bytes));
+    let entry = IndexEntry {
+        name: SKILL_ID.to_string(),
+        vers: version.to_string(),
+        deps: vec![],
+        cksum,
+        features: std::collections::HashMap::new(),
+        yanked: false,
+        links: None,
+        download_url: format!("{}/dl/{version}", server.uri()),
+        metadata: None,
+    };
+
+    Mock::given(method("GET"))
+        .and(path(format!("/index/{SKILL_ID}")))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(serde_json::to_string(&entry).unwrap()),
+        )
+        .mount(server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/dl/{version}")))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(zip_bytes))
+        .mount(server)
+        .await;
+}
+
+fn repo_manager(index_url: String) -> RepositoryManager {
+    RepositoryManager::from_definitions(vec![RepositoryDefinition {
+        name: REPO_NAME.to_string(),
+        repo_type: RepositoryType::HttpRegistry,
+        priority: 0,
+        config: RepositoryConfig::HttpRegistry { index_url },
+        auth: None,
+        storage: None,
+    }])
+}
+
+/// A minimal fastskill project directory: `skill-project.toml` + an empty
+/// skills directory, ready for `add_from_origin`.
+fn setup_project(root: &Path) -> std::path::PathBuf {
+    std::fs::write(
+        root.join("skill-project.toml"),
+        "[tool.fastskill]\nskills_directory = \".claude/skills\"\n\n[dependencies]\n",
+    )
+    .unwrap();
+    let skills_dir = root.join(".claude/skills");
+    std::fs::create_dir_all(&skills_dir).unwrap();
+    skills_dir
+}
+
+async fn make_service(
+    project_root: &Path,
+    storage: &Path,
+    cache_root: &Path,
+    manager: RepositoryManager,
+) -> FastSkillService {
+    let config = ServiceConfig {
+        skill_storage_path: storage.to_path_buf(),
+        skill_cache_root: Some(cache_root.to_path_buf()),
+        ..Default::default()
+    };
+    let mut service = FastSkillService::new(config).await.unwrap();
+    service.initialize().await.unwrap();
+    service
+        .with_project_root(project_root.to_path_buf())
+        .with_repository_manager(Arc::new(manager))
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+/// Two installs of the same pinned version, into two different projects,
+/// must perform exactly one download -- the second is served from the
+/// shared content cache (US-003 acceptance criterion).
+#[tokio::test]
+async fn two_installs_of_the_same_pinned_version_download_exactly_once() {
+    let server = MockServer::start().await;
+    mount_version(&server, "1.0.0").await;
+
+    let shared_cache = TempDir::new().unwrap();
+    let origin = Origin::Repository {
+        repo: REPO_NAME.to_string(),
+        skill: SKILL_ID.to_string(),
+        version: Some(VersionConstraint::parse("1.0.0").unwrap()),
+    };
+
+    let baseline = DOWNLOAD_INVOCATIONS.load(Ordering::SeqCst);
+
+    // Project A: fresh download (cache miss).
+    let project_a = TempDir::new().unwrap();
+    let skills_a = setup_project(project_a.path());
+    let storage_a = TempDir::new().unwrap();
+    let manager_a = repo_manager(format!("{}/index", server.uri()));
+    let service_a = make_service(
+        project_a.path(),
+        storage_a.path(),
+        shared_cache.path(),
+        manager_a,
+    )
+    .await;
+    let outcome_a = service_a
+        .add_from_origin(origin.clone(), AddMode::Fresh, vec![])
+        .await
+        .expect("project A install should succeed");
+    assert_eq!(outcome_a.resolved.version, "1.0.0");
+    let _ = skills_a;
+
+    // Project B: same pinned version, different project -- must be a cache hit.
+    let project_b = TempDir::new().unwrap();
+    let skills_b = setup_project(project_b.path());
+    let storage_b = TempDir::new().unwrap();
+    let manager_b = repo_manager(format!("{}/index", server.uri()));
+    let service_b = make_service(
+        project_b.path(),
+        storage_b.path(),
+        shared_cache.path(),
+        manager_b,
+    )
+    .await;
+    let outcome_b = service_b
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await
+        .expect("project B install should succeed");
+    assert_eq!(outcome_b.resolved.version, "1.0.0");
+    let _ = skills_b;
+
+    let downloads = DOWNLOAD_INVOCATIONS.load(Ordering::SeqCst) - baseline;
+    assert_eq!(
+        downloads, 1,
+        "two installs of the same pinned version must perform exactly one download"
+    );
+
+    // Both projects ended up with byte-identical installed content (FR-8).
+    let content_a =
+        std::fs::read_to_string(storage_a.path().join(SKILL_ID).join("SKILL.md")).unwrap();
+    let content_b =
+        std::fs::read_to_string(storage_b.path().join(SKILL_ID).join("SKILL.md")).unwrap();
+    assert_eq!(content_a, content_b);
+    assert_eq!(content_a, skill_md("1.0.0"));
+}
+
+/// A pinned version already published in the content cache installs with no
+/// network at all -- the registry is unreachable and is never contacted.
+#[tokio::test]
+async fn offline_install_of_a_pinned_cached_version_needs_no_network() {
+    // Nothing listens here; any HTTP request fails fast.
+    let unreachable_index_url = "http://127.0.0.1:1/index".to_string();
+
+    let cache_root = TempDir::new().unwrap();
+    let cache = SkillCache::at_root(cache_root.path());
+    let identity = CacheIdentity::Registry {
+        source: REPO_NAME.to_string(),
+        skill: SKILL_ID.to_string(),
+        version: "1.0.0".to_string(),
+    };
+    let content_dir = TempDir::new().unwrap();
+    std::fs::write(content_dir.path().join("SKILL.md"), skill_md("1.0.0")).unwrap();
+    cache.put(&identity, content_dir.path()).unwrap();
+
+    let project = TempDir::new().unwrap();
+    let skills_dir = setup_project(project.path());
+    let storage = TempDir::new().unwrap();
+    let manager = repo_manager(unreachable_index_url);
+    let service = make_service(project.path(), storage.path(), cache_root.path(), manager).await;
+
+    let baseline = DOWNLOAD_INVOCATIONS.load(Ordering::SeqCst);
+    let origin = Origin::Repository {
+        repo: REPO_NAME.to_string(),
+        skill: SKILL_ID.to_string(),
+        version: Some(VersionConstraint::parse("1.0.0").unwrap()),
+    };
+    let outcome = service
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await
+        .expect("offline install of a pinned, cached version should succeed");
+
+    assert_eq!(outcome.resolved.version, "1.0.0");
+    assert_eq!(
+        DOWNLOAD_INVOCATIONS.load(Ordering::SeqCst) - baseline,
+        0,
+        "a pinned, cached version must install without any network download"
+    );
+    let installed =
+        std::fs::read_to_string(storage.path().join(SKILL_ID).join("SKILL.md")).unwrap();
+    assert_eq!(installed, skill_md("1.0.0"));
+    let _ = skills_dir;
+}
+
+/// `newest` (`version: None`) with no cached index fails with an actionable
+/// error naming `repos refresh`, rather than falling back to a live listing
+/// call or failing with an opaque error.
+#[tokio::test]
+async fn newest_without_a_fresh_index_fails_naming_repos_refresh() {
+    // No mocks mounted at all: a live listing call would fail loudly (connection
+    // refused / no matching route), so a passing assertion here cannot be
+    // accidentally satisfied by an unintended network fallback.
+    let server = MockServer::start().await;
+
+    let project = TempDir::new().unwrap();
+    setup_project(project.path());
+    let storage = TempDir::new().unwrap();
+    let cache_root = TempDir::new().unwrap();
+    let manager = repo_manager(format!("{}/index", server.uri()));
+    let service = make_service(project.path(), storage.path(), cache_root.path(), manager).await;
+
+    let origin = Origin::Repository {
+        repo: REPO_NAME.to_string(),
+        skill: SKILL_ID.to_string(),
+        version: None,
+    };
+    let err = service
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await
+        .expect_err("`newest` with no cached index must fail");
+
+    let message = err.to_string();
+    assert!(
+        message.contains("repos refresh"),
+        "error must name `repos refresh` as the fix, got: {message}"
+    );
+}
+
+/// `newest` resolves to a concrete version via the on-disk index (populated
+/// as if by a prior `repos refresh`), then follows the ordinary
+/// cached-content path for that resolved version.
+#[tokio::test]
+async fn newest_resolves_via_cached_index_then_downloads_the_resolved_version() {
+    let server = MockServer::start().await;
+    mount_version(&server, "2.0.0").await;
+
+    let project = TempDir::new().unwrap();
+    setup_project(project.path());
+    let storage = TempDir::new().unwrap();
+    let cache_root = TempDir::new().unwrap();
+    let cache = SkillCache::at_root(cache_root.path());
+    cache
+        .write_source_index(
+            REPO_NAME,
+            &SourceIndex {
+                fetched_at: chrono::Utc::now(),
+                entries: vec![SourceIndexEntry {
+                    skill: SKILL_ID.to_string(),
+                    versions: vec!["1.0.0".to_string(), "2.0.0".to_string()],
+                }],
+            },
+        )
+        .unwrap();
+
+    let manager = repo_manager(format!("{}/index", server.uri()));
+    let service = make_service(project.path(), storage.path(), cache_root.path(), manager).await;
+
+    let origin = Origin::Repository {
+        repo: REPO_NAME.to_string(),
+        skill: SKILL_ID.to_string(),
+        version: None,
+    };
+    let outcome = service
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await
+        .expect("newest install should resolve via the cached index and succeed");
+
+    assert_eq!(
+        outcome.resolved.version, "2.0.0",
+        "must resolve to the newest version recorded in the cached index"
+    );
+}
+
+/// `preflight` (called by `update` before every re-fetch, per `update.rs` /
+/// `skills.rs`) persists the live listing it already fetched into the
+/// on-disk index. This is what makes "`update` implicitly refreshes just the
+/// sources it touches" (PRD 006 US-003, "Resolved Defaults") true: an
+/// unpinned (`newest`) registry origin an `update` re-fetches must not
+/// require a separate, prior `repos refresh` even though `add_from_origin`'s
+/// own version resolution never calls the network directly.
+#[tokio::test]
+async fn update_flow_preflight_implicitly_refreshes_the_index_for_newest() {
+    let server = MockServer::start().await;
+    mount_version(&server, "1.0.0").await;
+
+    let project = TempDir::new().unwrap();
+    setup_project(project.path());
+    let storage = TempDir::new().unwrap();
+    let cache_root = TempDir::new().unwrap();
+    let manager = repo_manager(format!("{}/index", server.uri()));
+    let service = make_service(project.path(), storage.path(), cache_root.path(), manager).await;
+
+    let origin = Origin::Repository {
+        repo: REPO_NAME.to_string(),
+        skill: SKILL_ID.to_string(),
+        version: None,
+    };
+
+    // No index cache exists yet -- mirrors a project whose dependency was
+    // added before any `repos refresh` ever ran.
+    let cache = SkillCache::at_root(cache_root.path());
+    assert!(cache.read_source_index(REPO_NAME).unwrap().is_none());
+
+    let preflight = service
+        .preflight(&origin)
+        .await
+        .expect("preflight should succeed via its own live listing call");
+    assert!(matches!(
+        preflight,
+        fastskill_core::core::UpdatePreflight::Updatable
+    ));
+
+    // preflight's live call must have persisted an index entry...
+    let idx = cache
+        .read_source_index(REPO_NAME)
+        .unwrap()
+        .expect("preflight must persist a listing it already fetched live");
+    assert_eq!(idx.entries[0].skill, SKILL_ID);
+
+    // ...so this `Update` re-fetch resolves `newest` through the index,
+    // exactly as `update.rs` / `skills.rs` chain the two calls.
+    let outcome = service
+        .add_from_origin(origin, AddMode::Update, vec![])
+        .await
+        .expect("update re-fetch must succeed without a separate `repos refresh`");
+    assert_eq!(outcome.resolved.version, "1.0.0");
+}

--- a/crates/fastskill-core/tests/repo_index_refresh_git_test.rs
+++ b/crates/fastskill-core/tests/repo_index_refresh_git_test.rs
@@ -1,0 +1,277 @@
+//! Integration test for git-source index refresh (PRD 006 "Local Skill
+//! Cache", US-005): `RepositoryManager::refresh_index` resolves a
+//! `GitMarketplace` repository's configured branch to its current commit SHA
+//! via `ls_remote` and records it in the git-resolutions index cache.
+//!
+//! Mirrors `git_content_cache_test.rs`'s fixture (US-002): a real `git
+//! daemon` serving a bare repo over `git://127.0.0.1` on a loopback port —
+//! not "the network", nothing DNS- or host-dependent, the only way to
+//! exercise the real `ls_remote` path without a `file://` URL (SEC-11 refuses
+//! those outright).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use fastskill_core::core::cache::SkillCache;
+use fastskill_core::core::repository::{
+    RepositoryConfig, RepositoryDefinition, RepositoryManager, RepositoryType,
+};
+use std::net::{TcpListener, TcpStream};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+const SKILL_MD: &str =
+    "---\nname: repo-skill\nversion: \"1.0.0\"\ndescription: A test skill\n---\nBody\n";
+
+// ── git daemon fixture (mirrors git_content_cache_test.rs) ─────────────────
+
+struct GitDaemonFixture {
+    child: Child,
+    port: u16,
+    _base: TempDir,
+}
+
+impl GitDaemonFixture {
+    fn start(base: TempDir) -> Self {
+        // `free_loopback_port` can only *suggest* a port: it binds :0, reads the
+        // number, then drops the listener so `git daemon` can take it. Under a
+        // parallel test run another process can win that gap, and the daemon
+        // then dies immediately with "address already in use". Retry on a fresh
+        // port instead of failing the test for an unlucky race.
+        const MAX_ATTEMPTS: u32 = 10;
+        for attempt in 1..=MAX_ATTEMPTS {
+            let port = free_loopback_port();
+            let mut child = git_command()
+                .args([
+                    "daemon",
+                    "--reuseaddr",
+                    "--export-all",
+                    "--listen=127.0.0.1",
+                    &format!("--port={port}"),
+                    &format!("--base-path={}", base.path().display()),
+                ])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("failed to start `git daemon`; is git installed with daemon support?");
+
+            if wait_for_port(port, &mut child) {
+                return Self {
+                    child,
+                    port,
+                    _base: base,
+                };
+            }
+
+            // Did not come up: reap this attempt before trying another port.
+            let _ = child.kill();
+            let _ = child.wait();
+            assert!(
+                attempt < MAX_ATTEMPTS,
+                "git daemon failed to start listening after {MAX_ATTEMPTS} attempts"
+            );
+        }
+        unreachable!("loop either returns or asserts on the final attempt")
+    }
+
+    fn repo_url(&self, repo_name: &str) -> String {
+        format!("git://127.0.0.1:{}/{repo_name}", self.port)
+    }
+}
+
+impl Drop for GitDaemonFixture {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// `git` exports these to its own subprocesses (hooks, `rebase --exec`) to pin
+/// them to the invoking repository. A test run *from* such a context — most
+/// obviously this repo's own `pre-push` hook — would otherwise inherit them,
+/// and every `git` below would retarget the real repo instead of the scratch
+/// one, firing the real hooks. Always spawn git through this.
+fn git_command() -> Command {
+    let mut cmd = Command::new("git");
+    for var in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_COMMON_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_PREFIX",
+        "GIT_NAMESPACE",
+        "GIT_CEILING_DIRECTORIES",
+    ] {
+        cmd.env_remove(var);
+    }
+    cmd
+}
+
+fn free_loopback_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind ephemeral port");
+    listener
+        .local_addr()
+        .expect("failed to read local addr")
+        .port()
+}
+
+/// Poll until `port` accepts connections. Returns `false` (rather than
+/// panicking) if the daemon exits first or the deadline passes, so the caller
+/// can retry on a different port.
+fn wait_for_port(port: u16, child: &mut Child) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return true;
+        }
+        // A daemon that already exited is never going to listen -- fail this
+        // attempt immediately instead of burning the whole deadline.
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            return false;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let output = git_command()
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to execute `git {}`: {e}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "`git {}` failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Seed a bare repo at `base/<repo_name>.git` with a single commit on
+/// `branch`, including a root `.claude-plugin/marketplace.json` so the repo
+/// is also listable as a marketplace source. Returns the seeded commit's SHA.
+fn seed_bare_repo(base: &Path, repo_name: &str, branch: &str) -> String {
+    let bare_path = base.join(format!("{repo_name}.git"));
+    run_git(
+        base,
+        &["init", "--bare", "--quiet", bare_path.to_str().unwrap()],
+    );
+
+    let work = base.join(format!("{repo_name}-work"));
+    std::fs::create_dir_all(&work).unwrap();
+    run_git(&work, &["init", "--quiet"]);
+    run_git(&work, &["config", "user.email", "test@example.com"]);
+    run_git(&work, &["config", "user.name", "test"]);
+    std::fs::write(work.join("SKILL.md"), SKILL_MD).unwrap();
+    run_git(&work, &["add", "-A"]);
+    run_git(&work, &["commit", "--quiet", "-m", "init"]);
+    run_git(&work, &["branch", "-M", branch]);
+    run_git(
+        &work,
+        &["remote", "add", "origin", bare_path.to_str().unwrap()],
+    );
+    run_git(&work, &["push", "--quiet", "origin", branch]);
+
+    let output = git_command()
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&work)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+/// Refreshing a `GitMarketplace` source resolves its configured branch to the
+/// remote's current commit SHA and records that resolution in the
+/// git-resolutions index — the same cache `install::fetch_git` reads for
+/// offline resolution (US-002's acceptance criterion this unblocks) — even
+/// though the fixture repo has no marketplace.json (so the listing half of
+/// the refresh fails: `list_skills()` fetches marketplace.json over HTTP(S),
+/// a completely separate path from the git-protocol `ls_remote` this test
+/// exercises). That the resolution is recorded regardless proves the two
+/// steps are independent, per `refresh_index`'s doc comment.
+#[tokio::test]
+async fn refresh_index_records_git_ref_resolution() {
+    let daemon_base = TempDir::new().unwrap();
+    let expected_sha = seed_bare_repo(daemon_base.path(), "repo", "main");
+    let daemon = GitDaemonFixture::start(daemon_base);
+    let repo_url = daemon.repo_url("repo");
+
+    let mut manager = RepositoryManager::new(std::path::PathBuf::new());
+    manager
+        .add_repository(
+            "git-src".to_string(),
+            RepositoryDefinition {
+                name: "git-src".to_string(),
+                repo_type: RepositoryType::GitMarketplace,
+                priority: 0,
+                config: RepositoryConfig::GitMarketplace {
+                    url: repo_url.clone(),
+                    branch: Some("main".to_string()),
+                    tag: None,
+                },
+                auth: None,
+                storage: None,
+            },
+        )
+        .unwrap();
+
+    let cache_root = TempDir::new().unwrap();
+    let cache = SkillCache::at_root(cache_root.path());
+
+    let result = manager.refresh_index(&cache, "git-src").await;
+    assert!(
+        result.is_err(),
+        "the listing step must fail: nothing serves marketplace.json over HTTP for this fixture"
+    );
+
+    let resolutions = cache.read_git_resolutions().unwrap();
+    let resolution = resolutions
+        .get(&repo_url, "branch:main")
+        .expect("ls_remote resolution must be recorded under url + branch:main");
+    assert_eq!(resolution.sha, expected_sha);
+
+    // Index-only per RFQ 004: no content is fetched or cached by a refresh.
+    assert!(!cache_root.path().join("git").join(&expected_sha).exists());
+}
+
+/// An unreachable git remote fails the refresh with a clear error rather than
+/// silently skipping the ref-resolution step.
+#[tokio::test]
+async fn refresh_index_fails_when_remote_is_unreachable() {
+    let unreachable_url = "git://127.0.0.1:1/does-not-exist.git";
+
+    let mut manager = RepositoryManager::new(std::path::PathBuf::new());
+    manager
+        .add_repository(
+            "unreachable".to_string(),
+            RepositoryDefinition {
+                name: "unreachable".to_string(),
+                repo_type: RepositoryType::GitMarketplace,
+                priority: 0,
+                config: RepositoryConfig::GitMarketplace {
+                    url: unreachable_url.to_string(),
+                    branch: Some("main".to_string()),
+                    tag: None,
+                },
+                auth: None,
+                storage: None,
+            },
+        )
+        .unwrap();
+
+    let cache_root = TempDir::new().unwrap();
+    let cache = SkillCache::at_root(cache_root.path());
+
+    let result = manager.refresh_index(&cache, "unreachable").await;
+    assert!(result.is_err(), "refresh must fail, not silently succeed");
+    assert!(cache.read_source_index("unreachable").unwrap().is_none());
+}

--- a/tests/cli/fixtures/minimal-skill/skill-project.toml
+++ b/tests/cli/fixtures/minimal-skill/skill-project.toml
@@ -1,5 +1,0 @@
-[metadata]
-id = "test-minimal"
-version = "1.0.0"
-name = "test-skill-minimal"
-description = "A minimal test skill for E2E testing"

--- a/tests/cli/repos_integration_tests.rs
+++ b/tests/cli/repos_integration_tests.rs
@@ -5,7 +5,7 @@
 
 #![allow(clippy::all, clippy::unwrap_used, clippy::expect_used)]
 
-use super::snapshot_helpers::run_fastskill_command;
+use super::snapshot_helpers::{run_fastskill_command, run_fastskill_command_with_env};
 use std::fs;
 use tempfile::TempDir;
 
@@ -98,8 +98,17 @@ fn test_repos_complete_workflow_matrix() {
     );
     assert!(test.stdout.contains("Testing repository: matrix-local"));
 
-    let refresh_one =
-        run_fastskill_command(&["repos", "refresh", "matrix-local"], Some(temp_dir.path()));
+    // PRD 006 "Local Skill Cache" (US-005): `repos refresh` now does a real
+    // on-disk index refresh via `SkillCache`. Point it at a scratch cache dir
+    // so the test never touches the developer/CI machine's real cache.
+    let cache_dir = TempDir::new().unwrap();
+    let cache_dir_str = cache_dir.path().to_str().unwrap();
+
+    let refresh_one = run_fastskill_command_with_env(
+        &["repos", "refresh", "matrix-local"],
+        &[("FASTSKILL_CACHE_DIR", cache_dir_str)],
+        Some(temp_dir.path()),
+    );
     assert!(
         refresh_one.success,
         "repos refresh <name> failed: {}{}",
@@ -107,9 +116,18 @@ fn test_repos_complete_workflow_matrix() {
     );
     assert!(refresh_one
         .stdout
-        .contains("Refreshed cache for repository: matrix-local"));
+        .contains("Refreshed matrix-local: 1 skill"));
+    assert!(cache_dir
+        .path()
+        .join("index")
+        .join("matrix-local.json")
+        .is_file());
 
-    let refresh_all = run_fastskill_command(&["repos", "refresh"], Some(temp_dir.path()));
+    let refresh_all = run_fastskill_command_with_env(
+        &["repos", "refresh"],
+        &[("FASTSKILL_CACHE_DIR", cache_dir_str)],
+        Some(temp_dir.path()),
+    );
     assert!(
         refresh_all.success,
         "repos refresh failed: {}{}",
@@ -117,7 +135,7 @@ fn test_repos_complete_workflow_matrix() {
     );
     assert!(refresh_all
         .stdout
-        .contains("Refreshed cache for all repositories"));
+        .contains("Refreshed matrix-local: 1 skill"));
 
     let skills = run_fastskill_command(
         &["repos", "skills", "--repository", "matrix-local"],
@@ -204,4 +222,127 @@ fn test_repos_help_does_not_advertise_search() {
     assert!(repos_help.stdout.contains("skills"));
     assert!(repos_help.stdout.contains("show"));
     assert!(repos_help.stdout.contains("versions"));
+}
+
+// ── PRD 006 "Local Skill Cache", US-005: `repos refresh` real semantics ────
+
+/// `refresh <name>` for a repository that was never added must fail with an
+/// error and a non-zero exit — not the old fake-success message.
+#[test]
+fn test_repos_refresh_unknown_repository_fails() {
+    let temp_dir = TempDir::new().unwrap();
+    write_project_manifest(temp_dir.path());
+    let cache_dir = TempDir::new().unwrap();
+
+    let refresh = run_fastskill_command_with_env(
+        &["repos", "refresh", "does-not-exist"],
+        &[("FASTSKILL_CACHE_DIR", cache_dir.path().to_str().unwrap())],
+        Some(temp_dir.path()),
+    );
+
+    assert!(
+        !refresh.success,
+        "refresh of an unknown repository must fail: {}{}",
+        refresh.stdout, refresh.stderr
+    );
+    assert!(refresh.stderr.contains("does-not-exist"));
+    assert!(refresh.stderr.contains("not found"));
+}
+
+/// Refreshing "all" repositories when one source fails (a `local` repository
+/// pointing at a path that does not exist) must still refresh the remaining,
+/// healthy sources — reporting each outcome — and exit non-zero overall.
+#[test]
+fn test_repos_refresh_all_partial_failure_still_refreshes_others_and_exits_nonzero() {
+    let temp_dir = TempDir::new().unwrap();
+    write_project_manifest(temp_dir.path());
+    let cache_dir = TempDir::new().unwrap();
+    let cache_dir_str = cache_dir.path().to_str().unwrap();
+
+    let good_repo_path = write_local_skill_repo(temp_dir.path(), "healthy-skill", "1.0.0");
+    let add_good = run_fastskill_command(
+        &[
+            "repos",
+            "add",
+            "healthy",
+            "--repo-type",
+            "local",
+            good_repo_path.to_str().unwrap(),
+        ],
+        Some(temp_dir.path()),
+    );
+    assert!(add_good.success, "{}{}", add_good.stdout, add_good.stderr);
+
+    let missing_path = temp_dir.path().join("this-path-does-not-exist");
+    let add_bad = run_fastskill_command(
+        &[
+            "repos",
+            "add",
+            "broken",
+            "--repo-type",
+            "local",
+            missing_path.to_str().unwrap(),
+        ],
+        Some(temp_dir.path()),
+    );
+    assert!(add_bad.success, "{}{}", add_bad.stdout, add_bad.stderr);
+
+    let refresh_all = run_fastskill_command_with_env(
+        &["repos", "refresh"],
+        &[("FASTSKILL_CACHE_DIR", cache_dir_str)],
+        Some(temp_dir.path()),
+    );
+
+    assert!(
+        !refresh_all.success,
+        "overall refresh must exit non-zero when any source fails: {}{}",
+        refresh_all.stdout, refresh_all.stderr
+    );
+    // The healthy source still refreshed and reported its outcome...
+    assert!(refresh_all.stdout.contains("Refreshed healthy: 1 skill"));
+    assert!(cache_dir
+        .path()
+        .join("index")
+        .join("healthy.json")
+        .is_file());
+    // ...and the broken source's failure was reported too, not swallowed.
+    assert!(refresh_all.stderr.contains("broken"));
+    assert!(!cache_dir.path().join("index").join("broken.json").exists());
+}
+
+/// A successful refresh persists a `SourceIndex` to disk under the resolved
+/// cache root, containing the skill(s) the source advertised.
+#[test]
+fn test_repos_refresh_writes_source_index_to_disk() {
+    let temp_dir = TempDir::new().unwrap();
+    write_project_manifest(temp_dir.path());
+    let cache_dir = TempDir::new().unwrap();
+
+    let repo_path = write_local_skill_repo(temp_dir.path(), "indexed-skill", "2.3.4");
+    let add = run_fastskill_command(
+        &[
+            "repos",
+            "add",
+            "idx-repo",
+            "--repo-type",
+            "local",
+            repo_path.to_str().unwrap(),
+        ],
+        Some(temp_dir.path()),
+    );
+    assert!(add.success, "{}{}", add.stdout, add.stderr);
+
+    let refresh = run_fastskill_command_with_env(
+        &["repos", "refresh", "idx-repo"],
+        &[("FASTSKILL_CACHE_DIR", cache_dir.path().to_str().unwrap())],
+        Some(temp_dir.path()),
+    );
+    assert!(refresh.success, "{}{}", refresh.stdout, refresh.stderr);
+
+    let index_path = cache_dir.path().join("index").join("idx-repo.json");
+    let index_contents = fs::read_to_string(&index_path)
+        .unwrap_or_else(|e| panic!("expected index file at {}: {e}", index_path.display()));
+    assert!(index_contents.contains("indexed-skill"));
+    assert!(index_contents.contains("2.3.4"));
+    assert!(index_contents.contains("fetched_at"));
 }

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_directory_walking.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_directory_walking.snap
@@ -33,6 +33,7 @@ Setup:
           Usage: doctor [OPTIONS]
 Other:
   analyze      Diagnostic and analysis commands
+  cache        Inspect and reclaim the on-disk skill content cache
   completion   Emit a shell completion stub for top-level subcommands
   eval         Evaluation commands for skill quality assurance
   marketplace  Create and manage skill marketplace artifacts

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_finds_skills_in_current_dir.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_finds_skills_in_current_dir.snap
@@ -33,6 +33,7 @@ Setup:
           Usage: doctor [OPTIONS]
 Other:
   analyze      Diagnostic and analysis commands
+  cache        Inspect and reclaim the on-disk skill content cache
   completion   Emit a shell completion stub for top-level subcommands
   eval         Evaluation commands for skill quality assurance
   marketplace  Create and manage skill marketplace artifacts

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_with_env_var.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__cli_with_env_var.snap
@@ -33,6 +33,7 @@ Setup:
           Usage: doctor [OPTIONS]
 Other:
   analyze      Diagnostic and analysis commands
+  cache        Inspect and reclaim the on-disk skill content cache
   completion   Emit a shell completion stub for top-level subcommands
   eval         Evaluation commands for skill quality assurance
   marketplace  Create and manage skill marketplace artifacts

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__help_flag.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__help_flag.snap
@@ -33,6 +33,7 @@ Setup:
           Usage: doctor [OPTIONS]
 Other:
   analyze      Diagnostic and analysis commands
+  cache        Inspect and reclaim the on-disk skill content cache
   completion   Emit a shell completion stub for top-level subcommands
   eval         Evaluation commands for skill quality assurance
   marketplace  Create and manage skill marketplace artifacts

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__help_no_args.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__help_no_args.snap
@@ -33,6 +33,7 @@ Setup:
           Usage: doctor [OPTIONS]
 Other:
   analyze      Diagnostic and analysis commands
+  cache        Inspect and reclaim the on-disk skill content cache
   completion   Emit a shell completion stub for top-level subcommands
   eval         Evaluation commands for skill quality assurance
   marketplace  Create and manage skill marketplace artifacts

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__help_short_flag.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__help_short_flag.snap
@@ -33,6 +33,7 @@ Setup:
           Usage: doctor [OPTIONS]
 Other:
   analyze      Diagnostic and analysis commands
+  cache        Inspect and reclaim the on-disk skill content cache
   completion   Emit a shell completion stub for top-level subcommands
   eval         Evaluation commands for skill quality assurance
   marketplace  Create and manage skill marketplace artifacts

--- a/webdocs/cli-reference/cache-command.mdx
+++ b/webdocs/cli-reference/cache-command.mdx
@@ -1,0 +1,94 @@
+---
+title: "cache Command"
+description: "Inspect and reclaim the on-disk skill content cache with fastskill cache."
+---
+
+# cache Command
+
+Inspect and reclaim the on-disk cache that `add`, `install`, and `update` use so a skill's
+content is fetched once per machine instead of once per project.
+
+<Callout type="info">
+Every git, registry, or local skill fetch is checked against this cache before touching the
+network again. `fastskill cache` is how to see what has accumulated there and reclaim disk
+space -- fastskill never evicts cache entries on its own.
+</Callout>
+
+## Usage
+
+```bash
+fastskill cache <SUBCOMMAND>
+```
+
+## Subcommands
+
+### info
+
+Show the cache location plus entry counts and disk usage, broken down by source kind (git,
+registry, or local).
+
+```bash
+# Human-readable summary
+fastskill cache info
+
+# JSON output
+fastskill cache info --json
+```
+
+**Example output**:
+```
+Cache location: /home/user/.cache/fastskill
+
+  • git      3 entries, 12.4 MB
+  • registry 5 entries, 3.1 MB
+  • local    1 entry, 45.6 KB
+
+Total: 9 entries, 15.6 MB
+```
+
+**Options**:
+- `--format <table|json>`: Output format (default: table)
+- `--json`: Shorthand for `--format json` (mutually exclusive with `--format`)
+
+### clean
+
+Remove cached skill content and print how many bytes were reclaimed.
+
+```bash
+# Remove every cached entry
+fastskill cache clean
+
+# Remove only one source kind
+fastskill cache clean --source git
+fastskill cache clean --source registry
+fastskill cache clean --source local
+
+# Machine-readable result
+fastskill cache clean --json
+```
+
+**Options**:
+- `--source <git|registry|local>`: Limit cleaning to one source kind (default: all)
+- `--json`: Print the result as JSON instead of a summary line
+
+**What it removes**: Only cached skill content -- the record of what a repository currently
+advertises (what `repos refresh` writes) is left alone, so `repos refresh` output stays valid
+after a clean. There is nothing to undo: the next `add`/`install`/`update` that needs a removed
+entry re-fetches it from its original source.
+
+**Safe with other fastskill processes running**: `clean` never removes an entry another process
+is mid-write on, and every write elsewhere is atomic. In the worst case, a fetch running at the
+exact moment of a clean simply re-fetches -- it never sees partial or corrupted content.
+
+## When to run it
+
+- **`cache info`**: Before a `clean`, to see what is actually taking up space, or when disk
+  usage seems higher than expected.
+- **`cache clean`**: To reclaim disk space after finishing with skills from a source no longer
+  in use, or as routine cleanup on a machine used for many short-lived projects.
+
+## See Also
+
+- [repos Command](/cli-reference/repository-command) -- refresh what a repository advertises
+  (`repos refresh`), independent of the content cache `cache` manages
+- [Install Command](/cli-reference/install-command) -- installs that hit this cache

--- a/webdocs/cli-reference/meta.json
+++ b/webdocs/cli-reference/meta.json
@@ -10,6 +10,7 @@
     "search-command",
     "serve-command",
     "repository-command",
+    "cache-command",
     "eval-command",
     "tooling-commands"
   ]

--- a/webdocs/cli-reference/overview.mdx
+++ b/webdocs/cli-reference/overview.mdx
@@ -117,6 +117,10 @@ fastskill list --help         # Help for list command
   <Card title="fastskill doctor">
     Check environment readiness (skills directory, embedding provider, auth). See [tooling commands](/cli-reference/tooling-commands#fastskill-doctor).
   </Card>
+  <Card title="fastskill cache">
+    Inspect or reclaim the on-disk skill content cache (`info`, `clean --source
+    <git|registry|local>`). See [cache Command](/cli-reference/cache-command).
+  </Card>
 </Cards>
 
 ## Version Command

--- a/webdocs/cli-reference/repository-command.mdx
+++ b/webdocs/cli-reference/repository-command.mdx
@@ -202,25 +202,45 @@ fastskill repos test team-skills
 
 ### refresh
 
-Refresh repository cache (re-fetch from source).
+Refresh what a repository currently advertises: its skills and their versions for a registry or
+git marketplace, or the resolved commit for a git repository's branch or tag.
 
 ```bash
-# Refresh specific repository
+# Refresh a specific repository
 fastskill repos refresh team-skills
 
-# Refresh all repositories
+# Refresh all configured repositories
 fastskill repos refresh
 ```
 
 **When to use**:
-- After repository has been updated with new skills
-- To get latest skill versions
-- If cache is stale or corrupted
+- After a repository has been updated with new skills or versions
+- Before installing with an unpinned version constraint (`newest`), so it resolves against
+  current data instead of failing with a "run `fastskill repos refresh`" error
+- If a repository's advertised skills seem stale
 
 **What it does**:
-- Re-fetches repository metadata
-- Updates local cache
-- Invalidates stale skill information
+- Contacts each targeted repository and records what it currently advertises
+- For a git repository, resolves its configured branch or tag to the current commit
+- Prints what was refreshed, by name and skill/entry count, for example:
+  ```
+  [OK] Refreshed team-skills: 12 skills
+  ```
+- Refreshing an unknown repository name fails rather than reporting fake success
+- With no name given, every configured repository is attempted; one repository's failure does
+  not stop the rest, and each failure is reported individually
+- Exits non-zero if any repository failed to refresh
+
+<Callout type="warn">
+`refresh` is a real network operation: it can fail if a repository is unreachable. Scripts
+calling `fastskill repos refresh` should check its exit code.
+</Callout>
+
+<Callout type="info">
+`refresh` only updates what a repository advertises -- it never downloads skill content. To see
+or reclaim previously downloaded skill content, use
+[`fastskill cache`](/cli-reference/cache-command).
+</Callout>
 
 ### skills
 
@@ -535,3 +555,5 @@ Repositories configuration is stored in `skill-project.toml` and should be commi
 - [Search Command](/cli-reference/search-command) - Semantic search for installed skills
 - [Install Command](/cli-reference/skill-commands#fastskill-install) - Installing skills from repositories
 - [Init Command](/cli-reference/skill-commands#fastskill-init) - Creating skill-project.toml
+- [cache Command](/cli-reference/cache-command) - Inspect or reclaim previously downloaded
+  skill content


### PR DESCRIPTION
## What

Implements the local skill cache from PRD 006 (design settled in RFQ 004): a machine-global, content-addressed store for fetched skill content, plus the per-source index it is resolved against.

Today every `add`/`install`/`update` fetches live from the source, in every project directory separately, and `fastskill repos refresh` is a no-op that prints a fake success message. This closes both gaps.

## Correctness model

Resolve every request to an **immutable identity**, then content-address on it:

| Source | Identity | Cheap "what's new" check |
|---|---|---|
| git | commit SHA | `git ls-remote` (new primitive) |
| registry | pinned version | index re-resolve |
| local | tree-hash (archive bytes for `.zip`) | rehash, no network |

`Origin::ZipUrl` is **deliberately untouched** (byte-for-byte unchanged): a bare URL carries no version identity, so its staleness policy — HTTP validators (`ETag`/`Last-Modified`) with a download-then-hash fallback — is a follow-up. Editable installs (`add -e`) still bypass the cache entirely.

## User-visible changes

- **`fastskill repos refresh [name]` now does something.** It refreshes each source's on-disk index, reports per-source failures, and **exits non-zero if any source failed**. Previously it always printed success and exited 0. Scripts/CI that call it may newly see failures — that is the fix, not a regression.
- **New `fastskill cache info`** — cache location, entry count and size per source type.
- **New `fastskill cache clean [--source git|registry|local]`** — manual reclamation, prints bytes reclaimed. Retention is keep-forever by design; there is no automatic GC in v1.
- Everything else keeps its flags and output; installs just get faster and work offline on a cache hit.

## Included bug fix (please review separately)

`checkout_branch_or_tag` built `git checkout -- <ref>`, which is git's **pathspec-restore** syntax, not ref-switch. It fails with `pathspec '<ref>' did not match any file(s)` for every real branch/tag, and `clone_repository` calls it unconditionally whenever `--branch`/`--tag` is set — so **no `Origin::Git` install with an explicit branch or tag could ever succeed**. Verified directly against `git`.

Fixed by fully-qualifying the ref (`refs/heads/<n>` / `refs/tags/<n>`), which preserves the SEC-12 property that the argument can never begin with `-` and so can never be read as a flag.

This is in scope only because US-002 depends on branch/tag installs working. It's isolated to `build_checkout_args` + its caller if you'd prefer it split out.

## Second bug fix: inherited `GIT_DIR` retargeted our git subprocesses

`git_head_commit` (and every other git spawn) inherited `GIT_DIR`/`GIT_WORK_TREE` from an enclosing git invocation. **`GIT_DIR` overrides `Command::current_dir`**, so `fastskill` run from inside any git context — a hook, `rebase --exec`, an alias — would `rev-parse HEAD` against the *enclosing* repo and record that as the commit it had just cloned.

This is not hypothetical: it is exactly how this branch's own `pre-push` hook failed. The test resolved `948e18ab`, a real commit in this repository, instead of its fixture's SHA. The codebase already knew about this class of bug and defends against it in `change_detection.rs`; this extends the same defence to all git invocations via a shared `scrub_inherited_git_env`, plus the test fixtures.

## Safety notes

- **Cache writes** stage into a private `tmp/` dir and publish via a single atomic rename, so a reader never observes a torn entry and a concurrent duplicate `put` degrades to a no-op. Windows gets a bounded rename retry.
- **`cache clean` deletes directories**, so it is deliberately paranoid: it refuses to run unless every top-level entry under the resolved root looks like a fastskill cache; only ever descends `git/`/`registry/`/`local/`; never follows symlinks; and re-canonicalizes each entry against the root immediately before removal. `--source` is enum-typed, so no user string is ever concatenated into a filesystem path. Covered by tests including a planted symlink escaping the cache root.
- `clean` leaves the **index** intact — only content is reclaimed, so resolution stays valid afterward.

## Testing

- **1134 tests pass** (+60 vs main). Full suite run 6x green, including under the `GIT_DIR` condition below.
- Proof tests use counting seams to assert the cache actually prevents work: two installs of the same git ref perform **exactly one clone**; two installs of the same pinned registry version perform **exactly one download**; a second local install performs **zero copies**.
- **Offline sweep** (`offline_verification_sweep_test.rs`): populates the cache against local fixtures, then kills the git daemon / points at unreachable `127.0.0.1:1`, and proves git, registry and local installs still succeed with **byte-identical** content — while `newest`-resolution and `update` fail with actionable errors naming `repos refresh` rather than panicking or silently serving stale content.
- No test touches the real network or the real user cache dir. The `git daemon` fixtures retry on a fresh port, since binding `:0` and releasing it can lose the port to another test under parallel load (this was observed once and fixed, not retried away).

## Notes for reviewers

- Three `#[doc(hidden)] pub static *_INVOCATIONS: AtomicUsize` counters live in production code purely so integration tests (a separate compilation unit) can assert "no fetch happened". Cheap and documented, but flagging it as a deliberate trade-off.
- `preflight`'s `Origin::Repository` branch now persists its live version listing into the index. Without this, `update` on an unpinned registry dependency would start demanding `repos refresh` even though `preflight` had just made a live call — this keeps `update` implicitly refreshing only the sources it touches.
- The in-memory `marketplace_cache`/`cache_ttl_seconds` in `SourcesManager` is **not** yet backed by the on-disk index. There is no double-caching bug today (it's a one-shot per client), but reconciling them is a natural follow-up.

## Follow-ups (deliberately out of scope)

1. zip-url caching + staleness policy
2. Automatic GC / size caps (v1 is keep-forever + manual `clean`)
3. Hardlinking into project dirs (installs still copy; the win here is fetch time, not target disk)
4. Backing `SourcesManager`'s in-memory cache with the on-disk index

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmpE6bvMsDtWDjmUP9wfu
