### PR TITLE
test(install): open for write before touching mtime (unblocks Windows CI)

### DIFF
--- a/crates/fastskill-core/src/core/install.rs
+++ b/crates/fastskill-core/src/core/install.rs
@@ -2056,8 +2056,13 @@ mod tests {
 
         let before = compute_local_tree_hash(&src).unwrap();
 
-        // Touch the file's mtime only, content untouched.
-        let file = std::fs::File::open(src.join("nested/file.txt")).unwrap();
+        // Touch the file's mtime only, content untouched. Open for *write*:
+        // Windows refuses to set a file's modified time through a read-only
+        // handle ("Access is denied"), while unix is happy either way.
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(src.join("nested/file.txt"))
+            .unwrap();
         let new_time = std::time::SystemTime::now() + std::time::Duration::from_secs(3600);
         file.set_modified(new_time).unwrap();
 


### PR DESCRIPTION
## Why

Follows #234 (added the Windows job) and #236 (fixed the ZIP extraction bug that job found). This is the **last** failure standing between main and a green Windows job.

`test_tree_hash_stable_across_mtime_touch` opened the file with `File::open` (read-only) and then called `set_modified`. Windows refuses to set a file's modified time through a read-only handle, so it panicked with access denied there while passing everywhere else.

## Scope

**Test-only.** `compute_local_tree_hash` never reads mtime — which is precisely what this test asserts — so production behaviour was never in doubt on any platform. The fix opens the file with write access, which works identically on unix.

## Verification

- Linux: full suite green (1154 under the pre-push suite).
- Windows: verified by the `test-windows` job on this PR.

Note the previous Windows run got from 105 → 137 tests through after #236's ZIP fix, with this as the single remaining failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmpE6bvMsDtWDjmUP9wfu