### PR TITLE
feat(cache): cache zip-url downloads behind HTTP validators

### DIFF
--- a/crates/fastskill-cli/src/commands/cache.rs
+++ b/crates/fastskill-cli/src/commands/cache.rs
@@ -157,16 +157,16 @@ impl IntoCommandSpec for CacheCleanArgs {
     fn command_spec() -> CommandSpec {
         CommandSpec {
             summary: "Remove cached skill content and print bytes reclaimed",
-            syntax: Some("cache clean [--source <git|registry|local>]"),
+            syntax: Some("cache clean [--source <git|registry|local|zip>]"),
             category: Some("cache"),
             args: vec![
                 ArgSpec {
                     name: "source",
                     kind: ArgKind::Option,
                     long: Some("source"),
-                    value_type: ArgValueType::Enum(vec!["git", "registry", "local"]),
+                    value_type: ArgValueType::Enum(vec!["git", "registry", "local", "zip"]),
                     cardinality: Cardinality::Optional,
-                    help: "Limit cleaning to one source kind: git, registry, or local \
+                    help: "Limit cleaning to one source kind: git, registry, local, or zip \
                            (default: all)",
                     ..Default::default()
                 },

--- a/crates/fastskill-core/src/core/cache/index.rs
+++ b/crates/fastskill-core/src/core/cache/index.rs
@@ -8,6 +8,9 @@
 //!   advertises (skills + versions), one file per source.
 //! - US-002 reads and writes [`GitResolutions`] — the `url+ref -> sha` map
 //!   that lets an offline install proceed from a previously-resolved ref.
+//! - Spec 007 (zip-url caching) reads and writes [`ZipValidators`] — the
+//!   `url -> {etag/last_modified, content_hash, fetched_at}` map that backs
+//!   the conditional-request staleness check for `Origin::ZipUrl`.
 
 use crate::core::cache::validate_component;
 use crate::core::service::ServiceError;
@@ -18,6 +21,7 @@ use std::path::{Path, PathBuf};
 
 const INDEX_DIR_NAME: &str = "index";
 const GIT_RESOLUTIONS_FILE_NAME: &str = "git-resolutions.json";
+const ZIP_VALIDATORS_FILE_NAME: &str = "zip-validators.json";
 
 /// `<cache-root>/index/<source>.json` — what a single configured source
 /// currently advertises: which skills, at which versions. Written by a real
@@ -94,6 +98,50 @@ impl GitResolutions {
     }
 }
 
+/// A single zip-URL fetch's recorded HTTP validators, plus the content hash
+/// they produced (spec 007 FR-2/FR-3). `etag`/`last_modified` are each
+/// optional because a server may supply either, both, or neither — with
+/// neither, only the "download-then-hash" dedup fallback applies (no
+/// fetch-time saving, no offline check; see spec 007's design notes).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ZipValidator {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub etag: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_modified: Option<String>,
+    pub content_hash: String,
+    pub fetched_at: DateTime<Utc>,
+}
+
+/// `<cache-root>/index/zip-validators.json` — `url -> ZipValidator` (spec
+/// 007 FR-2). A newtype over the map (rather than a bare `HashMap<String,
+/// ZipValidator>` alias), mirroring [`GitResolutions`], so the flat JSON
+/// object the spec calls for lives at exactly one call site. Serialized
+/// `#[serde(transparent)]` for the same reason.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ZipValidators(HashMap<String, ZipValidator>);
+
+impl ZipValidators {
+    /// Look up a previously-recorded validator for `url`.
+    pub fn get(&self, url: &str) -> Option<&ZipValidator> {
+        self.0.get(url)
+    }
+
+    /// Record (or replace) the validator for `url`.
+    pub fn insert(&mut self, url: &str, validator: ZipValidator) {
+        self.0.insert(url.to_string(), validator);
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
 fn index_dir(root: &Path) -> PathBuf {
     root.join(INDEX_DIR_NAME)
 }
@@ -129,6 +177,19 @@ pub(super) fn write_git_resolutions(
 ) -> Result<(), ServiceError> {
     let path = index_dir(root).join(GIT_RESOLUTIONS_FILE_NAME);
     write_json(&path, resolutions)
+}
+
+pub(super) fn read_zip_validators(root: &Path) -> Result<ZipValidators, ServiceError> {
+    let path = index_dir(root).join(ZIP_VALIDATORS_FILE_NAME);
+    Ok(read_json(&path)?.unwrap_or_default())
+}
+
+pub(super) fn write_zip_validators(
+    root: &Path,
+    validators: &ZipValidators,
+) -> Result<(), ServiceError> {
+    let path = index_dir(root).join(ZIP_VALIDATORS_FILE_NAME);
+    write_json(&path, validators)
 }
 
 fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> Result<Option<T>, ServiceError> {
@@ -232,5 +293,57 @@ mod tests {
         let root = TempDir::new().unwrap();
         let resolutions = read_git_resolutions(root.path()).unwrap();
         assert!(resolutions.is_empty());
+    }
+
+    #[test]
+    fn zip_validators_round_trip_and_key_on_url() {
+        let root = TempDir::new().unwrap();
+        let mut validators = ZipValidators::default();
+        let now = Utc::now();
+        validators.insert(
+            "https://example.com/pkg.zip",
+            ZipValidator {
+                etag: Some("\"abc123\"".to_string()),
+                last_modified: Some("Wed, 21 Oct 2015 07:28:00 GMT".to_string()),
+                content_hash: "deadbeef".to_string(),
+                fetched_at: now,
+            },
+        );
+        validators.insert(
+            "https://example.com/no-validators.zip",
+            ZipValidator {
+                etag: None,
+                last_modified: None,
+                content_hash: "cafef00d".to_string(),
+                fetched_at: now,
+            },
+        );
+
+        write_zip_validators(root.path(), &validators).unwrap();
+        let read_back = read_zip_validators(root.path()).unwrap();
+
+        let with_validators = read_back.get("https://example.com/pkg.zip").unwrap();
+        assert_eq!(with_validators.etag.as_deref(), Some("\"abc123\""));
+        assert_eq!(
+            with_validators.last_modified.as_deref(),
+            Some("Wed, 21 Oct 2015 07:28:00 GMT")
+        );
+        assert_eq!(with_validators.content_hash, "deadbeef");
+
+        let without_validators = read_back
+            .get("https://example.com/no-validators.zip")
+            .unwrap();
+        assert_eq!(without_validators.etag, None);
+        assert_eq!(without_validators.last_modified, None);
+        assert_eq!(without_validators.content_hash, "cafef00d");
+
+        assert_eq!(read_back.len(), 2);
+    }
+
+    #[test]
+    fn zip_validators_missing_file_is_empty() {
+        let root = TempDir::new().unwrap();
+        let validators = read_zip_validators(root.path()).unwrap();
+        assert!(validators.is_empty());
     }
 }

--- a/crates/fastskill-core/src/core/cache/mod.rs
+++ b/crates/fastskill-core/src/core/cache/mod.rs
@@ -15,8 +15,10 @@
 //!   git/<sha>/                             content, keyed by commit SHA
 //!   registry/<source>/<skill>/<version>/   content, keyed by pinned version
 //!   local/<tree-hash>/                     content, keyed by tree/archive hash
+//!   zip/<sha256>/                          content, keyed by archive bytes' hash (spec 007)
 //!   index/<source>.json                    what a source currently advertises
 //!   index/git-resolutions.json             url+ref -> resolved sha (see `index`)
+//!   index/zip-validators.json              url -> {etag/last_modified, content_hash} (spec 007)
 //!   tmp/                                   private staging area for atomic writes
 //!   CACHEDIR.TAG                           https://bford.info/cachedir/ marker
 //! ```
@@ -53,7 +55,9 @@
 
 pub mod index;
 
-pub use index::{GitResolution, GitResolutions, SourceIndex, SourceIndexEntry};
+pub use index::{
+    GitResolution, GitResolutions, SourceIndex, SourceIndexEntry, ZipValidator, ZipValidators,
+};
 
 use crate::core::service::ServiceError;
 use serde::Serialize;
@@ -93,6 +97,7 @@ const CACHE_ROOT_ALLOWED_ENTRIES: &[&str] = &[
     "git",
     "registry",
     "local",
+    "zip",
     "index",
     STAGING_DIR_NAME,
     CACHE_TAG_FILE_NAME,
@@ -121,6 +126,11 @@ pub enum CacheIdentity {
     },
     /// `local/<tree-hash>/` — a local directory or `.zip`, content-hashed (US-004).
     Local { tree_hash: String },
+    /// `zip/<sha256>/` — a `.zip` downloaded from a bare URL, keyed by the
+    /// hash of the downloaded archive bytes rather than any identity known
+    /// before the fetch (spec 007): a bare URL carries no version identity of
+    /// its own, unlike git/registry/local.
+    ZipUrl { content_hash: String },
 }
 
 impl CacheIdentity {
@@ -140,6 +150,9 @@ impl CacheIdentity {
                 .join(validate_component(version)?)),
             CacheIdentity::Local { tree_hash } => {
                 Ok(PathBuf::from("local").join(validate_component(tree_hash)?))
+            }
+            CacheIdentity::ZipUrl { content_hash } => {
+                Ok(PathBuf::from("zip").join(validate_component(content_hash)?))
             }
         }
     }
@@ -170,25 +183,27 @@ pub struct CachedContent {
     pub path: PathBuf,
 }
 
-/// The three top-level content kinds a [`CacheIdentity`] belongs to — also
-/// its on-disk directory name directly under the cache root (`git`,
-/// `registry`, `local`; see the module docs' on-disk layout). `fastskill
-/// cache info`/`clean` (PRD 006, US-006) report and scope by this rather
-/// than a free-form string, so an invalid `--source` can never be turned
-/// into a path.
+/// The top-level content kinds a [`CacheIdentity`] belongs to — also its
+/// on-disk directory name directly under the cache root (`git`, `registry`,
+/// `local`, `zip`; see the module docs' on-disk layout). `fastskill cache
+/// info`/`clean` (PRD 006, US-006; `zip` added by spec 007) report and scope
+/// by this rather than a free-form string, so an invalid `--source` can
+/// never be turned into a path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ContentSourceKind {
     Git,
     Registry,
     Local,
+    Zip,
 }
 
 impl ContentSourceKind {
-    /// All three kinds, in the order `fastskill cache info` reports them.
-    pub const ALL: [ContentSourceKind; 3] = [
+    /// All kinds, in the order `fastskill cache info` reports them.
+    pub const ALL: [ContentSourceKind; 4] = [
         ContentSourceKind::Git,
         ContentSourceKind::Registry,
         ContentSourceKind::Local,
+        ContentSourceKind::Zip,
     ];
 
     /// This kind's directory name directly under the cache root.
@@ -197,16 +212,17 @@ impl ContentSourceKind {
             ContentSourceKind::Git => "git",
             ContentSourceKind::Registry => "registry",
             ContentSourceKind::Local => "local",
+            ContentSourceKind::Zip => "zip",
         }
     }
 
     /// Depth (in directories) from `<cache-root>/<dir_name>/` down to a leaf
     /// identity directory — the unit `stats`/`clean` count and delete as one
-    /// entry. `git/<sha>/` and `local/<tree-hash>/` are one level deep;
-    /// `registry/<source>/<skill>/<version>/` is three.
+    /// entry. `git/<sha>/`, `local/<tree-hash>/`, and `zip/<sha256>/` are one
+    /// level deep; `registry/<source>/<skill>/<version>/` is three.
     fn leaf_depth(self) -> u32 {
         match self {
-            ContentSourceKind::Git | ContentSourceKind::Local => 1,
+            ContentSourceKind::Git | ContentSourceKind::Local | ContentSourceKind::Zip => 1,
             ContentSourceKind::Registry => 3,
         }
     }
@@ -226,8 +242,9 @@ impl std::str::FromStr for ContentSourceKind {
             "git" => Ok(ContentSourceKind::Git),
             "registry" => Ok(ContentSourceKind::Registry),
             "local" => Ok(ContentSourceKind::Local),
+            "zip" => Ok(ContentSourceKind::Zip),
             other => Err(ServiceError::Validation(format!(
-                "unknown cache source '{other}'; expected one of: git, registry, local"
+                "unknown cache source '{other}'; expected one of: git, registry, local, zip"
             ))),
         }
     }
@@ -249,6 +266,7 @@ pub struct CacheStats {
     pub git: ContentSourceStats,
     pub registry: ContentSourceStats,
     pub local: ContentSourceStats,
+    pub zip: ContentSourceStats,
 }
 
 impl CacheStats {
@@ -258,14 +276,21 @@ impl CacheStats {
             ContentSourceKind::Git => self.git,
             ContentSourceKind::Registry => self.registry,
             ContentSourceKind::Local => self.local,
+            ContentSourceKind::Zip => self.zip,
         }
     }
 
-    /// Entry counts and bytes summed across all three kinds.
+    /// Entry counts and bytes summed across all kinds.
     pub fn total(&self) -> ContentSourceStats {
         ContentSourceStats {
-            entry_count: self.git.entry_count + self.registry.entry_count + self.local.entry_count,
-            total_bytes: self.git.total_bytes + self.registry.total_bytes + self.local.total_bytes,
+            entry_count: self.git.entry_count
+                + self.registry.entry_count
+                + self.local.entry_count
+                + self.zip.entry_count,
+            total_bytes: self.git.total_bytes
+                + self.registry.total_bytes
+                + self.local.total_bytes
+                + self.zip.total_bytes,
         }
     }
 }
@@ -440,6 +465,17 @@ impl SkillCache {
         index::write_git_resolutions(&self.root, resolutions)
     }
 
+    /// Read `<cache-root>/index/zip-validators.json` (spec 007), or an empty
+    /// map if never written.
+    pub fn read_zip_validators(&self) -> Result<ZipValidators, ServiceError> {
+        index::read_zip_validators(&self.root)
+    }
+
+    /// Atomically write `<cache-root>/index/zip-validators.json` (spec 007).
+    pub fn write_zip_validators(&self, validators: &ZipValidators) -> Result<(), ServiceError> {
+        index::write_zip_validators(&self.root, validators)
+    }
+
     // ---- `fastskill cache info`/`clean` (PRD 006, US-006). --------------
 
     /// Entry counts and on-disk bytes per [`ContentSourceKind`] (`fastskill
@@ -451,6 +487,7 @@ impl SkillCache {
             git: self.source_stats(ContentSourceKind::Git)?,
             registry: self.source_stats(ContentSourceKind::Registry)?,
             local: self.source_stats(ContentSourceKind::Local)?,
+            zip: self.source_stats(ContentSourceKind::Zip)?,
         })
     }
 

--- a/crates/fastskill-core/src/core/install.rs
+++ b/crates/fastskill-core/src/core/install.rs
@@ -6,7 +6,7 @@
 //! skills dir → upsert Manifest → write Lock → reindex-if-provider). `mode` only
 //! governs the id-conflict policy. `add`/`update` are one operation.
 
-use crate::core::cache::{CacheIdentity, SkillCache, SourceIndex, SourceIndexEntry};
+use crate::core::cache::{CacheIdentity, SkillCache, SourceIndex, SourceIndexEntry, ZipValidator};
 use crate::core::lock::{project_lock_path, ProjectSkillsLock};
 use crate::core::manifest::{
     DependenciesSection, DependencySpec, ProjectContext, SkillProjectToml,
@@ -233,30 +233,21 @@ impl FastSkillService {
         })
     }
 
+    /// Fetch a remote `.zip` (spec 007 "zip-url caching"). Unlike every other
+    /// origin, a bare URL resolves to no identity *before* fetching — no SHA,
+    /// no pinned version, no local tree already on disk — so this cannot
+    /// just mirror `fetch_git`/`fetch_repository`'s "resolve identity, then
+    /// check cache" shape. Instead it prefers an HTTP conditional request
+    /// (`If-None-Match`/`If-Modified-Since` against a previously-recorded
+    /// `ETag`/`Last-Modified`) as the cheap "did it change?" check, with
+    /// download-then-hash as the correctness fallback when a server sends no
+    /// validators at all. See [`fetch_zip_url_cached`] for the full state
+    /// machine.
     async fn fetch_zip_url(&self, url: &str) -> Result<Fetched, ServiceError> {
-        let response = reqwest::get(url)
-            .await
-            .map_err(|e| {
-                ServiceError::InvalidOperation(format!("Failed to download '{url}': {e}"))
-            })?
-            .error_for_status()
-            .map_err(|e| {
-                ServiceError::InvalidOperation(format!("Failed to download '{url}': {e}"))
-            })?;
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|e| ServiceError::InvalidOperation(format!("Failed to read '{url}': {e}")))?;
-
+        let cache = self.skill_cache();
+        let client = reqwest::Client::new();
         let temp_dir = TempDir::new()?;
-        let zip_path = temp_dir.path().join("package.zip");
-        let extract_path = temp_dir.path().join("extracted");
-        tokio::fs::write(&zip_path, &bytes).await?;
-        tokio::fs::create_dir_all(&extract_path).await?;
-
-        let zip_handler = crate::storage::zip::ZipHandler::new()?;
-        zip_handler.extract_to_dir(&zip_path, &extract_path)?;
-        let skill_path = crate::storage::git::validate_cloned_skill(&extract_path)?;
+        let skill_path = fetch_zip_url_cached(cache, &client, url, temp_dir.path()).await?;
 
         let frontmatter = read_skill_frontmatter(&skill_path).await?;
         let (_, version) = derive_skill_id_and_version(&skill_path, &frontmatter)?;
@@ -989,6 +980,258 @@ async fn fetch_local_zip(
         );
     }
     Ok(skill_path)
+}
+
+// ── Zip-URL content cache (spec 007 "zip-url caching") ─────────────────────
+
+/// Number of times [`fetch_zip_url_cached`] has actually read a full response
+/// body over the network — incremented by the number of bytes read, never on
+/// a `304 Not Modified` (which per HTTP carries no body). Instrumentation
+/// only, kept for the same reason as `storage::git::CLONE_INVOCATIONS` /
+/// `registry::client::DOWNLOAD_INVOCATIONS`: proving the 304 fast path really
+/// downloaded nothing is otherwise only observable by timing. Deliberately
+/// not gated behind `#[cfg(test)]` — integration tests are a separate
+/// compilation unit and cannot see items scoped that way.
+#[doc(hidden)] // test instrumentation, not supported public API
+pub static ZIP_URL_BODY_BYTES_DOWNLOADED: AtomicUsize = AtomicUsize::new(0);
+
+/// The outcome of one HTTP attempt against a zip URL, distinguishing "server
+/// confirmed the bytes are unchanged" from "server sent (new) bytes" — the
+/// two paths [`fetch_zip_url_cached`] needs to tell apart.
+enum ZipFetchAttempt {
+    /// `304 Not Modified`: no body was sent.
+    NotModified,
+    /// `200 OK` (or any other success status): a body was sent and read.
+    Modified {
+        bytes: Vec<u8>,
+        etag: Option<String>,
+        last_modified: Option<String>,
+    },
+}
+
+/// Issue one GET against `url`, conditional on `validator` when given
+/// (`If-None-Match`/`If-Modified-Since`). Any failure — connection refused,
+/// DNS failure, timeout, or a non-2xx/304 status — is surfaced as a single
+/// `ServiceError` so [`fetch_zip_url_cached`] can apply spec 007 FR-5's
+/// offline fallback uniformly, the same way `resolve_git_sha` treats any
+/// `ls_remote` failure as one case regardless of cause.
+async fn zip_url_conditional_fetch(
+    client: &reqwest::Client,
+    url: &str,
+    validator: Option<&ZipValidator>,
+) -> Result<ZipFetchAttempt, ServiceError> {
+    let mut request = client.get(url);
+    if let Some(v) = validator {
+        if let Some(etag) = &v.etag {
+            request = request.header(reqwest::header::IF_NONE_MATCH, etag);
+        }
+        if let Some(last_modified) = &v.last_modified {
+            request = request.header(reqwest::header::IF_MODIFIED_SINCE, last_modified);
+        }
+    }
+
+    let response = request
+        .send()
+        .await
+        .map_err(|e| ServiceError::InvalidOperation(format!("Failed to download '{url}': {e}")))?;
+
+    if response.status() == reqwest::StatusCode::NOT_MODIFIED {
+        if validator.is_none() {
+            // A server returning 304 to a request that carried no validators
+            // at all is a protocol violation on its part, not a state this
+            // code can act on: there is nothing recorded to resolve it
+            // against. Surface it as an error rather than guessing.
+            return Err(ServiceError::InvalidOperation(format!(
+                "'{url}' returned 304 Not Modified to an unconditional request (no validators \
+                 were sent)"
+            )));
+        }
+        return Ok(ZipFetchAttempt::NotModified);
+    }
+
+    let response = response
+        .error_for_status()
+        .map_err(|e| ServiceError::InvalidOperation(format!("Failed to download '{url}': {e}")))?;
+
+    let etag = response
+        .headers()
+        .get(reqwest::header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    let last_modified = response
+        .headers()
+        .get(reqwest::header::LAST_MODIFIED)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| ServiceError::InvalidOperation(format!("Failed to read '{url}': {e}")))?
+        .to_vec();
+    ZIP_URL_BODY_BYTES_DOWNLOADED.fetch_add(bytes.len(), Ordering::SeqCst);
+
+    Ok(ZipFetchAttempt::Modified {
+        bytes,
+        etag,
+        last_modified,
+    })
+}
+
+/// Extract freshly-downloaded archive `bytes`, publish them into the content
+/// cache under their hash (FR-1: the archive bytes are the identity — same
+/// input as `fetch_local_zip`'s local `.zip` handling), and record the new
+/// validator (FR-2/FR-3). Dedups against the content cache first: identical
+/// bytes served under a different URL (or by a server with no validators at
+/// all) are stored once.
+async fn store_downloaded_zip(
+    cache: &SkillCache,
+    url: &str,
+    temp_dir: &Path,
+    bytes: &[u8],
+    etag: Option<String>,
+    last_modified: Option<String>,
+) -> Result<PathBuf, ServiceError> {
+    let content_hash = hash_bytes(bytes);
+    let identity = CacheIdentity::ZipUrl {
+        content_hash: content_hash.clone(),
+    };
+
+    let skill_path = if let Some(cached) = cache.get(&identity) {
+        let dest = temp_dir.join("cached");
+        copy_dir_recursive(&cached.path, &dest).await?;
+        crate::storage::git::validate_cloned_skill(&dest)?
+    } else {
+        let zip_path = temp_dir.join("package.zip");
+        let extract_path = temp_dir.join("extracted");
+        tokio::fs::write(&zip_path, bytes).await?;
+        tokio::fs::create_dir_all(&extract_path).await?;
+
+        let zip_handler = crate::storage::zip::ZipHandler::new()?;
+        zip_handler.extract_to_dir(&zip_path, &extract_path)?;
+        let skill_path = crate::storage::git::validate_cloned_skill(&extract_path)?;
+        if let Err(e) = cache.put(&identity, &skill_path) {
+            // The download already succeeded and is usable; a cache-write
+            // failure only costs this run the "download once per machine"
+            // win, so it must not fail the install.
+            tracing::warn!("failed to publish zip-url content to content cache: {}", e);
+        }
+        skill_path
+    };
+
+    if let Err(e) = record_zip_validator(cache, url, &content_hash, etag, last_modified) {
+        tracing::warn!("failed to record zip-url validator: {}", e);
+    }
+
+    Ok(skill_path)
+}
+
+/// Record (or replace) `url`'s validator in the zip-validators index (FR-2).
+fn record_zip_validator(
+    cache: &SkillCache,
+    url: &str,
+    content_hash: &str,
+    etag: Option<String>,
+    last_modified: Option<String>,
+) -> Result<(), ServiceError> {
+    let mut validators = cache.read_zip_validators()?;
+    validators.insert(
+        url,
+        ZipValidator {
+            etag,
+            last_modified,
+            content_hash: content_hash.to_string(),
+            fetched_at: chrono::Utc::now(),
+        },
+    );
+    cache.write_zip_validators(&validators)
+}
+
+/// Fetch a zip URL through the content cache (spec 007 FR-3): consult the
+/// recorded validator, issue a conditional request, and follow whichever of
+/// the spec's paths applies:
+///
+/// - **304** with the recorded hash still in the content cache (FR-3): serve
+///   it straight from the cache — zero bytes of body downloaded.
+/// - **304** with the recorded hash evicted, e.g. by `cache clean` (FR-4):
+///   fall back to an unconditional download rather than failing.
+/// - **200**: download, hash, store, and record the new validator (FR-3).
+/// - **transport/status failure** (FR-5): if a recorded hash exists *and* is
+///   still cached, proceed from it with a warning naming the recorded fetch
+///   time — mirroring `resolve_git_sha`'s offline fallback. Otherwise
+///   propagate the failure as-is.
+async fn fetch_zip_url_cached(
+    cache: &SkillCache,
+    client: &reqwest::Client,
+    url: &str,
+    temp_dir: &Path,
+) -> Result<PathBuf, ServiceError> {
+    let validators = cache.read_zip_validators()?;
+    let recorded = validators.get(url).cloned();
+
+    match zip_url_conditional_fetch(client, url, recorded.as_ref()).await {
+        Ok(ZipFetchAttempt::NotModified) => {
+            // `zip_url_conditional_fetch` only returns `NotModified` when a
+            // validator was actually sent, so `recorded` is present here.
+            let Some(recorded) = recorded else {
+                return Err(ServiceError::Custom(
+                    "zip-url fetch reported 304 Not Modified with no recorded validator"
+                        .to_string(),
+                ));
+            };
+            if let Some(cached) = cache.get(&CacheIdentity::ZipUrl {
+                content_hash: recorded.content_hash.clone(),
+            }) {
+                let dest = temp_dir.join("cached");
+                copy_dir_recursive(&cached.path, &dest).await?;
+                return crate::storage::git::validate_cloned_skill(&dest);
+            }
+
+            // FR-4: the server confirmed the bytes are unchanged, but this
+            // machine no longer has them (e.g. `cache clean`). Fall back to
+            // an unconditional download rather than failing.
+            tracing::warn!(
+                "cached content for '{url}' (hash {}) is no longer in the content cache; \
+                 re-downloading",
+                recorded.content_hash
+            );
+            match zip_url_conditional_fetch(client, url, None).await? {
+                ZipFetchAttempt::Modified {
+                    bytes,
+                    etag,
+                    last_modified,
+                } => store_downloaded_zip(cache, url, temp_dir, &bytes, etag, last_modified).await,
+                ZipFetchAttempt::NotModified => Err(ServiceError::Custom(format!(
+                    "'{url}' returned 304 Not Modified to an unconditional re-download request"
+                ))),
+            }
+        }
+        Ok(ZipFetchAttempt::Modified {
+            bytes,
+            etag,
+            last_modified,
+        }) => store_downloaded_zip(cache, url, temp_dir, &bytes, etag, last_modified).await,
+        Err(err) => {
+            // FR-5: offline / transport failure. Proceed from a recorded,
+            // still-cached hash with a warning; otherwise the failure stands.
+            if let Some(recorded) = &recorded {
+                if let Some(cached) = cache.get(&CacheIdentity::ZipUrl {
+                    content_hash: recorded.content_hash.clone(),
+                }) {
+                    tracing::warn!(
+                        "could not fetch '{url}' ({err}); using the content cached on \
+                         {fetched_at} instead (hash {hash})",
+                        fetched_at = recorded.fetched_at,
+                        hash = recorded.content_hash,
+                    );
+                    let dest = temp_dir.join("cached");
+                    copy_dir_recursive(&cached.path, &dest).await?;
+                    return crate::storage::git::validate_cloned_skill(&dest);
+                }
+            }
+            Err(err)
+        }
+    }
 }
 
 /// Compute a deterministic tree-hash of a validated skill directory (US-004):

--- a/crates/fastskill-core/tests/zip_url_cache_test.rs
+++ b/crates/fastskill-core/tests/zip_url_cache_test.rs
@@ -1,0 +1,403 @@
+//! Integration tests for the zip-url content cache (spec 007 "zip-url
+//! caching"): unlike git/registry/local, a bare URL carries no identity
+//! before the fetch, so `Origin::ZipUrl` must resolve staleness via an HTTP
+//! conditional request (`ETag`/`Last-Modified`) rather than a pre-fetch
+//! identity check.
+//!
+//! The fixture is a `wiremock` `MockServer` bound to a loopback port -- this
+//! is not "the network" (no DNS, no external host, nothing flaky in CI), the
+//! same posture `registry_content_cache_test.rs` takes. "Zero bytes
+//! downloaded on a 304" is proven via
+//! `core::install::ZIP_URL_BODY_BYTES_DOWNLOADED`, a counting seam kept for
+//! exactly this purpose (mirrors `storage::git::CLONE_INVOCATIONS` /
+//! `registry::client::DOWNLOAD_INVOCATIONS`).
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use fastskill_core::core::cache::{CacheIdentity, ContentSourceKind, SkillCache, ZipValidator};
+use fastskill_core::core::install::ZIP_URL_BODY_BYTES_DOWNLOADED;
+use fastskill_core::core::{AddMode, Origin};
+use fastskill_core::{FastSkillService, ServiceConfig};
+use sha2::Digest;
+use std::path::Path;
+use std::sync::atomic::Ordering;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const SKILL_ID: &str = "zip-cached-skill";
+
+fn skill_md(marker: &str) -> String {
+    format!(
+        "---\nname: {SKILL_ID}\nversion: \"1.0.0\"\ndescription: {marker}\n---\nBody: {marker}\n"
+    )
+}
+
+/// Build a `.zip` archive containing a single valid `SKILL.md`, with `marker`
+/// baked into the content so different builds are byte-distinguishable.
+fn build_zip(marker: &str) -> Vec<u8> {
+    use std::io::Write;
+    use zip::write::FileOptions;
+    let mut buf = Vec::new();
+    {
+        let cursor = std::io::Cursor::new(&mut buf);
+        let mut writer = zip::ZipWriter::new(cursor);
+        let opts = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        writer
+            .start_file(format!("{SKILL_ID}/SKILL.md"), opts)
+            .unwrap();
+        writer.write_all(skill_md(marker).as_bytes()).unwrap();
+        writer.finish().unwrap();
+    }
+    buf
+}
+
+/// A minimal fastskill project directory: `skill-project.toml` + an empty
+/// skills directory, ready for `add_from_origin`.
+fn setup_project(root: &Path) {
+    std::fs::write(
+        root.join("skill-project.toml"),
+        "[tool.fastskill]\nskills_directory = \".claude/skills\"\n\n[dependencies]\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(root.join(".claude/skills")).unwrap();
+}
+
+async fn make_service(project_root: &Path, storage: &Path, cache_root: &Path) -> FastSkillService {
+    let config = ServiceConfig {
+        skill_storage_path: storage.to_path_buf(),
+        skill_cache_root: Some(cache_root.to_path_buf()),
+        ..Default::default()
+    };
+    let mut service = FastSkillService::new(config).await.unwrap();
+    service.initialize().await.unwrap();
+    service.with_project_root(project_root.to_path_buf())
+}
+
+/// Install `url` into a brand-new project + storage dir, sharing `cache_root`
+/// with any other install in the same test. Returns the installed
+/// `SKILL.md` contents.
+async fn install_into_fresh_project(cache_root: &Path, url: &str) -> String {
+    let project = tempfile::TempDir::new().unwrap();
+    setup_project(project.path());
+    let storage = tempfile::TempDir::new().unwrap();
+    let service = make_service(project.path(), storage.path(), cache_root).await;
+
+    let origin = Origin::ZipUrl {
+        url: url.to_string(),
+    };
+    service
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await
+        .expect("zip-url install should succeed");
+
+    std::fs::read_to_string(storage.path().join(SKILL_ID).join("SKILL.md")).unwrap()
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+/// Two installs of the same URL: the first is a real download (200 + ETag),
+/// the second -- from a different project, sharing the cache -- gets a 304
+/// and must download **zero bytes** of body, still installing byte-identical
+/// content (spec 007 design + FR-3).
+#[tokio::test]
+async fn second_install_gets_a_304_and_downloads_zero_bytes() {
+    let server = MockServer::start().await;
+    let zip_bytes = build_zip("v1");
+    let etag = "\"etag-v1\"";
+
+    // A conditional request carrying the etag this server issued -> 304,
+    // no body. Higher priority so it wins whenever both mocks match.
+    Mock::given(method("GET"))
+        .and(path("/pkg.zip"))
+        .and(header("If-None-Match", etag))
+        .respond_with(ResponseTemplate::new(304))
+        .with_priority(1)
+        .mount(&server)
+        .await;
+    // Any other GET (i.e. no matching If-None-Match) -> a full 200 download.
+    Mock::given(method("GET"))
+        .and(path("/pkg.zip"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(zip_bytes.clone())
+                .insert_header("ETag", etag),
+        )
+        .mount(&server)
+        .await;
+
+    let cache_root = tempfile::TempDir::new().unwrap();
+    let url = format!("{}/pkg.zip", server.uri());
+
+    let baseline = ZIP_URL_BODY_BYTES_DOWNLOADED.load(Ordering::SeqCst);
+    let content_a = install_into_fresh_project(cache_root.path(), &url).await;
+    let after_a = ZIP_URL_BODY_BYTES_DOWNLOADED.load(Ordering::SeqCst);
+    assert_eq!(
+        after_a - baseline,
+        zip_bytes.len(),
+        "first install must download the full archive body"
+    );
+
+    let content_b = install_into_fresh_project(cache_root.path(), &url).await;
+    let after_b = ZIP_URL_BODY_BYTES_DOWNLOADED.load(Ordering::SeqCst);
+    assert_eq!(
+        after_b, after_a,
+        "second install must be a 304 that downloads zero additional bytes of body"
+    );
+
+    assert_eq!(
+        content_a, content_b,
+        "the 304 path must still install byte-identical content"
+    );
+    assert_eq!(content_a, skill_md("v1"));
+}
+
+/// A conditional request that gets a fresh `200` (the server's content
+/// actually changed) re-downloads and updates the recorded validator +
+/// content hash, rather than reusing the stale cached entry.
+#[tokio::test]
+async fn conditional_200_redownloads_and_updates_recorded_hash() {
+    let server = MockServer::start().await;
+    let zip_v1 = build_zip("v1");
+    let zip_v2 = build_zip("v2");
+    let etag_v1 = "\"etag-v1\"";
+    let etag_v2 = "\"etag-v2\"";
+
+    // A conditional request carrying the *old* etag -> the server reports a
+    // fresh 200 with new content and a new etag (content changed).
+    Mock::given(method("GET"))
+        .and(path("/pkg.zip"))
+        .and(header("If-None-Match", etag_v1))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(zip_v2.clone())
+                .insert_header("ETag", etag_v2),
+        )
+        .with_priority(1)
+        .mount(&server)
+        .await;
+    // Unconditional request -> the original content.
+    Mock::given(method("GET"))
+        .and(path("/pkg.zip"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(zip_v1.clone())
+                .insert_header("ETag", etag_v1),
+        )
+        .mount(&server)
+        .await;
+
+    let cache_root = tempfile::TempDir::new().unwrap();
+    let url = format!("{}/pkg.zip", server.uri());
+
+    let baseline = ZIP_URL_BODY_BYTES_DOWNLOADED.load(Ordering::SeqCst);
+    let content_a = install_into_fresh_project(cache_root.path(), &url).await;
+    assert_eq!(content_a, skill_md("v1"));
+
+    let content_b = install_into_fresh_project(cache_root.path(), &url).await;
+    assert_eq!(
+        content_b,
+        skill_md("v2"),
+        "a fresh 200 on the conditional request must re-download the new content"
+    );
+
+    let downloaded = ZIP_URL_BODY_BYTES_DOWNLOADED.load(Ordering::SeqCst) - baseline;
+    assert_eq!(
+        downloaded,
+        zip_v1.len() + zip_v2.len(),
+        "both installs must have downloaded a full body"
+    );
+
+    let cache = SkillCache::at_root(cache_root.path());
+    let validators = cache.read_zip_validators().unwrap();
+    let recorded = validators.get(&url).expect("validator must be recorded");
+    let expected_hash = format!("{:x}", sha2::Sha256::digest(&zip_v2));
+    assert_eq!(
+        recorded.content_hash, expected_hash,
+        "the recorded hash must be updated to the new content's hash"
+    );
+    assert_eq!(recorded.etag.as_deref(), Some(etag_v2));
+}
+
+/// A server that sends no `ETag`/`Last-Modified` at all still dedups:
+/// identical archive bytes served from two different URLs are stored once in
+/// the content cache (download-then-hash fallback; no fetch-time saving, but
+/// still dedup -- see spec 007's design notes).
+#[tokio::test]
+async fn no_validator_server_still_dedups_identical_bytes_to_one_entry() {
+    let server = MockServer::start().await;
+    let zip_bytes = build_zip("shared");
+
+    Mock::given(method("GET"))
+        .and(path("/a.zip"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(zip_bytes.clone()))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/b.zip"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(zip_bytes.clone()))
+        .mount(&server)
+        .await;
+
+    let cache_root = tempfile::TempDir::new().unwrap();
+
+    let content_a =
+        install_into_fresh_project(cache_root.path(), &format!("{}/a.zip", server.uri())).await;
+    let content_b =
+        install_into_fresh_project(cache_root.path(), &format!("{}/b.zip", server.uri())).await;
+    assert_eq!(content_a, content_b);
+
+    let cache = SkillCache::at_root(cache_root.path());
+    let stats = cache.stats().unwrap();
+    assert_eq!(
+        stats.zip.entry_count, 1,
+        "identical bytes from two different no-validator URLs must dedup to one stored entry"
+    );
+
+    // Two distinct URL entries in the validators index, though -- each URL's
+    // own validator is recorded independently.
+    let validators = cache.read_zip_validators().unwrap();
+    assert_eq!(validators.len(), 2);
+}
+
+/// FR-4: a `304` whose recorded content hash is no longer in the content
+/// cache (e.g. after `cache clean`) must fall back to an unconditional
+/// download rather than failing.
+#[tokio::test]
+async fn a_304_with_evicted_content_falls_back_to_a_full_download() {
+    let server = MockServer::start().await;
+    let zip_bytes = build_zip("v1");
+    let etag = "\"etag-v1\"";
+
+    Mock::given(method("GET"))
+        .and(path("/pkg.zip"))
+        .and(header("If-None-Match", etag))
+        .respond_with(ResponseTemplate::new(304))
+        .with_priority(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/pkg.zip"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(zip_bytes.clone())
+                .insert_header("ETag", etag),
+        )
+        .mount(&server)
+        .await;
+
+    let cache_root = tempfile::TempDir::new().unwrap();
+    let url = format!("{}/pkg.zip", server.uri());
+
+    // First install: real download, records the validator + publishes the
+    // content cache entry.
+    let content_a = install_into_fresh_project(cache_root.path(), &url).await;
+    assert_eq!(content_a, skill_md("v1"));
+
+    // Evict the content cache (mirrors `fastskill cache clean --source
+    // zip`), leaving the validators index untouched.
+    let cache = SkillCache::at_root(cache_root.path());
+    let cleaned = cache.clean(Some(ContentSourceKind::Zip)).unwrap();
+    assert_eq!(cleaned.entries_removed, 1);
+    assert_eq!(cache.stats().unwrap().zip.entry_count, 0);
+    assert!(
+        cache.read_zip_validators().unwrap().get(&url).is_some(),
+        "clean must never touch the validators index"
+    );
+
+    // Second install: the server still reports 304 for the conditional
+    // request (nothing changed server-side), but the content is gone locally
+    // -- must fall back to a full download rather than failing.
+    let baseline = ZIP_URL_BODY_BYTES_DOWNLOADED.load(Ordering::SeqCst);
+    let content_b = install_into_fresh_project(cache_root.path(), &url).await;
+    assert_eq!(content_b, skill_md("v1"));
+    assert_eq!(
+        ZIP_URL_BODY_BYTES_DOWNLOADED.load(Ordering::SeqCst) - baseline,
+        zip_bytes.len(),
+        "a 304 with evicted content must fall back to a full, unconditional download"
+    );
+    assert_eq!(cache.stats().unwrap().zip.entry_count, 1);
+}
+
+/// FR-5: offline / transport failure with a recorded, still-cached hash
+/// proceeds with a warning rather than failing (mirrors the git ref-
+/// resolution fallback shipped in PR #227).
+#[tokio::test]
+async fn offline_install_with_a_cached_hash_succeeds() {
+    // Nothing listens here; the request fails fast without touching the real
+    // network.
+    let unreachable_url = "http://127.0.0.1:1/pkg.zip";
+
+    let cache_root = tempfile::TempDir::new().unwrap();
+    let cache = SkillCache::at_root(cache_root.path());
+
+    let zip_bytes = build_zip("v1");
+    let content_hash = format!("{:x}", sha2::Sha256::digest(&zip_bytes));
+
+    // Prime the content cache with the previously-fetched, already-extracted
+    // skill content under its recorded hash.
+    let content_dir = tempfile::TempDir::new().unwrap();
+    std::fs::write(content_dir.path().join("SKILL.md"), skill_md("v1")).unwrap();
+    cache
+        .put(
+            &CacheIdentity::ZipUrl {
+                content_hash: content_hash.clone(),
+            },
+            content_dir.path(),
+        )
+        .unwrap();
+
+    // Prime the validators index as if a prior online install had recorded
+    // this resolution.
+    let mut validators = cache.read_zip_validators().unwrap();
+    validators.insert(
+        unreachable_url,
+        ZipValidator {
+            etag: Some("\"etag-v1\"".to_string()),
+            last_modified: None,
+            content_hash: content_hash.clone(),
+            fetched_at: chrono::Utc::now(),
+        },
+    );
+    cache.write_zip_validators(&validators).unwrap();
+
+    let project = tempfile::TempDir::new().unwrap();
+    setup_project(project.path());
+    let storage = tempfile::TempDir::new().unwrap();
+    let service = make_service(project.path(), storage.path(), cache_root.path()).await;
+
+    let origin = Origin::ZipUrl {
+        url: unreachable_url.to_string(),
+    };
+    let outcome = service
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await
+        .expect("offline install with a cached hash should succeed");
+    assert_eq!(outcome.id, SKILL_ID);
+
+    let installed =
+        std::fs::read_to_string(storage.path().join(SKILL_ID).join("SKILL.md")).unwrap();
+    assert_eq!(installed, skill_md("v1"));
+}
+
+/// With no prior resolution recorded, an unreachable URL fails the install
+/// (no silent staleness, no panic) -- the transport error is surfaced as-is.
+#[tokio::test]
+async fn offline_install_with_nothing_cached_fails_with_the_transport_error() {
+    let unreachable_url = "http://127.0.0.1:1/pkg.zip";
+    let cache_root = tempfile::TempDir::new().unwrap();
+    let project = tempfile::TempDir::new().unwrap();
+    setup_project(project.path());
+    let storage = tempfile::TempDir::new().unwrap();
+    let service = make_service(project.path(), storage.path(), cache_root.path()).await;
+
+    let origin = Origin::ZipUrl {
+        url: unreachable_url.to_string(),
+    };
+    let result = service
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await;
+    assert!(
+        result.is_err(),
+        "install must fail without a cached hash to fall back to"
+    );
+}


### PR DESCRIPTION
## What

Completes the local skill cache shipped in v0.9.161 (#227) by covering the one source type it deliberately left out. Design was settled in RFQ 004 and written up as spec 007 before implementation.

## Why zip-url was held back

Every other source resolves to an **immutable identity before fetching**:

| Source | Identity | Cheap "what's new" check |
|---|---|---|
| git | commit SHA | `git ls-remote` |
| registry | pinned version | index re-resolve |
| local | tree-hash | rehash, no network |
| **zip-url** | **hash of the bytes — only knowable *after* downloading** | **HTTP conditional request** |

A bare URL carries no version identity, so it could not reuse the pattern the other three share. That is why it needed its own staleness policy rather than a fourth copy of the same code.

## How it works

1. Record the `ETag` / `Last-Modified` a URL served, alongside the content hash it produced, in `index/zip-validators.json` (schema owned by `cache::index`, like every other index type).
2. The next install sends `If-None-Match` / `If-Modified-Since`:
   - **304** → resolve straight to the recorded hash, serve from the content cache, **no body downloaded**. This is the fetch-time win.
   - **200** → download, hash, store, record the new validator.

**Honest limitation:** when a server sends no validators at all, this degrades to download-then-hash. That still dedups identical bytes to one stored entry, but buys **no fetch-time saving and no offline check** — you had to download to learn the hash. This is inherent to the source type, not an oversight, and the docs don't oversell it.

## Edge cases

- **304 whose content is gone** (e.g. after `cache clean`) → falls back to an unconditional download rather than failing.
- **Transport failure with a recorded, still-cached hash** → proceeds from cache with a warning naming when it was fetched, mirroring the git fallback from #227.
- Neither is theoretical; both are covered by tests.

## Testing

- **1130 tests pass** with `-E 'not test(install_e2e_tests)'` (+8), and **1143 pass** under the full pre-push suite. Verified independently, not just by the authoring agent.
- All fixtures are local `wiremock` — **no real network**.
- The "no body downloaded" claim is proven by counting **actual bytes**, via a `ZIP_URL_BODY_BYTES_DOWNLOADED` seam following the counter pattern established in #227 (`#[doc(hidden)]`, test instrumentation, not supported API).
- Covered: 304 downloads zero body bytes and still installs byte-identical content; 200 re-downloads and updates the recorded hash; a no-validator server still dedups to one entry; 304-with-evicted-content falls back and succeeds; offline-with-cached-hash succeeds with a warning; offline-with-nothing surfaces the transport error.

## Notes for reviewers

- `cache info` / `cache clean --source zip` account for the new source type.
- No other source type's behaviour changes.
- Remaining follow-ups after this: automatic GC / size caps, hardlinking into project dirs, and spec 008 (the in-memory `SourcesManager` marketplace cache, which on inspection is near-dead weight — every production construction site is short-lived, so its 5-minute TTL rarely survives to serve a second read).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmpE6bvMsDtWDjmUP9wfu
