### PR TITLE
Bump cli-framework pin so examples render, and make example_tests strict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "cli-framework"
 version = "0.5.8"
-source = "git+https://github.com/aroff/cli-framework?rev=f6b77aebc6518c5e819f685942ed8257442717d0#f6b77aebc6518c5e819f685942ed8257442717d0"
+source = "git+https://github.com/aroff/cli-framework?rev=42cb312a6a21c01baf75ccb433e9f87a9adce423#42cb312a6a21c01baf75ccb433e9f87a9adce423"
 dependencies = [
  "aikit-sdk",
  "ailoop-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ tower = { version = "0.5", features = ["util", "timeout", "limit"] }
 tower-http = { version = "0.6", features = ["cors", "trace", "compression-gzip", "fs"] }
 
 # CLI framework for versioned API server hosting
-cli-framework = { git = "https://github.com/aroff/cli-framework", rev = "f6b77aebc6518c5e819f685942ed8257442717d0", default-features = false, features = ["api-server"] }
+cli-framework = { git = "https://github.com/aroff/cli-framework", rev = "42cb312a6a21c01baf75ccb433e9f87a9adce423", default-features = false, features = ["api-server"] }
 
 # Request validation
 validator = { version = "0.20", features = ["derive"] }

--- a/tests/cli/example_tests.rs
+++ b/tests/cli/example_tests.rs
@@ -31,16 +31,54 @@ fn help_succeeds_and_contains_examples(args: &[&str]) {
         "fastskill {} --help should succeed",
         args.join(" ")
     );
+
+    // Require a real `Examples:` block, not merely the string "fastskill"
+    // somewhere in the output. The previous form of this assertion was
+    // `contains("Examples:") || contains("fastskill ")`, and the fallback
+    // always matched the `Usage: fastskill ...` line -- so every test in this
+    // file passed unconditionally, including for commands that had no
+    // examples at all.
+    let examples_body = result.stdout.split_once("Examples:").map(|(_, rest)| rest);
+    let Some(examples_body) = examples_body else {
+        panic!(
+            "fastskill {} --help should contain an `Examples:` section; got:\n{}",
+            args.join(" "),
+            result.stdout
+        );
+    };
+
+    // ...and at least one listed example must actually be an invocation.
     assert!(
-        result.stdout.contains("Examples:") || result.stdout.contains("fastskill "),
-        "help output should contain Examples or example usage; got: {}",
-        &result.stdout[..result.stdout.len().min(500)]
+        examples_body
+            .lines()
+            .any(|line| line.trim_start().starts_with("fastskill ")),
+        "fastskill {} --help has an `Examples:` header but no `fastskill ...` \
+         invocation under it; got:\n{}",
+        args.join(" "),
+        result.stdout
     );
 }
 
+/// Root `--help` is rendered by cli-framework's own `HelpRenderer`, not by
+/// `build_typed_clap_command`, so it has no `Examples:` epilogue to assert on
+/// (unlike every subcommand below). Assert what the root help is actually for:
+/// that it succeeds and lists the command groups.
+///
+/// Rendering examples for the root command too would require a cli-framework
+/// change to `HelpRenderer`, mirroring aroff/cli-framework#110 which added the
+/// epilogue for subcommands.
 #[test]
-fn root_help_shows_examples() {
-    help_succeeds_and_contains_examples(&["--help"]);
+fn root_help_lists_command_groups() {
+    let result = run_fastskill_command(&["--help"], None);
+    assert!(result.success, "fastskill --help should succeed");
+    for group in ["Discovery:", "Packages:", "Options:"] {
+        assert!(
+            result.stdout.contains(group),
+            "root help should list the `{}` section; got:\n{}",
+            group,
+            result.stdout
+        );
+    }
 }
 
 #[test]
@@ -68,9 +106,23 @@ fn read_help_shows_examples() {
     help_succeeds_and_contains_examples(&["read", "--help"]);
 }
 
+/// `repos` is a command *group*, registered via `register_group(_, GroupMetadata)`.
+/// `GroupMetadata` carries only `summary` and `hidden` -- it has no `examples`
+/// field -- so group help cannot show an `Examples:` block the way leaf commands
+/// do. Assert what group help is for: listing its subcommands. (The individual
+/// `repos <sub> --help` tests below do assert on examples.)
 #[test]
-fn repos_help_shows_examples() {
-    help_succeeds_and_contains_examples(&["repos", "--help"]);
+fn repos_help_lists_subcommands() {
+    let result = run_fastskill_command(&["repos", "--help"], None);
+    assert!(result.success, "fastskill repos --help should succeed");
+    for sub in ["list", "add", "remove", "refresh"] {
+        assert!(
+            result.stdout.contains(sub),
+            "repos help should list the `{}` subcommand; got:\n{}",
+            sub,
+            result.stdout
+        );
+    }
 }
 
 #[test]
@@ -148,7 +200,11 @@ fn update_help_shows_examples() {
     help_succeeds_and_contains_examples(&["update", "--help"]);
 }
 
-#[test]
-fn version_help_shows_examples() {
-    help_succeeds_and_contains_examples(&["version", "--help"]);
-}
+// `version_help_shows_examples` was removed: `version` is not a command.
+// It is absent from `fastskill spec`, and `fastskill version --help` exits 0
+// only because the unknown token falls through to the `read <skill-id>`
+// shorthand -- so the test was asserting on `read`'s help while claiming to
+// cover `version`, and passed for entirely the wrong reason. Printing the
+// version is `--version`/`-V`, already covered by
+// `help_tests::test_version_flag`. Same rationale as the `disable`/`show`
+// removals noted at the top of this file.

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__add_command_help.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__add_command_help.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/fastskill-cli/../../tests/cli/snapshot_helpers.rs
-assertion_line: 262
 expression: normalized
 ---
 Add a skill (from local path, zip, git URL, or registry ID)
@@ -27,3 +26,8 @@ Options:
   -V, --version                    Print version
 
 Syntax: add <SOURCE> [OPTIONS]
+
+Examples:
+  fastskill add pptx
+  fastskill add ./my-skill --editable
+  fastskill add https://github.com/org/skill-repo.git --branch main

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__eval_report_help.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__eval_report_help.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/fastskill-cli/../../tests/cli/snapshot_helpers.rs
-assertion_line: 262
 expression: normalized
 ---
 Show a report for a completed eval run
@@ -18,3 +17,6 @@ Options:
   -V, --version                  Print version
 
 Syntax: eval report [OPTIONS]
+
+Examples:
+  fastskill eval report --run-dir ./eval-runs/2026-08-14T12-00-00

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__eval_run_help.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__eval_run_help.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/fastskill-cli/../../tests/cli/snapshot_helpers.rs
-assertion_line: 262
 expression: normalized
 ---
 Run eval cases against an agent
@@ -27,3 +26,7 @@ Options:
   -V, --version                  Print version
 
 Syntax: eval run [OPTIONS]
+
+Examples:
+  fastskill eval run --agent claude --output-dir ./eval-runs
+  fastskill eval run --all --output-dir ./eval-runs --ci --threshold 0.9

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__eval_score_help.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__eval_score_help.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/fastskill-cli/../../tests/cli/snapshot_helpers.rs
-assertion_line: 262
 expression: normalized
 ---
 Re-score saved eval artifacts without running the agent again
@@ -19,3 +18,6 @@ Options:
   -V, --version                  Print version
 
 Syntax: eval score [OPTIONS]
+
+Examples:
+  fastskill eval score --run-dir ./eval-runs/2026-08-14T12-00-00

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__eval_validate_help.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__eval_validate_help.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/fastskill-cli/../../tests/cli/snapshot_helpers.rs
-assertion_line: 262
 expression: normalized
 ---
 Validate eval configuration and files
@@ -19,3 +18,6 @@ Options:
   -V, --version                  Print version
 
 Syntax: eval validate [OPTIONS]
+
+Examples:
+  fastskill eval validate --all

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__optimize_export_help.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__optimize_export_help.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/cli/snapshot_helpers.rs
+source: crates/fastskill-cli/../../tests/cli/snapshot_helpers.rs
 expression: normalized
 ---
 Export the best skill document from a completed run
@@ -18,3 +18,6 @@ Options:
   -V, --version                  Print version
 
 Syntax: optimize export <run-dir> --out <path>
+
+Examples:
+  fastskill optimize export ./optimize-runs/run-1 --out ./SKILL.md

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__optimize_inspect_help.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__optimize_inspect_help.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/fastskill-cli/../../tests/cli/snapshot_helpers.rs
-assertion_line: 262
 expression: normalized
 ---
 Inspect per-step artifacts from a training run
@@ -21,3 +20,7 @@ Options:
   -V, --version                  Print version
 
 Syntax: optimize inspect <run-dir> --step <n> [--show <mode>]
+
+Examples:
+  fastskill optimize inspect ./optimize-runs/run-1 --step 3
+  fastskill optimize inspect ./optimize-runs/run-1 --step 3 --show diffs

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__optimize_resume_help.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__optimize_resume_help.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/cli/snapshot_helpers.rs
+source: crates/fastskill-cli/../../tests/cli/snapshot_helpers.rs
 expression: normalized
 ---
 Resume an interrupted optimization run
@@ -17,3 +17,6 @@ Options:
   -V, --version                  Print version
 
 Syntax: optimize resume <run-dir>
+
+Examples:
+  fastskill optimize resume ./optimize-runs/run-1

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__optimize_run_help.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__optimize_run_help.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/cli/snapshot_helpers.rs
+source: crates/fastskill-cli/../../tests/cli/snapshot_helpers.rs
 expression: normalized
 ---
 Run skill optimization from a config file
@@ -17,3 +17,6 @@ Options:
   -V, --version                  Print version
 
 Syntax: optimize run --config <path> [--out-dir <dir>] [--resume <run-dir>]
+
+Examples:
+  fastskill optimize run --config ./optimize.toml

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__optimize_status_help.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__optimize_status_help.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/cli/snapshot_helpers.rs
+source: crates/fastskill-cli/../../tests/cli/snapshot_helpers.rs
 expression: normalized
 ---
 Show the status of a training run
@@ -18,3 +18,7 @@ Options:
   -V, --version                  Print version
 
 Syntax: optimize status <run-dir> [--watch]
+
+Examples:
+  fastskill optimize status ./optimize-runs/run-1
+  fastskill optimize status ./optimize-runs/run-1 --watch

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__remove_command_help.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__remove_command_help.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/fastskill-cli/../../tests/cli/snapshot_helpers.rs
-assertion_line: 262
 expression: normalized
 ---
 Uninstall skills (removes from manifest and local installation)
@@ -21,3 +20,7 @@ Options:
   -V, --version                  Print version
 
 Syntax: remove <SKILL_ID>... [OPTIONS]
+
+Examples:
+  fastskill remove pptx
+  fastskill remove pptx docx --force

--- a/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__search_command_help.snap
+++ b/tests/cli/snapshots/cli_tests__cli__snapshot_helpers__search_command_help.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/fastskill-cli/../../tests/cli/snapshot_helpers.rs
-assertion_line: 262
 expression: normalized
 ---
 Search skills by query with explicit scope flags
@@ -28,3 +27,7 @@ Options:
   -V, --version                  Print version
 
 Syntax: search <QUERY> [--local|--remote] [OPTIONS]
+
+Examples:
+  fastskill search "pdf generation" --local
+  fastskill search "presentation builder" --remote --limit 5


### PR DESCRIPTION
**Follow-up to #232 — this is the half of that work that didn't make it in.**

#232 was merged while it still had only its first commit (`5bd7a09`, populating examples). The second commit — the cli-framework pin bump and the strict test assertion — was pushed afterwards and never merged. So `main` today has examples populated but the **old framework pin**, meaning they don't render in `--help`, and the **old tautological test**. This restores that commit on top of current `main`.

## What it does

**1. Bumps cli-framework `f6b77ae` → `42cb312`** (aroff/cli-framework#110), which maps `CommandSpec.examples` into the `--help` epilogue. Without this, the examples added in #232 are invisible to users — they only appear in `fastskill spec`.

Verified the aikit pins still match on both sides (`435a1132…`), per the warning in `Cargo.toml` about aikit compiling twice if they diverge.

**2. Makes `example_tests` actually verify something.** The old assertion:

```rust
result.stdout.contains("Examples:") || result.stdout.contains("fastskill ")
```

The fallback always matched the `Usage: fastskill ...` line, so **all ~23 tests passed unconditionally**. Now requires an `Examples:` section *and* a `fastskill …` invocation under it. Proven by emptying one command's examples and confirming failure — under the old assertion that same state passed.

**3. Three tests that structurally could not check examples:**

| Test | Why | Now |
|---|---|---|
| `root_help_shows_examples` | Root help comes from cli-framework's `HelpRenderer`, not `build_typed_clap_command` — no epilogue | → `root_help_lists_command_groups` |
| `repos_help_shows_examples` | `repos` is a *group*; `GroupMetadata` has only `summary`/`hidden`, no `examples` field exists for groups | → `repos_help_lists_subcommands` |
| `version_help_shows_examples` | **`version` is not a command** — absent from `spec`; `fastskill version --help` exits 0 only because the unknown token falls through to the `read <skill-id>` shorthand, so it asserted on `read`'s help | deleted (`--version` covered by `help_tests::test_version_flag`) |

## Result

```
Syntax: list [OPTIONS]

Examples:
  fastskill list
  fastskill list --details --format json
```

12 help snapshots gain an `Examples:` block — every diff verified purely additive (nothing removed; no added line other than blank, `Examples:`, or `fastskill …`).

## Verification

- Repo gate: **1155 tests, 1153 passing, 0 failing**
- CI parity (agent CLIs off `PATH`, coverage job's exact command): **1140 passed, 0 failed**
- Confirmed examples actually render from the rebuilt binary, not just that tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPWdJZDbVTzy3rBcgbP1E8