### PR TITLE
chore(tests): silence pre-existing clippy noise in two test files

### DIFF
--- a/crates/fastskill-cli/tests/mcp_stdio_protocol_test.rs
+++ b/crates/fastskill-cli/tests/mcp_stdio_protocol_test.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
 //! `fastskill mcp serve --transport stdio` must speak only JSON-RPC on stdout.
 //!
 //! Regression coverage for the bug where commands wrote to `stdout` with
@@ -59,7 +61,7 @@ fn fixture() -> tempfile::TempDir {
     dir
 }
 
-fn response<'a>(stdout: &'a str, id: i64) -> serde_json::Value {
+fn response(stdout: &str, id: i64) -> serde_json::Value {
     stdout
         .lines()
         .filter(|l| !l.trim().is_empty())

--- a/tests/http/search_tests.rs
+++ b/tests/http/search_tests.rs
@@ -20,7 +20,7 @@
 )]
 
 use fastskill_core::http::handlers::search::search_skills;
-use fastskill_core::http::models::{ApiResponse, SearchRequest};
+use fastskill_core::http::models::SearchRequest;
 use fastskill_core::{EmbeddingConfig, ServiceConfig};
 use std::sync::Arc;
 use tempfile::TempDir;


### PR DESCRIPTION
## What

Lint-only cleanup of two test files. No production code, no behaviour change.

Workspace clippy warnings drop **24 → 5**, so the ones that remain are actually visible instead of being buried.

## The two issues

**`crates/fastskill-cli/tests/mcp_stdio_protocol_test.rs`** produced 15 warnings for `unwrap()` / `expect()` / `panic!` — completely normal in a test. Every other file in that directory already carries an allow attribute for exactly this; this one just missed it.

Worth noting the convention isn't uniform across the repo: files in `crates/fastskill-cli/tests/` use `#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]` above the doc comment, while the root `tests/` tree uses a form that also includes `clippy::all`. This follows the **local** convention of the directory the file lives in.

The same file also had a genuine `needless_lifetimes` warning. That one is fixed properly (elided) rather than allowed, since it's a real lint with a trivial fix — allowing it would have left a warning in the very file this PR is de-noising.

**`tests/http/search_tests.rs`** imported `ApiResponse` and never used it — the identifier appeared exactly once, in the import.

## Verification

- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets --all-features` exit 0.
- **1141 tests pass, count unchanged** (1154 under the full pre-push suite). A lint-only change must not move the test count, and it doesn't.

The 5 remaining warnings are pre-existing and deliberately out of scope: `clippy::panic` in `storage/git.rs` (production) and in `tests/cli/repos_integration_tests.rs`, plus a `proc-macro-error2` future-incompat note from a third-party crate that can't be fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmpE6bvMsDtWDjmUP9wfu
