### PR TITLE
feat(cache): resolve marketplace listings from the on-disk index

### DIFF
--- a/crates/fastskill-cli/src/commands/install.rs
+++ b/crates/fastskill-cli/src/commands/install.rs
@@ -263,8 +263,11 @@ pub async fn execute_install(args: InstallArgs) -> CliResult<()> {
     let repo_manager = RepositoryManager::from_definitions(repositories);
 
     // Create SourcesManager from marketplace-based repositories for PackageResolver
-    let sources_manager = install_utils::create_sources_manager_from_repositories(&repo_manager)
-        .map_err(|e| CliError::Config(format!("Failed to create sources manager: {}", e)))?;
+    let sources_manager = install_utils::create_sources_manager_from_repositories(
+        &repo_manager,
+        service.skill_cache(),
+    )
+    .map_err(|e| CliError::Config(format!("Failed to create sources manager: {}", e)))?;
 
     // Determine effective depth limit and skip_transitive flag from config then CLI override
     let (config_depth, config_skip_transitive) = if project_file_result.found {

--- a/crates/fastskill-cli/src/utils/install_utils.rs
+++ b/crates/fastskill-cli/src/utils/install_utils.rs
@@ -423,7 +423,9 @@ async fn install_from_zip_url(
 }
 
 /// Create and initialize package resolver
-async fn create_package_resolver() -> CliResult<fastskill_core::core::resolver::PackageResolver> {
+async fn create_package_resolver(
+    skill_cache: &fastskill_core::core::cache::SkillCache,
+) -> CliResult<fastskill_core::core::resolver::PackageResolver> {
     use fastskill_core::core::resolver::PackageResolver;
     use std::sync::Arc;
 
@@ -432,7 +434,7 @@ async fn create_package_resolver() -> CliResult<fastskill_core::core::resolver::
         fastskill_core::core::repository::RepositoryManager::from_definitions(repositories);
 
     let sources_mgr = if let Some(sources_manager) =
-        create_sources_manager_from_repositories(&repo_manager)
+        create_sources_manager_from_repositories(&repo_manager, skill_cache)
             .map_err(|e| CliError::Config(format!("Failed to create sources manager: {}", e)))?
     {
         Arc::new(sources_manager)
@@ -487,7 +489,7 @@ async fn install_from_source(
 ) -> CliResult<SkillDefinition> {
     use fastskill_core::core::resolver::ConflictStrategy;
 
-    let resolver = create_package_resolver().await?;
+    let resolver = create_package_resolver(service.skill_cache()).await?;
     let version_constraint = version
         .map(|v| {
             fastskill_core::core::version::VersionConstraint::parse(v)
@@ -510,11 +512,18 @@ async fn install_from_source(
 
 /// Create SourcesManager from RepositoryManager for marketplace-based repositories
 /// This is needed because PackageResolver requires SourcesManager
+///
+/// spec 008: opts the manager into the on-disk index cache
+/// (`SourcesManager::with_skill_cache`) so a cold or offline `install`
+/// resolves a marketplace listing already known to `skill_cache` (via a
+/// prior `repos refresh` or live fetch) without a network round-trip.
 pub fn create_sources_manager_from_repositories(
     repo_manager: &RepositoryManager,
+    skill_cache: &fastskill_core::core::cache::SkillCache,
 ) -> CliResult<Option<SourcesManager>> {
     SourcesManager::from_repositories(repo_manager)
         .map_err(|e| CliError::Config(format!("Failed to create sources manager: {}", e)))
+        .map(|opt| opt.map(|mgr| mgr.with_skill_cache(skill_cache.clone())))
 }
 
 #[cfg(test)]
@@ -830,10 +839,21 @@ mod tests {
         }
     }
 
+    /// A `SkillCache` rooted at a throwaway path (never written to by these
+    /// tests, which only assert on `SourcesManager` construction) —
+    /// `TempDir` is intentionally not kept alive since the directory itself
+    /// need not exist for this.
+    fn test_skill_cache() -> fastskill_core::core::cache::SkillCache {
+        fastskill_core::core::cache::SkillCache::at_root(
+            tempfile::TempDir::new().unwrap().path().to_path_buf(),
+        )
+    }
+
     #[test]
     fn test_create_sources_manager_from_marketplace_repo() {
         let repo_manager = RepositoryManager::from_definitions(vec![git_marketplace_repo("mp")]);
-        let result = create_sources_manager_from_repositories(&repo_manager).unwrap();
+        let result =
+            create_sources_manager_from_repositories(&repo_manager, &test_skill_cache()).unwrap();
         assert!(
             result.is_some(),
             "a marketplace repo yields a SourcesManager"
@@ -843,7 +863,8 @@ mod tests {
     #[test]
     fn test_create_sources_manager_from_http_registry_only_is_none() {
         let repo_manager = RepositoryManager::from_definitions(vec![http_registry_repo("reg")]);
-        let result = create_sources_manager_from_repositories(&repo_manager).unwrap();
+        let result =
+            create_sources_manager_from_repositories(&repo_manager, &test_skill_cache()).unwrap();
         assert!(
             result.is_none(),
             "http-registry-only repos produce no marketplace sources manager"
@@ -853,7 +874,8 @@ mod tests {
     #[test]
     fn test_create_sources_manager_from_empty_is_none() {
         let repo_manager = RepositoryManager::from_definitions(Vec::new());
-        let result = create_sources_manager_from_repositories(&repo_manager).unwrap();
+        let result =
+            create_sources_manager_from_repositories(&repo_manager, &test_skill_cache()).unwrap();
         assert!(result.is_none());
     }
 }

--- a/crates/fastskill-core/src/core/cache/index.rs
+++ b/crates/fastskill-core/src/core/cache/index.rs
@@ -34,11 +34,23 @@ pub struct SourceIndex {
 }
 
 /// One skill's advertised versions within a [`SourceIndex`].
+///
+/// `name`/`description` (spec 008) are a representative snapshot for the
+/// skill id — the same simplification `RepositoryManager::refresh_index`
+/// already applies to `versions` (one set per id, not per-version metadata).
+/// Both are `#[serde(default)]` so an index written before spec 008 (just
+/// `skill` and `versions`) still deserializes: a pre-existing on-disk index
+/// is read back with empty strings until the next refresh or live fetch
+/// repopulates it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SourceIndexEntry {
     pub skill: String,
     #[serde(default)]
     pub versions: Vec<String>,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
 }
 
 /// A single git ref resolution: the commit SHA `url+ref` resolved to, and
@@ -225,6 +237,8 @@ mod tests {
             entries: vec![SourceIndexEntry {
                 skill: "demo".to_string(),
                 versions: vec!["1.0.0".to_string(), "1.1.0".to_string()],
+                name: "Demo".to_string(),
+                description: "A demo skill".to_string(),
             }],
         };
 
@@ -232,6 +246,30 @@ mod tests {
         let read_back = read_source_index(root.path(), "acme").unwrap();
 
         assert_eq!(read_back, Some(idx));
+    }
+
+    /// spec 008: `name`/`description` were added to `SourceIndexEntry` after
+    /// the on-disk schema shipped (US-001/US-005). An index file written by
+    /// an older binary (`skill` + `versions` only) must still deserialize,
+    /// with the new fields defaulting to empty strings rather than failing to
+    /// parse.
+    #[test]
+    fn source_index_entry_without_name_or_description_still_deserializes() {
+        let root = TempDir::new().unwrap();
+        let index_dir = root.path().join("index");
+        std::fs::create_dir_all(&index_dir).unwrap();
+        std::fs::write(
+            index_dir.join("acme.json"),
+            r#"{"fetched_at":"2026-01-01T00:00:00Z","entries":[{"skill":"demo","versions":["1.0.0"]}]}"#,
+        )
+        .unwrap();
+
+        let idx = read_source_index(root.path(), "acme").unwrap().unwrap();
+        assert_eq!(idx.entries.len(), 1);
+        assert_eq!(idx.entries[0].skill, "demo");
+        assert_eq!(idx.entries[0].versions, vec!["1.0.0".to_string()]);
+        assert_eq!(idx.entries[0].name, "");
+        assert_eq!(idx.entries[0].description, "");
     }
 
     #[test]

--- a/crates/fastskill-core/src/core/install.rs
+++ b/crates/fastskill-core/src/core/install.rs
@@ -726,6 +726,12 @@ fn resolve_registry_version(
 /// branch to persist a listing call it already made live, so a
 /// same-invocation update can resolve through the index instead of needing a
 /// separate `repos refresh`.
+///
+/// `client.get_versions` (this function's only caller) has no `name`/
+/// `description` to offer, so an existing entry's `name`/`description`
+/// (spec 008) are left as they were rather than clobbered with blanks, and a
+/// newly-created entry gets empty strings until a `repos refresh` or a live
+/// marketplace fetch fills them in.
 fn upsert_source_index_entry(
     cache: &SkillCache,
     repo_name: &str,
@@ -745,6 +751,8 @@ fn upsert_source_index_entry(
         idx.entries.push(SourceIndexEntry {
             skill: skill.to_string(),
             versions: versions.to_vec(),
+            name: String::new(),
+            description: String::new(),
         });
     }
     cache.write_source_index(repo_name, &idx)

--- a/crates/fastskill-core/src/core/repository.rs
+++ b/crates/fastskill-core/src/core/repository.rs
@@ -499,20 +499,36 @@ impl RepositoryManager {
         // Group by skill id, deduping versions — `list_skills()` currently
         // advertises one (the current/latest) version per skill for every
         // repository type, but this stays correct if that ever changes.
-        let mut by_id: std::collections::BTreeMap<String, std::collections::BTreeSet<String>> =
-            std::collections::BTreeMap::new();
+        //
+        // `name`/`description` (spec 008) are recorded as a representative
+        // snapshot for the id — the first `SkillMetadata` seen for it — the
+        // same "one per id, not one per version" simplification `versions`
+        // already applies; `list_skills()`'s current one-version-per-skill
+        // behavior means this loses nothing in practice today.
+        let mut by_id: std::collections::BTreeMap<
+            String,
+            (std::collections::BTreeSet<String>, String, String),
+        > = std::collections::BTreeMap::new();
         for skill in &skills {
-            by_id
-                .entry(skill.id.to_string())
-                .or_default()
-                .insert(skill.version.clone());
+            let entry = by_id.entry(skill.id.to_string()).or_insert_with(|| {
+                (
+                    std::collections::BTreeSet::new(),
+                    skill.name.clone(),
+                    skill.description.clone(),
+                )
+            });
+            entry.0.insert(skill.version.clone());
         }
         let entries: Vec<crate::core::cache::SourceIndexEntry> = by_id
             .into_iter()
-            .map(|(skill, versions)| crate::core::cache::SourceIndexEntry {
-                skill,
-                versions: versions.into_iter().collect(),
-            })
+            .map(
+                |(skill, (versions, name, description))| crate::core::cache::SourceIndexEntry {
+                    skill,
+                    versions: versions.into_iter().collect(),
+                    name,
+                    description,
+                },
+            )
             .collect();
         let entry_count = entries.len();
 
@@ -589,6 +605,10 @@ mod refresh_index_tests {
         assert_eq!(skills, vec!["alpha", "beta"]);
         let alpha = idx.entries.iter().find(|e| e.skill == "alpha").unwrap();
         assert_eq!(alpha.versions, vec!["1.0.0".to_string()]);
+        // spec 008: name/description are captured from the listing too, not
+        // just id + versions.
+        assert_eq!(alpha.name, "alpha");
+        assert_eq!(alpha.description, "a skill");
     }
 
     #[tokio::test]

--- a/crates/fastskill-core/src/core/sources/manager.rs
+++ b/crates/fastskill-core/src/core/sources/manager.rs
@@ -12,6 +12,19 @@ use super::marketplace::{
 };
 use super::model::{SkillInfo, SourceConfig, SourceDefinition, SourcesConfig};
 use super::SourcesError;
+use crate::core::cache::SkillCache;
+
+/// Number of times [`SourcesManager::try_fetch_marketplace`] actually issued
+/// an HTTP request for a `marketplace.json` (either candidate location).
+/// Instrumentation-only, kept for the same reason as
+/// `storage::git::CLONE_INVOCATIONS` / `registry::client::DOWNLOAD_INVOCATIONS`
+/// / `install::LOCAL_COPY_INVOCATIONS`: proving spec 008's "zero HTTP calls
+/// on a disk-index hit" claim is otherwise only observable by timing.
+/// Deliberately not gated behind `#[cfg(test)]` — integration tests are a
+/// separate compilation unit and cannot see items scoped that way.
+#[doc(hidden)] // test instrumentation, not supported public API
+pub static MARKETPLACE_FETCH_INVOCATIONS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
 
 /// Sources manager for handling multiple sources
 pub struct SourcesManager {
@@ -19,6 +32,19 @@ pub struct SourcesManager {
     sources: HashMap<String, SourceDefinition>,
     marketplace_cache: Arc<RwLock<HashMap<String, CachedMarketplace>>>,
     cache_ttl_seconds: u64,
+    /// The on-disk index cache (spec 008 FR-1/FR-2), consulted on an
+    /// in-memory miss and refreshed on a successful live fetch.
+    ///
+    /// `None` by default (`new`/`with_cache_ttl`/`from_repositories` do not
+    /// set it) so every construction site keeps today's memory-only
+    /// behavior unless it opts in via [`Self::with_skill_cache`] — notably
+    /// `MarketplaceRepositoryClient::new` (`repository/client.rs`), whose
+    /// `SourcesManager` backs `RepositoryManager::refresh_index`'s listing
+    /// call and must stay a real, unconditional network fetch (FR-4: `repos
+    /// refresh`'s contract must not change). Giving that one a disk-first
+    /// read-through would let a stale on-disk index silently answer what is
+    /// supposed to be an explicit refresh.
+    skill_cache: Option<SkillCache>,
 }
 
 impl SourcesManager {
@@ -29,6 +55,7 @@ impl SourcesManager {
             sources: HashMap::new(),
             marketplace_cache: Arc::new(RwLock::new(HashMap::new())),
             cache_ttl_seconds: 300, // 5 minutes default TTL
+            skill_cache: None,
         }
     }
 
@@ -39,7 +66,20 @@ impl SourcesManager {
             sources: HashMap::new(),
             marketplace_cache: Arc::new(RwLock::new(HashMap::new())),
             cache_ttl_seconds,
+            skill_cache: None,
         }
+    }
+
+    /// Opt this manager into the on-disk index cache (spec 008 FR-1/FR-2):
+    /// `fetch_and_cache_marketplace` will consult it on an in-memory miss
+    /// before going to the network, and refresh it after a successful live
+    /// fetch. Without this, `SourcesManager` behaves exactly as it did
+    /// before spec 008 (memory-only, always live on a miss) — see the
+    /// `skill_cache` field's docs for why some construction sites must not
+    /// opt in.
+    pub fn with_skill_cache(mut self, skill_cache: SkillCache) -> Self {
+        self.skill_cache = Some(skill_cache);
+        self
     }
 
     /// Load sources from TOML file
@@ -272,6 +312,7 @@ impl SourcesManager {
         url: &str,
         base_repo_url: Option<&str>,
     ) -> Result<MarketplaceJson, SourcesError> {
+        MARKETPLACE_FETCH_INVOCATIONS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let client = reqwest::Client::new();
         let response = client.get(url).send().await.map_err(|e| {
             SourcesError::Network(format!("Failed to fetch marketplace.json: {}", e))
@@ -363,8 +404,25 @@ impl SourcesManager {
     /// Check cache, fetch from the network if stale, update cache, and return the marketplace.
     ///
     /// This is the single place where cache reads, TTL checks, HTTP calls, and cache writes live.
+    ///
+    /// spec 008: on an in-memory miss, the on-disk index (keyed by
+    /// `source_name`) is consulted *before* the network (FR-1) — a genuine
+    /// bypass, not just a fallback, so a cold process with a previously
+    /// `repos refresh`-ed (or previously live-fetched) source resolves a
+    /// listing with zero HTTP calls. A successful live fetch still populates
+    /// the in-memory map as before, and additionally refreshes the on-disk
+    /// index for `source_name` so the two layers do not drift (FR-2). If
+    /// *neither* layer has anything yet, the network is attempted as a last
+    /// resort; if that fails too but the on-disk index gained a usable entry
+    /// in the meantime (e.g. a concurrent `repos refresh`), it is used with a
+    /// warning naming when it was recorded (FR-3) — mirroring
+    /// `install::resolve_git_sha` / `install::fetch_zip_url_cached`'s
+    /// offline-fallback shape. `self.skill_cache` is `None` for managers that
+    /// must never read the disk index this way (see its field docs), so all
+    /// of the above degrades to today's memory-only behavior for them.
     async fn fetch_and_cache_marketplace(
         &self,
+        source_name: &str,
         claude_plugin_url: &str,
         root_url: &str,
         base_url: &str,
@@ -384,8 +442,20 @@ impl SourcesManager {
             }
         }
 
+        // FR-1: consult the on-disk index before the network.
+        if let Some((marketplace, fetched_at)) = self.disk_index_marketplace(source_name).await {
+            tracing::warn!(
+                "using the on-disk index for source '{source_name}' (recorded {fetched_at}) \
+                 instead of a live marketplace fetch; run `fastskill repos refresh {source_name}` \
+                 for the latest listing"
+            );
+            self.cache_marketplace_in_memory(claude_plugin_url, &marketplace)
+                .await;
+            return Ok(marketplace);
+        }
+
         // Try Claude Code standard location first, fall back to root
-        let (marketplace, successful_url) = match self
+        let live_fetch = match self
             .try_fetch_marketplace(claude_plugin_url, Some(base_url))
             .await
         {
@@ -394,7 +464,7 @@ impl SourcesManager {
                     "Loaded marketplace.json from Claude Code standard location: {}",
                     claude_plugin_url
                 );
-                (m, claude_plugin_url.to_string())
+                Ok((m, claude_plugin_url.to_string()))
             }
             Err(e) => {
                 tracing::debug!(
@@ -405,31 +475,94 @@ impl SourcesManager {
                 match self.try_fetch_marketplace(root_url, Some(base_url)).await {
                     Ok(m) => {
                         tracing::debug!("Loaded marketplace.json from root location: {}", root_url);
-                        (m, root_url.to_string())
+                        Ok((m, root_url.to_string()))
                     }
-                    Err(e2) => {
-                        return Err(SourcesError::Network(format!(
-                            "Failed to fetch marketplace.json from both locations. Claude Code location (.claude-plugin/marketplace.json): {}. Root location (marketplace.json): {}",
-                            e, e2
-                        )));
-                    }
+                    Err(e2) => Err(SourcesError::Network(format!(
+                        "Failed to fetch marketplace.json from both locations. Claude Code location (.claude-plugin/marketplace.json): {}. Root location (marketplace.json): {}",
+                        e, e2
+                    ))),
                 }
             }
         };
 
-        {
-            let mut cache = self.marketplace_cache.write().await;
-            cache.insert(
-                successful_url,
-                CachedMarketplace {
-                    data: marketplace.clone(),
-                    fetched_at: Utc::now(),
-                    ttl_seconds: self.cache_ttl_seconds,
-                },
-            );
+        let (marketplace, successful_url) = match live_fetch {
+            Ok(ok) => ok,
+            Err(err) => {
+                // FR-3: both live locations failed. A last-resort re-check of
+                // the on-disk index (it found nothing above, but this guards
+                // a concurrent `repos refresh`/live-fetch landing in
+                // between) proceeds with a warning naming when it was
+                // recorded, rather than surfacing the network error.
+                if let Some((marketplace, fetched_at)) =
+                    self.disk_index_marketplace(source_name).await
+                {
+                    tracing::warn!(
+                        "could not fetch a live marketplace listing for source '{source_name}' \
+                         ({err}); using the on-disk index recorded {fetched_at} instead"
+                    );
+                    self.cache_marketplace_in_memory(claude_plugin_url, &marketplace)
+                        .await;
+                    return Ok(marketplace);
+                }
+                return Err(err);
+            }
+        };
+
+        self.cache_marketplace_in_memory(&successful_url, &marketplace)
+            .await;
+
+        // FR-2: refresh the on-disk index so it does not drift behind what
+        // was just fetched live. Best-effort: a write failure must not fail
+        // a fetch that has already succeeded.
+        if let Some(skill_cache) = &self.skill_cache {
+            if let Err(e) = skill_cache
+                .write_source_index(source_name, &marketplace_to_source_index(&marketplace))
+            {
+                tracing::warn!(
+                    "failed to refresh the on-disk index for source '{source_name}': {}",
+                    e
+                );
+            }
         }
 
         Ok(marketplace)
+    }
+
+    /// FR-1/FR-3's shared disk-index lookup: `None` when this manager has no
+    /// [`SkillCache`] configured, the index has never been written for
+    /// `source_name`, or it was written with zero entries. Otherwise a best-
+    /// effort [`MarketplaceJson`] reconstructed from it (see
+    /// [`source_index_to_marketplace`] for exactly what is and is not
+    /// recoverable from the on-disk shape), paired with the index's recorded
+    /// `fetched_at` so callers can name it in their warning (FR-3).
+    async fn disk_index_marketplace(
+        &self,
+        source_name: &str,
+    ) -> Option<(MarketplaceJson, chrono::DateTime<Utc>)> {
+        let skill_cache = self.skill_cache.as_ref()?;
+        let idx = skill_cache.read_source_index(source_name).ok()??;
+        if idx.entries.is_empty() {
+            return None;
+        }
+        let fetched_at = idx.fetched_at;
+        Some((source_index_to_marketplace(&idx), fetched_at))
+    }
+
+    /// Insert `marketplace` into the in-memory map under `key` (FR-5: this is
+    /// the seam the within-operation dedup relies on — every return point in
+    /// `fetch_and_cache_marketplace`, disk or network, goes through it, so a
+    /// second call in the same operation always hits the in-memory check at
+    /// the top rather than repeating a disk read or a fetch).
+    async fn cache_marketplace_in_memory(&self, key: &str, marketplace: &MarketplaceJson) {
+        let mut cache = self.marketplace_cache.write().await;
+        cache.insert(
+            key.to_string(),
+            CachedMarketplace {
+                data: marketplace.clone(),
+                fetched_at: Utc::now(),
+                ttl_seconds: self.cache_ttl_seconds,
+            },
+        );
     }
 
     /// Load marketplace.json from a URL.
@@ -446,7 +579,7 @@ impl SourcesManager {
         let root_url = Self::to_github_raw_url(base_url, branch_name, "marketplace.json");
 
         let marketplace = self
-            .fetch_and_cache_marketplace(&claude_plugin_url, &root_url, base_url)
+            .fetch_and_cache_marketplace(source_name, &claude_plugin_url, &root_url, base_url)
             .await?;
 
         Ok(marketplace
@@ -558,8 +691,96 @@ impl SourcesManager {
             Self::to_github_raw_url(base_url, branch, ".claude-plugin/marketplace.json");
         let root_url = Self::to_github_raw_url(base_url, branch, "marketplace.json");
 
-        self.fetch_and_cache_marketplace(&claude_plugin_url, &root_url, base_url)
+        self.fetch_and_cache_marketplace(source_name, &claude_plugin_url, &root_url, base_url)
             .await
+    }
+}
+
+/// FR-2: fold a freshly-fetched [`MarketplaceJson`] into the on-disk
+/// [`crate::core::cache::SourceIndex`] shape — group by skill id, dedup
+/// versions, keep a representative `name`/`description` per id (the first
+/// skill entry seen for it). Mirrors
+/// `RepositoryManager::refresh_index`'s grouping (`repository.rs`) applied to
+/// a [`MarketplaceSkill`] list instead of a `SkillMetadata` list.
+fn marketplace_to_source_index(marketplace: &MarketplaceJson) -> crate::core::cache::SourceIndex {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    let mut by_id: BTreeMap<String, (BTreeSet<String>, String, String)> = BTreeMap::new();
+    for skill in &marketplace.skills {
+        let entry = by_id.entry(skill.id.clone()).or_insert_with(|| {
+            (
+                BTreeSet::new(),
+                skill.name.clone(),
+                skill.description.clone(),
+            )
+        });
+        entry.0.insert(skill.version.clone());
+    }
+
+    let entries = by_id
+        .into_iter()
+        .map(
+            |(skill, (versions, name, description))| crate::core::cache::SourceIndexEntry {
+                skill,
+                versions: versions.into_iter().collect(),
+                name,
+                description,
+            },
+        )
+        .collect();
+
+    crate::core::cache::SourceIndex {
+        fetched_at: Utc::now(),
+        entries,
+    }
+}
+
+/// FR-1/FR-3: the read-side inverse of [`marketplace_to_source_index`] —
+/// best-effort reconstruct a [`MarketplaceJson`] from a
+/// [`crate::core::cache::SourceIndex`] so a disk hit can stand in for a live
+/// fetch.
+///
+/// **Lossy**: `SourceIndexEntry` (owned by the on-disk index schema, shared
+/// with `RepositoryManager::refresh_index` and `install::resolve_repository_version`,
+/// which never needed more than `skill` + `versions`) has no `author` or
+/// `download_url` field — a skill reconstructed this way always gets
+/// `author: None, download_url: None`. In this codebase that is a narrow,
+/// display-only gap: the real skill-content fetch (`install_from_resolved_source`,
+/// `install.rs`) resolves bytes from a `SourceConfig` (git/zip-url/local),
+/// never from `MarketplaceSkill::download_url` — so it is never even read on
+/// the path that matters for *installing*. It does reach two read-only HTTP
+/// registry endpoints (`GET /api/v1/registry/skills`,
+/// `.../sources/:name/skills`) that surface `author`/`download_url` for
+/// display; those fields render blank when a listing came from the disk
+/// fallback instead of a live fetch, until the next live fetch or `repos
+/// refresh` repopulates them with real values.
+///
+/// One [`MarketplaceSkill`] is emitted per recorded version, all sharing the
+/// entry's representative `name`/`description` (the same "one per id, not
+/// one per version" approximation `marketplace_to_source_index` already made
+/// when writing the index).
+fn source_index_to_marketplace(idx: &crate::core::cache::SourceIndex) -> MarketplaceJson {
+    let skills = idx
+        .entries
+        .iter()
+        .flat_map(|entry| {
+            let id = entry.skill.clone();
+            let name = entry.name.clone();
+            let description = entry.description.clone();
+            entry.versions.iter().map(move |version| MarketplaceSkill {
+                id: id.clone(),
+                name: name.clone(),
+                description: description.clone(),
+                version: version.clone(),
+                author: None,
+                download_url: None,
+            })
+        })
+        .collect();
+
+    MarketplaceJson {
+        version: "1.0".to_string(),
+        skills,
     }
 }
 

--- a/crates/fastskill-core/src/http/handlers/manifest.rs
+++ b/crates/fastskill-core/src/http/handlers/manifest.rs
@@ -254,9 +254,12 @@ pub async fn add_skill_to_manifest(
     let repositories = get_repositories(&project);
     let repo_manager = RepositoryManager::from_definitions(repositories);
 
-    // Get sources manager for marketplace-based repositories
+    // Get sources manager for marketplace-based repositories. spec 008: opts
+    // into the on-disk index cache so a cold/offline add resolves a listing
+    // already known to `state.service`'s cache without a network round-trip.
     let sources_manager = SourcesManager::from_repositories(&repo_manager)
-        .map_err(|e| HttpError::InternalServerError(e.to_string()))?;
+        .map_err(|e| HttpError::InternalServerError(e.to_string()))?
+        .map(|mgr| mgr.with_skill_cache(state.service.skill_cache().clone()));
 
     // Find the skill in sources
     let marketplace_skill = if let Some(sources_mgr) = &sources_manager {

--- a/crates/fastskill-core/src/http/handlers/registry.rs
+++ b/crates/fastskill-core/src/http/handlers/registry.rs
@@ -41,6 +41,19 @@ fn get_repository_manager(project_file_path: &std::path::Path) -> RepositoryMana
 /// local symlink/pre-create race. The returned `TempDir` owns that directory
 /// and MUST be kept alive by the caller for as long as the `SourcesManager` is
 /// used — dropping it deletes the backing file.
+///
+/// spec 008: deliberately does *not* opt this manager into the on-disk index
+/// cache (`SourcesManager::with_skill_cache`) — `refresh_sources` (`POST
+/// /api/v1/registry/refresh`) reuses this same helper via `list_all_skills`
+/// to serve its "post-refresh" listing, and that call must stay a real,
+/// live fetch (mirroring FR-4's requirement for `repos refresh`): a disk-
+/// first read-through here would let `/refresh` silently answer from a
+/// stale on-disk index instead of actually refreshing. The plain read-only
+/// browse endpoints (`list_all_skills`, `list_source_skills`,
+/// `get_marketplace`) therefore do not get spec 008's offline benefit either
+/// — out of scope for this change, which targets the CLI install path and
+/// `POST /api/manifest/skills` (`manifest.rs`), neither of which has this
+/// reuse hazard.
 async fn get_sources_manager_from_repos(
     repo_manager: &RepositoryManager,
 ) -> Result<(SourcesManager, tempfile::TempDir), String> {

--- a/crates/fastskill-core/tests/marketplace_index_readthrough_test.rs
+++ b/crates/fastskill-core/tests/marketplace_index_readthrough_test.rs
@@ -1,0 +1,344 @@
+//! Integration tests for spec 008 "marketplace-cache-reconciliation":
+//! `SourcesManager::fetch_and_cache_marketplace` reads through to the on-disk
+//! index cache (`SkillCache::read_source_index`) on an in-memory miss,
+//! instead of always hitting the network — closing the same offline gap
+//! `Origin::Git`/`Origin::Repository` already have (`install::resolve_git_sha`,
+//! `install::resolve_repository_version`) for the marketplace-listing path.
+//!
+//! "Zero HTTP calls" is proven via
+//! `core::sources::manager::MARKETPLACE_FETCH_INVOCATIONS`, a counting seam
+//! kept for exactly this purpose (mirrors `storage::git::CLONE_INVOCATIONS` /
+//! `registry::client::DOWNLOAD_INVOCATIONS` / `install::ZIP_URL_BODY_BYTES_DOWNLOADED`).
+//! The `wiremock` `MockServer` fixture used where a live fetch *is* expected
+//! is a loopback-bound server, not "the network" — same posture as
+//! `zip_url_cache_test.rs`/`registry_content_cache_test.rs`.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use fastskill_core::core::cache::{SkillCache, SourceIndex, SourceIndexEntry};
+use fastskill_core::core::sources::manager::MARKETPLACE_FETCH_INVOCATIONS;
+use fastskill_core::core::sources::{SourceConfig, SourcesManager};
+use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// An address nothing listens on: a connection attempt fails fast (refused)
+/// without touching the real network — mirrors the same technique
+/// `zip_url_cache_test.rs` uses for its offline-fallback tests.
+const UNREACHABLE_BASE_URL: &str = "http://127.0.0.1:1";
+
+fn sources_toml_path(dir: &TempDir) -> std::path::PathBuf {
+    dir.path().join("sources.toml")
+}
+
+/// A minimal, valid Claude Code `marketplace.json` advertising `count`
+/// skills (`skill-a`, `skill-b`, ...), each with a non-empty id/name/
+/// description/version so `SourcesManager`'s own validation accepts it.
+fn claude_marketplace_json(count: usize) -> serde_json::Value {
+    let plugins: Vec<serde_json::Value> = (0..count)
+        .map(|i| {
+            let letter = (b'a' + i as u8) as char;
+            serde_json::json!({
+                "name": format!("plugin-{letter}"),
+                "description": format!("Plugin {letter}"),
+                "source": "./",
+                "skills": [format!("./skill-{letter}")],
+            })
+        })
+        .collect();
+    serde_json::json!({
+        "name": "test-marketplace",
+        "owner": {"name": "Test Owner"},
+        "metadata": {"description": "test marketplace", "version": "1.0.0"},
+        "plugins": plugins,
+    })
+}
+
+// ── FR-1: disk-first bypass, zero HTTP calls ────────────────────────────────
+
+/// A cold `SourcesManager` (empty in-memory cache) with a `SkillCache`
+/// carrying a previously-refreshed on-disk index for the source resolves the
+/// listing straight from disk: zero HTTP calls, and the returned data
+/// matches what was recorded.
+#[tokio::test]
+async fn cold_sources_manager_resolves_listing_from_disk_index_with_zero_http_calls() {
+    let cache_root = TempDir::new().unwrap();
+    let cache = SkillCache::at_root(cache_root.path());
+    cache
+        .write_source_index(
+            "acme",
+            &SourceIndex {
+                fetched_at: chrono::Utc::now(),
+                entries: vec![SourceIndexEntry {
+                    skill: "alpha".to_string(),
+                    versions: vec!["1.0.0".to_string()],
+                    name: "Alpha".to_string(),
+                    description: "The alpha skill".to_string(),
+                }],
+            },
+        )
+        .unwrap();
+
+    let sources_dir = TempDir::new().unwrap();
+    let mut manager = SourcesManager::new(sources_toml_path(&sources_dir)).with_skill_cache(cache);
+    manager.load().unwrap();
+    manager
+        .add_source(
+            "acme".to_string(),
+            SourceConfig::ZipUrl {
+                // Never touched if FR-1's disk-first bypass works: nothing
+                // listens here, so any real request would fail fast.
+                base_url: UNREACHABLE_BASE_URL.to_string(),
+                auth: None,
+            },
+        )
+        .unwrap();
+
+    let baseline = MARKETPLACE_FETCH_INVOCATIONS.load(Ordering::SeqCst);
+    let marketplace = manager
+        .get_marketplace_json("acme")
+        .await
+        .expect("a disk-index hit must resolve without touching the network");
+    let after = MARKETPLACE_FETCH_INVOCATIONS.load(Ordering::SeqCst);
+
+    assert_eq!(
+        after, baseline,
+        "resolving from the on-disk index must make zero HTTP calls"
+    );
+    assert_eq!(marketplace.skills.len(), 1);
+    let skill = &marketplace.skills[0];
+    assert_eq!(skill.id, "alpha");
+    assert_eq!(skill.name, "Alpha");
+    assert_eq!(skill.description, "The alpha skill");
+    assert_eq!(skill.version, "1.0.0");
+}
+
+/// With no `SkillCache` configured at all (today's pre-spec-008 behavior,
+/// still the default for e.g. `SourcesManager::new`), an in-memory miss goes
+/// straight to the network exactly as before — spec 008 must not change
+/// behavior for a manager that never opted in.
+#[tokio::test]
+async fn without_a_skill_cache_configured_behavior_is_unchanged_network_on_miss() {
+    let sources_dir = TempDir::new().unwrap();
+    let mut manager = SourcesManager::new(sources_toml_path(&sources_dir));
+    manager.load().unwrap();
+    manager
+        .add_source(
+            "acme".to_string(),
+            SourceConfig::ZipUrl {
+                base_url: UNREACHABLE_BASE_URL.to_string(),
+                auth: None,
+            },
+        )
+        .unwrap();
+
+    let err = manager
+        .get_marketplace_json("acme")
+        .await
+        .expect_err("no cache configured and nothing reachable must fail, not silently succeed");
+    assert!(err.to_string().to_lowercase().contains("failed to fetch"));
+}
+
+// ── FR-5: within-operation dedup is preserved ───────────────────────────────
+
+/// Resolving N skills from one marketplace source, in one operation, performs
+/// exactly one live fetch — the in-memory `marketplace_cache` collapses the
+/// rest, per spec 008's "Correction" (this is the load-bearing behavior the
+/// first draft nearly deleted).
+#[tokio::test]
+async fn resolving_n_skills_from_one_marketplace_performs_exactly_one_fetch() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.claude-plugin/marketplace.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(claude_marketplace_json(3)))
+        .mount(&server)
+        .await;
+
+    let sources_dir = TempDir::new().unwrap();
+    let mut manager = SourcesManager::new(sources_toml_path(&sources_dir));
+    manager.load().unwrap();
+    manager
+        .add_source(
+            "acme".to_string(),
+            SourceConfig::ZipUrl {
+                base_url: server.uri(),
+                auth: None,
+            },
+        )
+        .unwrap();
+
+    use fastskill_core::core::resolver::{ConflictStrategy, PackageResolver};
+    let mut resolver = PackageResolver::new(Arc::new(manager));
+
+    let baseline = MARKETPLACE_FETCH_INVOCATIONS.load(Ordering::SeqCst);
+    resolver
+        .build_index()
+        .await
+        .expect("build_index must succeed");
+    let after_build = MARKETPLACE_FETCH_INVOCATIONS.load(Ordering::SeqCst);
+    assert_eq!(
+        after_build - baseline,
+        1,
+        "one source, one build_index() call, must fetch exactly once"
+    );
+
+    for id in ["skill-a", "skill-b", "skill-c"] {
+        resolver
+            .resolve_skill(id, None, None, ConflictStrategy::Priority)
+            .unwrap_or_else(|e| panic!("resolving '{id}' must succeed: {e}"));
+    }
+    let after_resolves = MARKETPLACE_FETCH_INVOCATIONS.load(Ordering::SeqCst);
+    assert_eq!(
+        after_resolves, after_build,
+        "resolving already-indexed skills must not perform additional fetches"
+    );
+}
+
+// ── FR-2: a live fetch refreshes the on-disk index ──────────────────────────
+
+/// A successful live fetch (in-memory and on-disk both cold) writes the
+/// on-disk index for the source, so a later cold process can resolve the
+/// same listing offline (FR-2: the two layers must not drift).
+#[tokio::test]
+async fn a_successful_live_fetch_refreshes_the_on_disk_index() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.claude-plugin/marketplace.json"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(claude_marketplace_json(1)))
+        .mount(&server)
+        .await;
+
+    let cache_root = TempDir::new().unwrap();
+    let cache = SkillCache::at_root(cache_root.path());
+    assert!(
+        cache.read_source_index("acme").unwrap().is_none(),
+        "precondition: nothing on disk yet"
+    );
+
+    let sources_dir = TempDir::new().unwrap();
+    let mut manager =
+        SourcesManager::new(sources_toml_path(&sources_dir)).with_skill_cache(cache.clone());
+    manager.load().unwrap();
+    manager
+        .add_source(
+            "acme".to_string(),
+            SourceConfig::ZipUrl {
+                base_url: server.uri(),
+                auth: None,
+            },
+        )
+        .unwrap();
+
+    manager
+        .get_marketplace_json("acme")
+        .await
+        .expect("live fetch must succeed");
+
+    let idx = cache
+        .read_source_index("acme")
+        .unwrap()
+        .expect("FR-2: a successful live fetch must write the on-disk index");
+    assert_eq!(idx.entries.len(), 1);
+    assert_eq!(idx.entries[0].skill, "skill-a");
+    assert_eq!(idx.entries[0].versions, vec!["1.0.0".to_string()]);
+    assert_eq!(idx.entries[0].name, "skill-a");
+    assert_eq!(idx.entries[0].description, "Plugin a");
+}
+
+// ── FR-3: network-failure fallback names the recorded fetch time ───────────
+
+/// Captures every `tracing` event's formatted message emitted while alive.
+#[derive(Clone, Default)]
+struct CapturedLog(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CapturedLog {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl CapturedLog {
+    fn text(&self) -> String {
+        String::from_utf8_lossy(&self.0.lock().unwrap()).into_owned()
+    }
+}
+
+/// FR-3 / offline install: a refreshed on-disk index lets an otherwise
+/// offline `get_marketplace_json` succeed, and — since this is the same
+/// disk-first branch FR-1 uses (both live locations are never even
+/// reachable here) — the warning naming the recorded fetch time is emitted
+/// regardless of whether the network was actually attempted or bypassed
+/// outright, matching the git/zip-url fallback shape
+/// (`install::resolve_git_sha` / `install::fetch_zip_url_cached`).
+#[tokio::test]
+async fn offline_resolution_of_a_refreshed_index_succeeds_and_warns_with_the_recorded_time() {
+    let cache_root = TempDir::new().unwrap();
+    let cache = SkillCache::at_root(cache_root.path());
+    let recorded_at = chrono::Utc::now();
+    cache
+        .write_source_index(
+            "acme",
+            &SourceIndex {
+                fetched_at: recorded_at,
+                entries: vec![SourceIndexEntry {
+                    skill: "alpha".to_string(),
+                    versions: vec!["1.0.0".to_string()],
+                    name: "Alpha".to_string(),
+                    description: "The alpha skill".to_string(),
+                }],
+            },
+        )
+        .unwrap();
+
+    let sources_dir = TempDir::new().unwrap();
+    let mut manager = SourcesManager::new(sources_toml_path(&sources_dir)).with_skill_cache(cache);
+    manager.load().unwrap();
+    manager
+        .add_source(
+            "acme".to_string(),
+            SourceConfig::ZipUrl {
+                base_url: UNREACHABLE_BASE_URL.to_string(),
+                auth: None,
+            },
+        )
+        .unwrap();
+
+    let log = CapturedLog::default();
+    let make_writer = {
+        let log = log.clone();
+        move || log.clone()
+    };
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(make_writer)
+        .with_max_level(tracing::Level::WARN)
+        .with_ansi(false)
+        .without_time()
+        .with_target(false)
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let marketplace = manager
+        .get_marketplace_json("acme")
+        .await
+        .expect("offline install of a skill listed in a refreshed index must succeed");
+    assert_eq!(marketplace.skills.len(), 1);
+    assert_eq!(marketplace.skills[0].id, "alpha");
+
+    drop(_guard);
+    let captured = log.text();
+    let expected_time = recorded_at.to_string();
+    assert!(
+        captured.contains(&expected_time),
+        "the warning must name the recorded fetch time ({expected_time}); captured: {captured}"
+    );
+    assert!(
+        captured.to_lowercase().contains("warn"),
+        "the fallback must be logged at warn level; captured: {captured}"
+    );
+}

--- a/crates/fastskill-core/tests/registry_content_cache_test.rs
+++ b/crates/fastskill-core/tests/registry_content_cache_test.rs
@@ -301,6 +301,8 @@ async fn newest_resolves_via_cached_index_then_downloads_the_resolved_version() 
                 entries: vec![SourceIndexEntry {
                     skill: SKILL_ID.to_string(),
                     versions: vec!["1.0.0".to_string(), "2.0.0".to_string()],
+                    name: SKILL_ID.to_string(),
+                    description: String::new(),
                 }],
             },
         )


### PR DESCRIPTION
## What

Closes the last path in the local skill cache that always hit the network. Spec 008.

## The gap

`SourcesManager` keeps an in-memory marketplace map. It is **load-bearing**: `resolve_dependency_list` loops `resolve_skill` over a dependency tree on one `PackageResolver` holding one `SourcesManager`, so that map collapses N marketplace fetches into one per install.

But it starts empty in every process. So the **first** marketplace read of every install went to the network — even when `repos refresh` had already fetched that exact listing and written it to `index/<source>.json`. Consequences:

- Cold installs paid a round-trip the on-disk index could have answered.
- **Offline install of a listed skill failed** — the one case the earlier cache work (#227, #229) closed for git, registry and zip-url sources but never for marketplace listings.

The two caches were never duplicates competing for one job. They are different layers: in-memory dedups *within* an operation, on-disk persists *across* invocations. This PR connects them.

> An earlier draft of spec 008 proposed **deleting** the in-memory cache as dead weight. That was wrong and was corrected before any code was written — deleting it would have turned one marketplace fetch per install into N.

## How

`SourcesManager` can now opt into a `SkillCache`. On an in-memory miss it consults the on-disk index before the network; a live fetch refreshes that index so the layers don't drift; a transport failure with a usable entry proceeds with a warning naming when it was recorded — the same shape as the git and zip-url fallbacks already shipped.

## The trap this deliberately avoids

**`repos refresh` must never answer from the index it exists to update.**

`MarketplaceRepositoryClient` — which backs `RepositoryManager::refresh_index` — does **not** opt in. The same trap sits one layer up in the HTTP registry handlers, where `refresh_sources` (`POST /api/v1/registry/refresh`) shares a helper with the read-only browse endpoints; wiring the cache into that shared helper would have made the refresh endpoint serve stale disk data. Those are left alone too, so they simply don't gain the offline benefit — a deliberate scope narrowing, not an oversight.

Opt-in is confined to two confirmed-safe production paths: the CLI install path and `POST /api/manifest/skills`.

## Schema change

`SourceIndexEntry` gains `name`/`description`, both `#[serde(default)]` so an index written by an older binary still deserializes (covered by a test). Values come from metadata that `refresh_index` already had and was discarding.

`author`/`download_url` are **not** recoverable from disk. Verified this doesn't matter on the install path: it resolves bytes from `SourceConfig` (git/zip-url/local) and never reads `download_url` — the resolver already hardcodes it to `None` on main. It reaches only the read-only browse endpoints, which is exactly why those weren't wired up.

## Testing

- **1141 pass** with `-E 'not test(install_e2e_tests)'` (+6), **1154** under the full pre-push suite. Verified independently, not just by the authoring agent.
- Zero-network claims proven by counting real calls via a `MARKETPLACE_FETCH_INVOCATIONS` seam, following the `CLONE_INVOCATIONS` / `DOWNLOAD_INVOCATIONS` / `ZIP_URL_BODY_BYTES_DOWNLOADED` pattern.
- Covered: a cold manager resolves from disk with **zero** HTTP calls (pointed at an unreachable address, so a real call would also fail loudly); resolving 3 skills from one marketplace still performs **exactly one** fetch (dedup preserved); a live fetch writes through to the index; offline resolution warns with the recorded `fetched_at`; a manager **without** a cache behaves exactly as before.
- Local `wiremock` fixtures only; no real network; never points at the real user cache dir.

## Note

`cache_ttl_seconds` (default 300) is kept — it's public API and absence of in-repo callers isn't proof of none externally. Its meaning is now narrower: it bounds only the in-memory, within-operation layer, while the durable layer is the on-disk index invalidated by explicit `repos refresh`. Documented rather than silently changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmpE6bvMsDtWDjmUP9wfu
