### PR TITLE
test(project-config): TOML literal path + report all Windows failures per run [PLEASE WAIT FOR GREEN BEFORE MERGING]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - run: cargo install cargo-nextest --locked
-      - run: cargo nextest run -p fastskill-core --lib --retries 3
+      # --no-fail-fast: this job is still being brought up, and stopping at the
+      # first failure would surface only one platform issue per CI round-trip.
+      - run: cargo nextest run -p fastskill-core --lib --retries 3 --no-fail-fast
 
   test-all-features:
     name: Test (All Features)

--- a/crates/fastskill-core/src/core/project_config.rs
+++ b/crates/fastskill-core/src/core/project_config.rs
@@ -168,14 +168,17 @@ test-skill = "1.0.0"
         let temp_dir = TempDir::new().unwrap();
         let skills_path = temp_dir.path().join("skills");
 
-        // Create project-level skill-project.toml with absolute skills_directory
+        // Create project-level skill-project.toml with absolute skills_directory.
+        // Uses a TOML *literal* string (single quotes): a Windows path contains
+        // backslashes, which inside a basic string would be parsed as escape
+        // sequences (`\\U`, `\\A`, ...) and fail to parse.
         let content = format!(
             r#"
 [dependencies]
 test-skill = "1.0.0"
 
 [tool.fastskill]
-skills_directory = "{}"
+skills_directory = '{}'
         "#,
             skills_path.display()
         );

--- a/crates/fastskill-core/src/core/sources/mod.rs
+++ b/crates/fastskill-core/src/core/sources/mod.rs
@@ -47,7 +47,7 @@ pub enum SourcesError {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, TempDir};
 
     #[test]
     fn test_sources_config_parsing() {
@@ -75,8 +75,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_sources_manager() {
-        let temp_file = NamedTempFile::new().unwrap();
-        let config_path = temp_file.path().to_path_buf();
+        // A TempDir, not a NamedTempFile: the latter keeps the file open, and
+        // Windows refuses to rewrite a file another handle still holds, so
+        // `manager.save()` fails there with access denied. The config file
+        // does not need to exist up front.
+        let temp_dir = TempDir::new().unwrap();
+        let config_path = temp_dir.path().join("sources.toml");
 
         let mut manager = SourcesManager::new(config_path.clone());
 

--- a/crates/fastskill-core/src/security/path.rs
+++ b/crates/fastskill-core/src/security/path.rs
@@ -239,12 +239,16 @@ mod tests {
         // Validate path component and get the safe return value
         let safe_component = validate_path_component("valid-name").unwrap();
 
-        // Build path using the validated return value
-        let path = root.join(&safe_component);
+        // Canonicalize the root FIRST, then join, so both sides of the
+        // containment check are in the same form. `path` does not exist, so
+        // `path.canonicalize()` fails and falls back to the raw path; on
+        // Windows `root.canonicalize()` meanwhile returns an extended-length
+        // path (`\\?\C:\...`), and a raw path never starts with that.
+        let canonical_root = root.canonicalize().unwrap_or(root.to_path_buf());
+        let path = canonical_root.join(&safe_component);
 
         // Verify the path is safe and doesn't escape root
         let canonical_path = path.canonicalize().unwrap_or(path);
-        let canonical_root = root.canonicalize().unwrap_or(root.to_path_buf());
         assert!(canonical_path.starts_with(&canonical_root));
 
         // Verify the validated string doesn't contain dangerous characters


### PR DESCRIPTION
> **Please don't merge until the `Test (Windows, core unit tests)` check is green.** The three previous PRs in this chain (#234, #236, #237) were each merged at a commit that predated the follow-up fix already pushed to the same branch, which left main red each time and required another PR to chase it. This one is meant to end that chain.

## What

Two changes, both aimed at getting main's Windows job green.

**1. The current failure on main.** `test_load_project_config_success_absolute` interpolated a temp-dir path into a TOML *basic* string. On Windows that path contains backslashes, which a basic string parses as escape sequences (`\U`, `\A`, …) — so the document failed to parse and the test asserted on an `Err`. Switched to a TOML **literal** string, which does not process escapes.

This is test-only. Production never does this: project files are written with serde (`toml::to_string_pretty`, which escapes correctly), and the only hardcoded values are relative literals like `".claude/skills"`. I checked before assuming.

**2. Run the Windows job with `--no-fail-fast`.** This is the process fix. While the job is being brought up, stopping at the first failure reveals exactly **one** platform issue per ~10-minute CI round-trip — which is why this has taken four PRs. With `--no-fail-fast`, one run reports everything still broken.

## Chain so far

| PR | What Windows revealed |
|---|---|
| #234 | added the job — immediately failed |
| #236 | **real product bug**: ZIP extraction broken on Windows for every archive (canonical-path mismatch) |
| #237 | test bug: can't set mtime through a read-only handle on Windows |
| this | test bug: TOML basic string ate the backslashes |

Only #236 was a genuine defect in shipped code; the rest are tests making unix assumptions. Progress is real — the job got from 105 → 137 → 192 tests through as each landed.

## Honest status

I expect this to be green, but `--no-fail-fast` may surface further failures in the ~250 tests that have never yet run on Windows. If it does, they'll all appear in this one run rather than trickling out one per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmpE6bvMsDtWDjmUP9wfu