### PR TITLE
ci: run fastskill-core unit tests on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,28 @@ jobs:
       - run: cargo install cargo-nextest --locked
       - run: cargo nextest run --retries 3 --fail-fast -E 'not test(install_e2e_tests)'
 
+  # Windows unit-test coverage (Phase 1).
+  #
+  # release.yml ships an x86_64-pc-windows-msvc binary, but every other job
+  # here is ubuntu-only, so Windows-specific code has never executed anywhere.
+  # Most concretely: the `#[cfg(windows)]` rename-retry loop in
+  # `core::cache` (for a rename that transiently fails while a file is held
+  # open) has never even been compiled -- it cannot be built from Linux
+  # because `ring` and `onig_sys` need MSVC tooling to cross-compile.
+  #
+  # Scope is deliberately the fastskill-core library unit tests, with default
+  # features. The integration tests under crates/fastskill-core/tests/ are
+  # NOT included: they spin up a real `git daemon`, and one of them finds the
+  # daemon's child via /proc, which is Linux-only. Porting those is Phase 2.
+  test-windows:
+    name: Test (Windows, core unit tests)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo install cargo-nextest --locked
+      - run: cargo nextest run -p fastskill-core --lib --retries 3
+
   test-all-features:
     name: Test (All Features)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## The gap

`release.yml` ships an **`x86_64-pc-windows-msvc` binary**, but every job in `test.yml` runs on `ubuntu-latest`. So Windows-specific code ships to users having never executed anywhere.

The sharpest example: `core::cache` contains a `#[cfg(windows)]` rename-retry loop — added because a rename can transiently fail while a file is briefly held open (AV scanner, indexer) — and it has **never even been compiled**.

That is not something anyone could have caught locally. `ring` and `onig_sys` need MSVC tooling to cross-compile, so `cargo check --target x86_64-pc-windows-msvc` fails on Linux with `failed to find tool "lib.exe"`. I confirmed this both with `--all-features` and with default features, and the `x86_64-pc-windows-gnu` fallback has no std for the pinned nightly. **CI is the only place this code can be built** — which is precisely why it went untested.

## What this adds

One `windows-latest` job running the fastskill-core **library** unit tests with default features (455 tests). No existing job is modified.

Deliberately excluded: the integration tests under `crates/fastskill-core/tests/`, which spin up a real `git daemon`, and one of which locates the daemon's re-exec'd child through `/proc/<pid>/task/<pid>/children` — Linux-only. Porting those is a follow-up, not this PR.

## Honest status

**This PR is the experiment.** I cannot verify on Linux that these 455 tests pass on Windows — that's the whole point. What I did verify:

- The exact command CI will run passes locally: `cargo nextest run -p fastskill-core --lib --retries 3` → **455 passed**.
- The full Linux suite is **unchanged at 1141 passing**.
- `test.yml` parses as valid YAML with the expected six jobs.

If the Windows job fails, that is a genuine finding about shipped code rather than a problem with this PR, and I'd rather learn it here than from a user. Expect the first run to surface real issues — cache-root resolution via `dirs::cache_dir()`, path separators, temp-dir behaviour, and the rename-retry logic itself are all plausible candidates.

One thing that turned out **better** than expected: the symlink-rejection tests were already `#[cfg(unix)]`-gated by whoever wrote them, so nothing needed changing to make this compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmpE6bvMsDtWDjmUP9wfu
