### PR TITLE
fix(cache): stop caching .git metadata with git-sourced skills

### DIFF
--- a/crates/fastskill-core/src/core/install.rs
+++ b/crates/fastskill-core/src/core/install.rs
@@ -140,6 +140,21 @@ impl FastSkillService {
             // caching under a now-stale SHA.
             let temp_dir = crate::storage::git::clone_repository(url, branch, tag, None).await?;
             let actual_sha = git_head_commit(temp_dir.path()).await?;
+            // `.git` metadata is only ever needed transiently, to resolve the
+            // commit just cloned to (just done, above) — the content cache is
+            // only ever read back as skill *files* (`copy_dir_recursive`
+            // above), never as a git repository, so caching `.git` is pure
+            // bloat (and can dwarf the skill itself on a real repository).
+            // Strip it before publishing so the cache only ever holds skill
+            // content. Best-effort: if this fails, the clone (and thus the
+            // install) is still perfectly usable — it only means this one
+            // `put` below caches `.git` too, same as before this fix.
+            if let Err(e) = strip_git_dir(temp_dir.path()).await {
+                tracing::warn!(
+                    "failed to strip .git before publishing to the content cache: {}",
+                    e
+                );
+            }
 
             if let Err(e) = cache.put(
                 &CacheIdentity::Git {
@@ -1074,6 +1089,31 @@ async fn git_head_commit(repo_dir: &Path) -> Result<String, ServiceError> {
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+/// Remove the top-level `.git` directory from a freshly-cloned repository
+/// root, if present. Called only after [`git_head_commit`] has already read
+/// it and only on the just-cloned root (never on a subdirectory), since
+/// `.git` always lives at the clone root regardless of `subdir`. A no-op if
+/// there is nothing at `.git` (e.g. called twice, or on content that was
+/// already stripped). Never follows a symlink for the removal (defense in
+/// depth, mirroring `copy_dir_recursive`'s SEC-4 stance elsewhere in this
+/// file) — a `.git` symlink is unlinked directly rather than dereferenced.
+async fn strip_git_dir(repo_root: &Path) -> Result<(), ServiceError> {
+    let git_dir = repo_root.join(".git");
+    let Ok(metadata) = tokio::fs::symlink_metadata(&git_dir).await else {
+        // Nothing there: already stripped, or never existed. Not an error.
+        return Ok(());
+    };
+    if metadata.is_dir() {
+        tokio::fs::remove_dir_all(&git_dir).await?;
+    } else {
+        // A symlink or a regular file (e.g. a `.git` gitlink file, as used
+        // by worktrees/submodules): unlink it directly either way, never
+        // following it.
+        tokio::fs::remove_file(&git_dir).await?;
+    }
+    Ok(())
+}
+
 /// Remove whatever currently sits at `path` (file, symlink, or directory), if
 /// anything, so a fresh move/copy/symlink can take its place.
 async fn remove_existing_storage_path(path: &Path) -> Result<(), ServiceError> {
@@ -1692,6 +1732,65 @@ mod tests {
         copy_dir_recursive(&src, &dst).await.unwrap();
         assert!(dst.join("SKILL.md").exists());
         assert!(dst.join("nested/file.txt").exists());
+    }
+
+    // ── strip_git_dir (cache-bloat bugfix) ────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_strip_git_dir_removes_a_directory_git() {
+        let tmp = TestTempDir::new().unwrap();
+        let root = tmp.path().join("clone");
+        std::fs::create_dir_all(root.join(".git/objects")).unwrap();
+        std::fs::write(root.join(".git/HEAD"), "ref: refs/heads/main\n").unwrap();
+        std::fs::write(root.join("SKILL.md"), "# skill\n").unwrap();
+
+        strip_git_dir(&root).await.unwrap();
+
+        assert!(!root.join(".git").exists(), ".git must be removed");
+        assert!(
+            root.join("SKILL.md").exists(),
+            "sibling skill content must be untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_strip_git_dir_is_a_noop_when_absent() {
+        let tmp = TestTempDir::new().unwrap();
+        let root = tmp.path().join("clone");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("SKILL.md"), "# skill\n").unwrap();
+
+        // Must not error just because there is nothing to strip.
+        strip_git_dir(&root).await.unwrap();
+        assert!(root.join("SKILL.md").exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_strip_git_dir_unlinks_without_following_a_symlinked_git() {
+        use std::os::unix::fs::symlink;
+        let tmp = TestTempDir::new().unwrap();
+        let root = tmp.path().join("clone");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("SKILL.md"), "# skill\n").unwrap();
+
+        // A directory outside `root` that a symlinked `.git` could otherwise
+        // redirect a recursive removal into; it must survive untouched.
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("sentinel.txt"), "do not delete me").unwrap();
+        symlink(&outside, root.join(".git")).unwrap();
+
+        strip_git_dir(&root).await.unwrap();
+
+        assert!(
+            !root.join(".git").exists(),
+            "the symlink entry itself must be gone"
+        );
+        assert!(
+            outside.join("sentinel.txt").is_file(),
+            "must never follow the symlink to delete its target"
+        );
     }
 
     // ── compute_local_tree_hash / hash_bytes (US-004) ─────────────────────────

--- a/crates/fastskill-core/tests/git_content_cache_test.rs
+++ b/crates/fastskill-core/tests/git_content_cache_test.rs
@@ -221,6 +221,28 @@ async fn make_service(storage: &Path, cache_root: &Path) -> FastSkillService {
     service
 }
 
+/// Every regular file under `root`, as a `/`-normalized path relative to
+/// `root`, sorted. Used to assert a cache entry's contents exactly, without
+/// caring about directory-read order.
+fn list_files_relative(root: &Path) -> Vec<String> {
+    fn walk(dir: &Path, base: &Path, out: &mut Vec<String>) {
+        for entry in std::fs::read_dir(dir).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, base, out);
+            } else {
+                let rel = path.strip_prefix(base).unwrap();
+                out.push(rel.to_string_lossy().replace('\\', "/"));
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, root, &mut out);
+    out.sort();
+    out
+}
+
 // ── tests ────────────────────────────────────────────────────────────────
 
 /// Two installs of the same git ref, into two different project directories,
@@ -294,6 +316,104 @@ async fn two_installs_of_the_same_ref_clone_exactly_once() {
             .unwrap();
     assert_eq!(content_a, content_b);
     assert_eq!(content_a, VALID_SKILL_MD);
+}
+
+/// Bugfix regression (cache bloat): the content cache must store only skill
+/// files, never the clone's own `.git` metadata. `.git` is only ever read
+/// transiently, to resolve the commit the clone just landed on
+/// (`git rev-parse HEAD`) — a cache entry is only ever copied back out as
+/// skill *files* (never re-treated as a git repository), so caching `.git`
+/// is pure bloat that scales with the source repo's full history, not the
+/// (typically tiny) skill payload it actually serves. Also proves a
+/// cache-hit install still reproduces byte-identical skill content to the
+/// original clone-path install, and that the cache-hit's own on-disk footprint
+/// (what `cache info` sizes) matches the pared-down entry, not a `.git`-laden
+/// one.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn git_cache_entry_excludes_git_metadata_and_stays_byte_identical_on_a_hit() {
+    let _lock = DIR_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+
+    let daemon_base = TempDir::new().unwrap();
+    let expected_sha = seed_bare_repo(daemon_base.path(), "repo", "main");
+    let daemon = GitDaemonFixture::start(daemon_base);
+    let repo_url = daemon.repo_url("repo");
+
+    let shared_cache = TempDir::new().unwrap();
+    let origin = Origin::Git {
+        url: repo_url,
+        r#ref: GitRef::Branch("main".to_string()),
+        subdir: None,
+    };
+
+    // Project A: fresh clone (cache miss) — exercises the `fetch_git` "miss"
+    // branch that strips `.git` before `cache.put`.
+    let project_a = TempDir::new().unwrap();
+    let original_dir = std::env::current_dir().ok();
+    std::env::set_current_dir(project_a.path()).unwrap();
+    let _guard_a = DirGuard(original_dir);
+    setup_project(project_a.path());
+    let storage_a = TempDir::new().unwrap();
+    let service_a = make_service(storage_a.path(), shared_cache.path()).await;
+    service_a
+        .add_from_origin(origin.clone(), AddMode::Fresh, vec![])
+        .await
+        .expect("project A install should succeed");
+
+    // Inspect the published cache entry directly: it must hold exactly the
+    // skill's files, nothing named `.git` anywhere inside it.
+    let cache = SkillCache::at_root(shared_cache.path());
+    let cached = cache
+        .get(&CacheIdentity::Git {
+            sha: expected_sha.clone(),
+        })
+        .expect("cache entry should exist after a miss+put");
+
+    assert!(
+        !cached.path.join(".git").exists(),
+        "published cache entry must not contain a .git directory"
+    );
+    let entry_files = list_files_relative(&cached.path);
+    assert_eq!(
+        entry_files,
+        vec!["SKILL.md".to_string()],
+        "cache entry must contain exactly the skill's files, no git metadata"
+    );
+
+    // Project B: same ref, different project directory — must be a cache hit
+    // (exercises the `fetch_git` "hit" branch's `copy_dir_recursive`).
+    let project_b = TempDir::new().unwrap();
+    std::env::set_current_dir(project_b.path()).unwrap();
+    setup_project(project_b.path());
+    let storage_b = TempDir::new().unwrap();
+    let service_b = make_service(storage_b.path(), shared_cache.path()).await;
+    service_b
+        .add_from_origin(origin, AddMode::Fresh, vec![])
+        .await
+        .expect("project B (cache-hit) install should succeed");
+
+    // Byte-identical skill content between the clone-path and cache-hit-path
+    // installs (FR-8): read the same file both ways and compare raw bytes.
+    let content_a =
+        std::fs::read(storage_a.path().join("cached-git-skill").join("SKILL.md")).unwrap();
+    let content_b =
+        std::fs::read(storage_b.path().join("cached-git-skill").join("SKILL.md")).unwrap();
+    assert_eq!(
+        content_a, content_b,
+        "a cache-hit install must be byte-identical to the original clone-path install"
+    );
+    assert_eq!(content_a, VALID_SKILL_MD.as_bytes());
+
+    // The cache-hit install must not have materialized a `.git` either,
+    // proving the cache entry it copied from was itself already clean.
+    assert!(
+        !storage_b
+            .path()
+            .join("cached-git-skill")
+            .join(".git")
+            .exists(),
+        "a cache-hit install must not carry a .git directory into the installed skill"
+    );
 }
 
 /// When `ls_remote` fails (offline / unreachable remote) but a previous


### PR DESCRIPTION
## The bug

Found while smoke-testing the cache shipped in v0.9.161 (#227) against the real binary. Installing a trivial **one-file** skill from a git URL produced a **26.1 KB** cache entry:

```
cache/git/9b590b3e.../demo-skill    <- the skill (a few hundred bytes)
cache/git/9b590b3e.../.git          <- the entire clone's git metadata
```

`fetch_git` clones into a temp dir and publishes that whole directory, so the clone's `.git` gets stored in the content cache forever. It is never read back — cached content is only ever copied out as skill *files* — so it is pure bloat, and on a real repository it dominates the entry. Measured on a minimal fixture: **152K of a 156K clone was `.git` (~97%)**. It also made `cache info` sizes misleading.

## The fix

Strip `.git` in `fetch_git`, **not** inside `SkillCache::put`.

`put` is shared by the git, registry and local paths, and its contract is *"publish whatever directory you hand me."* Baking a `.git` exclusion into it would make it lie about what it stores for callers who never asked, and would be dead logic for the two paths that never produce a `.git`. The knowledge that *a clone's `.git` is scaffolding, not content* belongs at the one call site that knows it's dealing with a clone.

**Ordering is the trap here:** `git_head_commit` shells out to `git rev-parse HEAD` and needs `.git` to resolve the commit just cloned. The strip runs immediately after that read and before `put`, so `.git` is read exactly once for its one legitimate purpose, then removed.

Other properties:
- **Best-effort.** A strip failure only means this one entry caches `.git` as before; it must never fail an otherwise-successful install — consistent with how a cache-write failure is already handled.
- **Never follows a symlink.** A symlinked or gitlink-file `.git` is unlinked directly rather than dereferenced (defence in depth, mirroring the SEC-4 stance elsewhere in the file).
- **Subdir installs unaffected** — `.git` always lives at the clone root regardless of `Origin::Git { subdir }`, and the strip happens on the root before subdir resolution.
- **"Exactly one clone" guarantee unaffected.**

## Behaviour change worth flagging

For repositories whose `SKILL.md` sits at the **root**, installs previously copied `.git` into the project's skills directory as well. That now stops. This is an improvement, but it is user-visible.

## Testing

- **1126 pass** with `-E 'not test(install_e2e_tests)'` (+4), and **1139** under the full pre-push suite. Verified independently, not just by the authoring agent.
- New integration test asserts: no `.git` in the published cache entry; the entry's file list is exactly the expected skill files; a cache-hit install yields **byte-identical** `SKILL.md` to the clone-path install; and the cache-hit install's on-disk skill carries no `.git` either.
- Unit tests cover the directory case, the absent case (no-op), and the symlinked-`.git` case.
- Uses the existing local `git daemon` fixture — no real network, cache always pointed at a temp dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmpE6bvMsDtWDjmUP9wfu
