### PR TITLE
Populate usage examples and make example_tests actually verify them

### DIFF
--- a/crates/fastskill-cli/src/commands/add/mod.rs
+++ b/crates/fastskill-cli/src/commands/add/mod.rs
@@ -158,6 +158,11 @@ impl IntoCommandSpec for AddArgs {
             summary: "Add a skill (from local path, zip, git URL, or registry ID)",
             syntax: Some("add <SOURCE> [OPTIONS]"),
             category: Some("packages"),
+            examples: vec![
+                "fastskill add pptx",
+                "fastskill add ./my-skill --editable",
+                "fastskill add https://github.com/org/skill-repo.git --branch main",
+            ],
             args: vec![
                 ArgSpec {
                     name: "source",

--- a/crates/fastskill-cli/src/commands/analyze/cluster.rs
+++ b/crates/fastskill-cli/src/commands/analyze/cluster.rs
@@ -37,6 +37,10 @@ impl IntoCommandSpec for ClusterArgs {
             summary: "Group skills by semantic similarity",
             syntax: Some("analyze cluster [OPTIONS]"),
             category: Some("analysis"),
+            examples: vec![
+                "fastskill analyze cluster",
+                "fastskill analyze cluster --num-clusters 8 --format json",
+            ],
             args: vec![
                 ArgSpec {
                     name: "num-clusters",

--- a/crates/fastskill-cli/src/commands/analyze/duplicates.rs
+++ b/crates/fastskill-cli/src/commands/analyze/duplicates.rs
@@ -56,6 +56,10 @@ impl IntoCommandSpec for DuplicatesArgs {
             summary: "Find semantically duplicate or very similar skills",
             syntax: Some("analyze duplicates [OPTIONS]"),
             category: Some("analysis"),
+            examples: vec![
+                "fastskill analyze duplicates",
+                "fastskill analyze duplicates --threshold 0.95 --severity critical",
+            ],
             args: vec![
                 ArgSpec {
                     name: "threshold",

--- a/crates/fastskill-cli/src/commands/analyze/matrix.rs
+++ b/crates/fastskill-cli/src/commands/analyze/matrix.rs
@@ -37,6 +37,10 @@ impl IntoCommandSpec for MatrixArgs {
             summary: "Show pairwise similarity matrix for all indexed skills",
             syntax: Some("analyze matrix [OPTIONS]"),
             category: Some("analysis"),
+            examples: vec![
+                "fastskill analyze matrix",
+                "fastskill analyze matrix --threshold 0.5 --limit 3",
+            ],
             args: vec![
                 ArgSpec {
                     name: "format",

--- a/crates/fastskill-cli/src/commands/cache.rs
+++ b/crates/fastskill-cli/src/commands/cache.rs
@@ -54,6 +54,7 @@ impl IntoCommandSpec for CacheInfoArgs {
             summary: "Show the skill content cache location, entry counts, and disk usage",
             syntax: Some("cache info [OPTIONS]"),
             category: Some("cache"),
+            examples: vec!["fastskill cache info", "fastskill cache info --json"],
             args: vec![
                 ArgSpec {
                     name: "format",
@@ -159,6 +160,10 @@ impl IntoCommandSpec for CacheCleanArgs {
             summary: "Remove cached skill content and print bytes reclaimed",
             syntax: Some("cache clean [--source <git|registry|local|zip>]"),
             category: Some("cache"),
+            examples: vec![
+                "fastskill cache clean",
+                "fastskill cache clean --source git",
+            ],
             args: vec![
                 ArgSpec {
                     name: "source",

--- a/crates/fastskill-cli/src/commands/doctor.rs
+++ b/crates/fastskill-cli/src/commands/doctor.rs
@@ -45,6 +45,7 @@ impl IntoCommandSpec for DoctorArgs {
             summary: "Diagnose FastSkill configuration and environment",
             syntax: Some("doctor [OPTIONS]"),
             category: Some("setup"),
+            examples: vec!["fastskill doctor", "fastskill doctor --json"],
             args: vec![ArgSpec {
                 name: "json",
                 long: Some("json"),

--- a/crates/fastskill-cli/src/commands/eval/report.rs
+++ b/crates/fastskill-cli/src/commands/eval/report.rs
@@ -40,6 +40,7 @@ impl IntoCommandSpec for ReportArgs {
             summary: "Show a report for a completed eval run",
             syntax: Some("eval report [OPTIONS]"),
             category: Some("quality"),
+            examples: vec!["fastskill eval report --run-dir ./eval-runs/2026-08-14T12-00-00"],
             args: vec![
                 ArgSpec {
                     name: "run-dir",

--- a/crates/fastskill-cli/src/commands/eval/run.rs
+++ b/crates/fastskill-cli/src/commands/eval/run.rs
@@ -86,6 +86,10 @@ impl IntoCommandSpec for RunArgs {
             summary: "Run eval cases against an agent",
             syntax: Some("eval run [OPTIONS]"),
             category: Some("quality"),
+            examples: vec![
+                "fastskill eval run --agent claude --output-dir ./eval-runs",
+                "fastskill eval run --all --output-dir ./eval-runs --ci --threshold 0.9",
+            ],
             args: vec![
                 ArgSpec {
                     name: "agent",

--- a/crates/fastskill-cli/src/commands/eval/score.rs
+++ b/crates/fastskill-cli/src/commands/eval/score.rs
@@ -44,6 +44,7 @@ impl IntoCommandSpec for ScoreArgs {
             summary: "Re-score saved eval artifacts without running the agent again",
             syntax: Some("eval score [OPTIONS]"),
             category: Some("quality"),
+            examples: vec!["fastskill eval score --run-dir ./eval-runs/2026-08-14T12-00-00"],
             args: vec![
                 ArgSpec {
                     name: "run-dir",

--- a/crates/fastskill-cli/src/commands/eval/validate.rs
+++ b/crates/fastskill-cli/src/commands/eval/validate.rs
@@ -48,6 +48,7 @@ impl IntoCommandSpec for ValidateArgs {
             summary: "Validate eval configuration and files",
             syntax: Some("eval validate [OPTIONS]"),
             category: Some("quality"),
+            examples: vec!["fastskill eval validate --all"],
             args: vec![
                 ArgSpec {
                     name: "agent",

--- a/crates/fastskill-cli/src/commands/init.rs
+++ b/crates/fastskill-cli/src/commands/init.rs
@@ -54,6 +54,10 @@ impl IntoCommandSpec for InitArgs {
             summary: "Initialize skill-project.toml in current skill directory",
             syntax: Some("init [OPTIONS]"),
             category: Some("project"),
+            examples: vec![
+                "fastskill init",
+                "fastskill init --yes --description \"My skill\"",
+            ],
             args: vec![
                 ArgSpec {
                     name: "yes",

--- a/crates/fastskill-cli/src/commands/install.rs
+++ b/crates/fastskill-cli/src/commands/install.rs
@@ -55,6 +55,11 @@ impl IntoCommandSpec for InstallArgs {
             summary: "Apply manifest: install skills from skill-project.toml [dependencies]",
             syntax: Some("install [OPTIONS]"),
             category: Some("packages"),
+            examples: vec![
+                "fastskill install",
+                "fastskill install --lock",
+                "fastskill install --without dev",
+            ],
             args: vec![
                 ArgSpec {
                     name: "without",

--- a/crates/fastskill-cli/src/commands/list.rs
+++ b/crates/fastskill-cli/src/commands/list.rs
@@ -57,6 +57,7 @@ impl IntoCommandSpec for ListArgs {
             summary: "List locally installed skills",
             syntax: Some("list [OPTIONS]"),
             category: Some("discovery"),
+            examples: vec!["fastskill list", "fastskill list --details --format json"],
             args: vec![
                 ArgSpec {
                     name: "format",

--- a/crates/fastskill-cli/src/commands/marketplace.rs
+++ b/crates/fastskill-cli/src/commands/marketplace.rs
@@ -83,6 +83,10 @@ impl IntoCommandSpec for MarketplaceCreateArgs {
             summary: "Create skill marketplace artifacts",
             syntax: Some("marketplace create <PATH> [OPTIONS]"),
             category: Some("publishing"),
+            examples: vec![
+                "fastskill marketplace create . --name my-skills",
+                "fastskill marketplace create ./skills --name my-skills --output .claude-plugin/marketplace.json",
+            ],
             args: vec![
                 ArgSpec {
                     name: "path",

--- a/crates/fastskill-cli/src/commands/read.rs
+++ b/crates/fastskill-cli/src/commands/read.rs
@@ -57,6 +57,7 @@ impl IntoCommandSpec for ReadArgs {
             summary: "Read full SKILL.md content for a skill",
             syntax: Some("read <SKILL_ID> [OPTIONS]"),
             category: Some("discovery"),
+            examples: vec!["fastskill read pptx", "fastskill read pptx --meta --json"],
             args: vec![
                 ArgSpec {
                     name: "skill-id",

--- a/crates/fastskill-cli/src/commands/reindex.rs
+++ b/crates/fastskill-cli/src/commands/reindex.rs
@@ -83,6 +83,7 @@ impl IntoCommandSpec for ReindexArgs {
             summary: "Reindex the vector index for semantic search",
             syntax: Some("reindex [OPTIONS]"),
             category: Some("packages"),
+            examples: vec!["fastskill reindex", "fastskill reindex --force"],
             args: vec![
                 ArgSpec {
                     name: "skills-dir",

--- a/crates/fastskill-cli/src/commands/remove.rs
+++ b/crates/fastskill-cli/src/commands/remove.rs
@@ -51,6 +51,10 @@ impl IntoCommandSpec for RemoveArgs {
             summary: "Uninstall skills (removes from manifest and local installation)",
             syntax: Some("remove <SKILL_ID>... [OPTIONS]"),
             category: Some("packages"),
+            examples: vec![
+                "fastskill remove pptx",
+                "fastskill remove pptx docx --force",
+            ],
             args: vec![
                 ArgSpec {
                     name: "skill-ids",

--- a/crates/fastskill-cli/src/commands/repos.rs
+++ b/crates/fastskill-cli/src/commands/repos.rs
@@ -266,6 +266,7 @@ impl IntoCommandSpec for ReposListArgs {
             summary: "List all configured repositories",
             syntax: Some("repos list [OPTIONS]"),
             category: Some("repositories"),
+            examples: vec!["fastskill repos list", "fastskill repos list --json"],
             args: vec![
                 ArgSpec {
                     name: "format",
@@ -315,6 +316,10 @@ impl IntoCommandSpec for ReposAddArgs {
             summary: "Add a new repository",
             syntax: Some("repos add <NAME> <URL-OR-PATH> [OPTIONS]"),
             category: Some("repositories"),
+            examples: vec![
+                "fastskill repos add my-repo https://github.com/org/skills.git --repo-type git-marketplace",
+                "fastskill repos add local-skills ./skills --repo-type local",
+            ],
             args: vec![
                 ArgSpec {
                     name: "name",
@@ -502,6 +507,7 @@ impl IntoCommandSpec for ReposRemoveArgs {
             summary: "Remove a repository",
             syntax: Some("repos remove <NAME>"),
             category: Some("repositories"),
+            examples: vec!["fastskill repos remove my-repo"],
             args: vec![ArgSpec {
                 name: "name",
                 kind: ArgKind::Positional,
@@ -538,6 +544,7 @@ impl IntoCommandSpec for ReposInfoArgs {
             summary: "Show repository details",
             syntax: Some("repos info <NAME> [OPTIONS]"),
             category: Some("repositories"),
+            examples: vec!["fastskill repos info my-repo"],
             args: vec![
                 ArgSpec {
                     name: "name",
@@ -605,6 +612,7 @@ impl IntoCommandSpec for ReposUpdateArgs {
             summary: "Update repository metadata",
             syntax: Some("repos update <NAME> [OPTIONS]"),
             category: Some("repositories"),
+            examples: vec!["fastskill repos update my-repo --branch main --priority 1"],
             args: vec![
                 ArgSpec {
                     name: "name",
@@ -675,6 +683,7 @@ impl IntoCommandSpec for ReposTestArgs {
             summary: "Test repository connectivity",
             syntax: Some("repos test <NAME>"),
             category: Some("repositories"),
+            examples: vec!["fastskill repos test my-repo"],
             args: vec![ArgSpec {
                 name: "name",
                 kind: ArgKind::Positional,
@@ -711,6 +720,7 @@ impl IntoCommandSpec for ReposRefreshArgs {
             summary: "Refresh repository cache",
             syntax: Some("repos refresh [NAME]"),
             category: Some("repositories"),
+            examples: vec!["fastskill repos refresh", "fastskill repos refresh my-repo"],
             args: vec![ArgSpec {
                 name: "name",
                 kind: ArgKind::Positional,
@@ -744,6 +754,10 @@ impl IntoCommandSpec for ReposSkillsArgs {
             summary: "List skills in repository catalog",
             syntax: Some("repos skills [OPTIONS]"),
             category: Some("repositories"),
+            examples: vec![
+                "fastskill repos skills",
+                "fastskill repos skills --repository my-repo --all-versions",
+            ],
             args: vec![
                 ArgSpec {
                     name: "repository",
@@ -848,6 +862,10 @@ impl IntoCommandSpec for ReposShowArgs {
             summary: "Show skill details from catalog",
             syntax: Some("repos show <SKILL-ID> [OPTIONS]"),
             category: Some("repositories"),
+            examples: vec![
+                "fastskill repos show pptx",
+                "fastskill repos show pptx --repository my-repo",
+            ],
             args: vec![
                 ArgSpec {
                     name: "skill-id",
@@ -902,6 +920,7 @@ impl IntoCommandSpec for ReposVersionsArgs {
             summary: "List available versions for a skill",
             syntax: Some("repos versions <SKILL-ID> [OPTIONS]"),
             category: Some("repositories"),
+            examples: vec!["fastskill repos versions pptx"],
             args: vec![
                 ArgSpec {
                     name: "skill-id",

--- a/crates/fastskill-cli/src/commands/search.rs
+++ b/crates/fastskill-cli/src/commands/search.rs
@@ -63,6 +63,10 @@ impl IntoCommandSpec for SearchArgs {
             summary: "Search skills by query with explicit scope flags",
             syntax: Some("search <QUERY> [--local|--remote] [OPTIONS]"),
             category: Some("discovery"),
+            examples: vec![
+                "fastskill search \"pdf generation\" --local",
+                "fastskill search \"presentation builder\" --remote --limit 5",
+            ],
             args: vec![
                 ArgSpec {
                     name: "query",

--- a/crates/fastskill-cli/src/commands/serve.rs
+++ b/crates/fastskill-cli/src/commands/serve.rs
@@ -32,6 +32,10 @@ impl IntoCommandSpec for ServeArgs {
             summary: "Start the FastSkill HTTP API server",
             syntax: Some("serve [OPTIONS]"),
             category: Some("server"),
+            examples: vec![
+                "fastskill serve",
+                "fastskill serve --port 9000 --enable-write",
+            ],
             args: vec![
                 ArgSpec {
                     name: "host",

--- a/crates/fastskill-cli/src/commands/skillopt/export.rs
+++ b/crates/fastskill-cli/src/commands/skillopt/export.rs
@@ -23,6 +23,7 @@ impl IntoCommandSpec for ExportArgs {
         CommandSpec {
             summary: "Export the best skill document from a completed run",
             syntax: Some("optimize export <run-dir> --out <path>"),
+            examples: vec!["fastskill optimize export ./optimize-runs/run-1 --out ./SKILL.md"],
             args: vec![
                 ArgSpec {
                     name: "run-dir",

--- a/crates/fastskill-cli/src/commands/skillopt/inspect.rs
+++ b/crates/fastskill-cli/src/commands/skillopt/inspect.rs
@@ -35,6 +35,10 @@ impl IntoCommandSpec for InspectArgs {
         CommandSpec {
             summary: "Inspect per-step artifacts from a training run",
             syntax: Some("optimize inspect <run-dir> --step <n> [--show <mode>]"),
+            examples: vec![
+                "fastskill optimize inspect ./optimize-runs/run-1 --step 3",
+                "fastskill optimize inspect ./optimize-runs/run-1 --step 3 --show diffs",
+            ],
             args: vec![
                 ArgSpec {
                     name: "run-dir",

--- a/crates/fastskill-cli/src/commands/skillopt/resume.rs
+++ b/crates/fastskill-cli/src/commands/skillopt/resume.rs
@@ -21,6 +21,7 @@ impl IntoCommandSpec for ResumeArgs {
         CommandSpec {
             summary: "Resume an interrupted optimization run",
             syntax: Some("optimize resume <run-dir>"),
+            examples: vec!["fastskill optimize resume ./optimize-runs/run-1"],
             args: vec![ArgSpec {
                 name: "run-dir",
                 kind: ArgKind::Positional,

--- a/crates/fastskill-cli/src/commands/skillopt/run.rs
+++ b/crates/fastskill-cli/src/commands/skillopt/run.rs
@@ -27,6 +27,7 @@ impl IntoCommandSpec for RunArgs {
         CommandSpec {
             summary: "Run skill optimization from a config file",
             syntax: Some("optimize run --config <path> [--out-dir <dir>] [--resume <run-dir>]"),
+            examples: vec!["fastskill optimize run --config ./optimize.toml"],
             args: vec![
                 ArgSpec {
                     name: "config",

--- a/crates/fastskill-cli/src/commands/skillopt/status.rs
+++ b/crates/fastskill-cli/src/commands/skillopt/status.rs
@@ -24,6 +24,10 @@ impl IntoCommandSpec for StatusArgs {
         CommandSpec {
             summary: "Show the status of a training run",
             syntax: Some("optimize status <run-dir> [--watch]"),
+            examples: vec![
+                "fastskill optimize status ./optimize-runs/run-1",
+                "fastskill optimize status ./optimize-runs/run-1 --watch",
+            ],
             args: vec![
                 ArgSpec {
                     name: "run-dir",

--- a/crates/fastskill-cli/src/commands/update.rs
+++ b/crates/fastskill-cli/src/commands/update.rs
@@ -63,6 +63,11 @@ impl IntoCommandSpec for UpdateArgs {
             summary: "Update skills to latest versions",
             syntax: Some("update [SKILL_ID] [OPTIONS]"),
             category: Some("packages"),
+            examples: vec![
+                "fastskill update",
+                "fastskill update pptx",
+                "fastskill update --check",
+            ],
             args: vec![
                 ArgSpec {
                     name: "skill-id",


### PR DESCRIPTION
Every fastskill command declared `examples: vec![]`, and the test file that was supposed to check them passed unconditionally. This fixes both ends.

Depends on **aroff/cli-framework#110** (merged) — the pinned rev is bumped to `42cb312` here.

## 1. The tests were verifying nothing

`tests/cli/example_tests.rs` asserted:

```rust
result.stdout.contains("Examples:") || result.stdout.contains("fastskill ")
```

The fallback always matched the `Usage: fastskill ...` line, so **all ~23 tests passed unconditionally** — including for commands with no examples at all, which until now was every one of them.

Now it requires an `Examples:` section **and** at least one `fastskill …` invocation under it. Proven by emptying one command's examples and confirming the test fails; under the old assertion that same state passed.

## 2. Examples populated (26 files)

1–3 real examples per fastskill-owned command: `add`, `install`, `list`, `read`, `search`, `remove`, `update`, `reindex`, `init`, `serve`, `doctor`, `cache/*`, `repos/*`, `eval/*`, `analyze/*`, `optimize/*`, `marketplace/*`.

Checked against the **actual command surface**, not the docs — the docs still reference removed commands (`publish`, `auth`, `package`, `sources`, `registry`). Safe ones were executed for real; network/long-running/agent-invoking ones were run to confirm they fail (if at all) on business logic rather than argument errors.

`completion`, `spec`, `mcp/*` are cli-framework built-ins constructed inside that crate — not reachable from here, left alone.

## 3. Three tests that were structurally unable to check examples

| Test | Why | Now |
|---|---|---|
| `root_help_shows_examples` | Root help comes from cli-framework's `HelpRenderer`, not `build_typed_clap_command` — no epilogue exists | → `root_help_lists_command_groups` |
| `repos_help_shows_examples` | `repos` is a *group*; `GroupMetadata` has only `summary`/`hidden` — no `examples` field exists for groups | → `repos_help_lists_subcommands` (per-subcommand tests still assert examples) |
| `version_help_shows_examples` | **`version` is not a command.** Absent from `fastskill spec`; `fastskill version --help` exits 0 only because the unknown token falls through to the `read <skill-id>` shorthand — so it was asserting on `read`'s help while claiming to cover `version` | deleted; `--version`/`-V` is covered by `help_tests::test_version_flag` |

## Result

```
Syntax: list [OPTIONS]

Examples:
  fastskill list
  fastskill list --details --format json
```

12 help snapshots gain an `Examples:` block. Every diff was verified **purely additive** — nothing removed, no added line other than a blank line, `Examples:`, or a `fastskill …` invocation.

## Verification

- Repo gate: **1155 tests, 1153 passing, 0 failing**
- CI parity (agent CLIs stripped from `PATH`, coverage job's exact command): **1140 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPWdJZDbVTzy3rBcgbP1E8