### PR TITLE
Support macOS in install.sh; re-enable stale-ignored init test

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -156,16 +156,29 @@ detect_platform() {
             ;;
     esac
     
-    # Currently only Linux x86_64 is supported
-    if [ "$os" != "linux" ] || [ "$arch" != "x86_64" ]; then
-        error "Currently only Linux x86_64 is supported. Detected: ${os} ${arch}"
-    fi
-    
+    # Supported platforms: Linux x86_64 (gnu/musl auto-detected) and macOS x86_64/arm64.
+    # Windows and Linux arm64 are not published by the release workflow.
+    case "$os" in
+        linux)
+            if [ "$arch" != "x86_64" ]; then
+                error "Unsupported platform: ${os} ${arch}. Supported platforms: Linux (x86_64), macOS (x86_64, arm64)."
+            fi
+            ;;
+        macos)
+            if [ "$arch" != "x86_64" ] && [ "$arch" != "arm64" ]; then
+                error "Unsupported platform: ${os} ${arch}. Supported platforms: Linux (x86_64), macOS (x86_64, arm64)."
+            fi
+            ;;
+        *)
+            error "Unsupported platform: ${os} ${arch}. Supported platforms: Linux (x86_64), macOS (x86_64, arm64)."
+            ;;
+    esac
+
     # For Linux x86_64, detect glibc version to choose appropriate binary
-    if [ "$os" = "linux" ] && [ "$arch" = "x86_64" ]; then
+    if [ "$os" = "linux" ]; then
         local glibc_ver
         glibc_ver=$(detect_glibc_version)
-        
+
         # Compare version: glibc >= 2.38 uses gnu binary, otherwise use musl
         # Use awk for floating point comparison
         if [ "$glibc_ver" != "0" ] && awk "BEGIN {exit !($glibc_ver >= 2.38)}" 2>/dev/null; then
@@ -181,8 +194,16 @@ detect_platform() {
         fi
         return
     fi
-    
-    echo "${arch}-unknown-${os}-gnu"
+
+    # macOS: map arch to the published target triple
+    if [ "$os" = "macos" ]; then
+        if [ "$arch" = "arm64" ]; then
+            echo "aarch64-apple-darwin"
+        else
+            echo "x86_64-apple-darwin"
+        fi
+        return
+    fi
 }
 
 # Fetch latest version from GitHub API

--- a/tests/cli/init_tests.rs
+++ b/tests/cli/init_tests.rs
@@ -11,24 +11,11 @@ use tempfile::TempDir;
 
 /// T037: Test fastskill init creating skill-project.toml with metadata
 ///
-/// REAL PRODUCT BUG (do not remove `#[ignore]` until fixed in `crates/fastskill-cli`):
-/// `InitArgs::command_spec()` in `crates/fastskill-cli/src/commands/init.rs` declares a
-/// custom `--version` argument that collides with clap's auto-generated `--version` flag.
-/// This trips a clap debug_assert and panics on **every** invocation of `init` in debug
-/// builds, not just `--version` usage:
-///   $ ./target/debug/fastskill init --help
-///   thread 'main' panicked at .../clap_builder-4.6.0/src/builder/debug_asserts.rs:99:13:
-///   Command init: Argument names must be unique, but 'version' is in use by more than
-///   one argument or group (call `cmd.disable_version_flag(true)` to remove the
-///   auto-generated `--version`)
-///   $ ./target/debug/fastskill init --yes   # also panics
-/// Fix requires either renaming the custom flag or calling `disable_version_flag(true)`
-/// on the generated clap Command for `init`, in production code this test's owner may
-/// not modify. Re-enable once that lands.
+/// Verifies that `fastskill init --yes --set-version <v> --description <d> --author <a>`
+/// creates a `skill-project.toml` populated with the given metadata. `init`'s
+/// value-setting flag is `--set-version` (not `--version`, which clap reserves for its
+/// auto-generated `-V/--version` flag that prints the CLI version).
 #[test]
-#[ignore = "REAL BUG: init's custom --version arg collides with clap's auto-generated \
-            --version flag (debug_assert panic on every `init` invocation, not just \
-            --version usage); see crates/fastskill-cli/src/commands/init.rs InitArgs::command_spec()"]
 fn test_init_creates_skill_project_toml_with_metadata() {
     let temp_dir = TempDir::new().unwrap();
     let skill_dir = temp_dir.path().join("test-skill");
@@ -57,7 +44,7 @@ capabilities:
         &[
             "init",
             "--yes",
-            "--version",
+            "--set-version",
             "1.0.0",
             "--description",
             "A test skill",

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__init_with_metadata.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__init_with_metadata.snap
@@ -1,8 +1,8 @@
 ---
-source: tests/cli/snapshot_helpers.rs
+source: crates/fastskill-cli/../../tests/cli/snapshot_helpers.rs
+assertion_line: 277
 expression: normalized
 ---
-FastSkill [VERSION]
 FastSkill Skill Initialization
 
 [OK] Created skill-project.toml with version: [VERSION]


### PR DESCRIPTION
Two pieces of fallout from already-merged work (#225 / #226).

## 🔴 `install.sh` rejected macOS despite shipping macOS binaries

The script **already** detected `Darwin → macos` and `arm64`, then threw both away four lines later:

```sh
# Currently only Linux x86_64 is supported
if [ "$os" != "linux" ] || [ "$arch" != "x86_64" ]; then
    error "Currently only Linux x86_64 is supported. ..."
```

Meanwhile `release.yml` publishes `fastskill-aarch64-apple-darwin.tar.gz` and `fastskill-x86_64-apple-darwin.tar.gz`, and the README advertises the script under **"Linux & macOS"**. So every Mac user following the documented install path hit a hard error. The artifacts existed and the detection existed — only the mapping was missing.

Linux glibc-vs-musl selection is unchanged. Genuinely unbuilt combinations (Linux arm64, Windows) still fail, but now name what *is* supported rather than claiming Linux-only.

**Verified without performing any install** — `uname` stubbed, `detect_platform` called directly:

| uname -s | uname -m | resolved |
|---|---|---|
| Darwin | arm64 | `aarch64-apple-darwin` |
| Darwin | aarch64 | `aarch64-apple-darwin` |
| Darwin | x86_64 | `x86_64-apple-darwin` |
| Linux | x86_64 | `…-linux-musl` / `…-linux-gnu` per glibc |
| Linux | aarch64 | clear error |
| MINGW / FreeBSD | — | clear error |

Resolved triples match `release.yml` asset names exactly (`fastskill-${platform}.tar.gz`), so no 404 risk. `shellcheck` and `bash -n` clean. No README change needed — its "Linux & macOS" claim simply becomes true.

## 🔴 An init test was `#[ignore]`d for a bug that is already fixed

`test_init_creates_skill_project_toml_with_metadata` still carried:

> *"REAL BUG: init's custom --version arg collides with clap's auto-generated --version"*

That bug was fixed in #225 (flag renamed to `--set-version`). The stale ignore reason hid a second problem: the test itself still passed `--version`, which now just prints the CLI version instead of initializing.

Points it at `--set-version`, replaces the obsolete comment, removes the `#[ignore]`. The test asserts the **written metadata** (`version = "1.0.0"`, description, author), so it proves the flag genuinely works rather than that the command merely exited 0. Its snapshot drops a stray `FastSkill [VERSION]` banner line — the same banner removal already applied across the other snapshots.

The other remaining ignores are legitimate and untouched: `test_eval_run_persists_event_trace_jsonl` (real upstream aikit bug) and `test_reindex_with_force_flag` (needs a real `OPENAI_API_KEY`).

## Verification

- Repo gate: **1138 tests, 1136 passing, 0 failing**.
- CI parity, run locally with agent CLIs stripped from `PATH`, from a directory with no ancestor `skill-project.toml`, using the coverage job's exact command: **1123 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPWdJZDbVTzy3rBcgbP1E8