### PR TITLE
fix(zip): repair ZIP extraction on Windows (unblocks main's CI)

### DIFF
--- a/crates/fastskill-core/src/storage/zip.rs
+++ b/crates/fastskill-core/src/storage/zip.rs
@@ -159,13 +159,20 @@ impl ZipHandler {
                 )));
             }
 
-            // Build the output path using the normalized entry name
-            let outpath = dest_dir.join(&normalized_entry_name);
+            // Build the output path from the *canonical* destination, not from
+            // `dest_dir`: the containment check below compares against
+            // `dest_canonical`, and on Windows `canonicalize()` returns an
+            // extended-length path (`\\?\C:\...`) while `dest_dir` does not.
+            // Joining the raw form and comparing against the canonical one made
+            // every ordinary entry look like an escape, so no ZIP could be
+            // extracted on Windows at all.
+            let outpath = dest_canonical.join(&normalized_entry_name);
 
-            // Ensure the normalized path is within the destination directory before any I/O
-            let outpath_str = outpath.to_string_lossy().to_string();
-            let dest_str = dest_canonical.to_string_lossy().to_string();
-            if !outpath_str.starts_with(&dest_str) {
+            // Ensure the normalized path is within the destination directory
+            // before any I/O. Compare by path component rather than by string
+            // prefix -- a string prefix also treats `/dest-evil/x` as living
+            // inside `/dest`.
+            if !outpath.starts_with(&dest_canonical) {
                 return Err(ServiceError::Validation(format!(
                     "Path traversal attempt detected in ZIP entry: '{}' would resolve outside extraction directory",
                     entry_name


### PR DESCRIPTION
## Urgent: main's CI is currently red

PR #234 added a `windows-latest` job and was merged while that job was **failing** — the fix for what it found is in this PR. Until this lands, `PR Tests` fails on main and on every open PR.

## The bug it found

Every ZIP install fails on Windows with:

```
Path traversal attempt detected in ZIP entry: 'test-skill/SKILL.md'
would resolve outside extraction directory
```

…for an entirely ordinary entry. This affects **local `.zip` installs and the zip-url cache path**, so ZIP installs have never worked at all in the shipped `x86_64-pc-windows-msvc` binary.

## Root cause

In `storage/zip.rs`, the containment guard built the output path from `dest_dir` but compared it against `dest_canonical`:

```rust
let outpath = dest_dir.join(&normalized_entry_name);   // NOT canonical
let outpath_str = outpath.to_string_lossy().to_string();
let dest_str = dest_canonical.to_string_lossy().to_string();
if !outpath_str.starts_with(&dest_str) { /* reject */ }
```

On Linux those two are usually the same string, so it passes and nobody noticed. On Windows, `canonicalize()` returns an **extended-length path** (`\\?\C:\...`) while `dest_dir` does not — so no entry could ever match the prefix and everything was rejected.

## Fix

- Build the output path from `dest_canonical`, so both sides of the comparison are in the same form.
- Compare with `Path::starts_with` (component-wise) rather than a string prefix. The string form has a second latent flaw: it treats `/dest-evil/x` as living inside `/dest`. Not exploitable as written, since the path was always derived from `dest_dir`, but it's the wrong comparison for a security guard.

**Severity:** the guard was failing *closed*, so this was a functional break, not a vulnerability. No ZIP could be extracted rather than a malicious one being admitted.

## Verification

- All existing zip-slip / traversal rejection tests pass **unchanged** — the guard still rejects what it should (40/40 zip tests).
- Full Linux suite: **1141 passing**; 1154 under the full pre-push suite.
- Windows behaviour is verified by the `test-windows` job on this PR — which is exactly the job that caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmpE6bvMsDtWDjmUP9wfu
