### PR TITLE
ci: extend Windows coverage to integration tests (Phase 2a) [WAIT FOR GREEN BEFORE MERGING]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       - run: cargo install cargo-nextest --locked
       - run: cargo nextest run --retries 3 --fail-fast -E 'not test(install_e2e_tests)'
 
-  # Windows unit-test coverage (Phase 1).
+  # Windows unit + integration test coverage (Phase 2a).
   #
   # release.yml ships an x86_64-pc-windows-msvc binary, but every other job
   # here is ubuntu-only, so Windows-specific code has never executed anywhere.
@@ -55,12 +55,20 @@ jobs:
   # open) has never even been compiled -- it cannot be built from Linux
   # because `ring` and `onig_sys` need MSVC tooling to cross-compile.
   #
-  # Scope is deliberately the fastskill-core library unit tests, with default
-  # features. The integration tests under crates/fastskill-core/tests/ are
-  # NOT included: they spin up a real `git daemon`, and one of them finds the
-  # daemon's child via /proc, which is Linux-only. Porting those is Phase 2.
+  # Scope is the fastskill-core library unit tests (Phase 1) plus the
+  # integration tests under crates/fastskill-core/tests/, with default
+  # features. Excluded are the three integration-test binaries that spin up
+  # a real `git daemon`. Their fixture is unported rather than known-broken:
+  # it kills the daemon by finding its child process through
+  # /proc/<pid>/task/<pid>/children, which does not exist on Windows. (Git
+  # for Windows does ship git-daemon, so these may well work once the
+  # fixture uses a portable process-tree kill.) The three files are:
+  #   - git_content_cache_test
+  #   - offline_verification_sweep_test
+  #   - repo_index_refresh_git_test
+  # Porting those is Phase 2b.
   test-windows:
-    name: Test (Windows, core unit tests)
+    name: Test (Windows, core unit + integration tests)
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +76,7 @@ jobs:
       - run: cargo install cargo-nextest --locked
       # --no-fail-fast: this job is still being brought up, and stopping at the
       # first failure would surface only one platform issue per CI round-trip.
-      - run: cargo nextest run -p fastskill-core --lib --retries 3 --no-fail-fast
+      - run: cargo nextest run -p fastskill-core --lib --test '*' --retries 3 --no-fail-fast -E 'not binary(git_content_cache_test) and not binary(offline_verification_sweep_test) and not binary(repo_index_refresh_git_test)'
 
   test-all-features:
     name: Test (All Features)

--- a/crates/fastskill-core/src/core/registry_index.rs
+++ b/crates/fastskill-core/src/core/registry_index.rs
@@ -353,7 +353,13 @@ pub async fn scan_registry_index(
 
         // Try to determine skill_id from path
         // Path format: {registry_path}/{scope}/{name}
-        let relative_path = path.strip_prefix(registry_path).map_err(|e| {
+        //
+        // Strip the *canonical* root, which is what WalkDir actually walked.
+        // Stripping `registry_path` instead only works when the two forms
+        // coincide: on Windows `canonicalize()` yields an extended-length path
+        // (`\\?\C:\...`), so every entry failed to strip and the whole scan
+        // returned Err -- registry listing was broken outright there.
+        let relative_path = path.strip_prefix(&canonical_registry).map_err(|e| {
             ServiceError::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 format!("Failed to strip prefix: {}", e),

--- a/crates/fastskill-core/tests/http_handler_route_tests.rs
+++ b/crates/fastskill-core/tests/http_handler_route_tests.rs
@@ -140,8 +140,11 @@ async fn fixture_for_install(enable_write: bool) -> Fixture {
     let project_file_path = project.path().join("skill-project.toml");
     fs::write(
         &project_file_path,
+        // TOML *literal* string (single quotes): a Windows path contains
+        // backslashes, which inside a basic string ("...") would be parsed
+        // as escape sequences and fail to parse.
         format!(
-            "[tool.fastskill]\nskills_directory = \"{}\"\n\n[dependencies]\n",
+            "[tool.fastskill]\nskills_directory = '{}'\n\n[dependencies]\n",
             store.display()
         ),
     )
@@ -662,8 +665,11 @@ async fn update_version_pin_happy_path_repository_origin() {
     let project_file_path = project.path().join("skill-project.toml");
     fs::write(
         &project_file_path,
+        // TOML literal string (single quotes) for the path: a Windows path
+        // contains backslashes, which a basic string ("...") would parse as
+        // escape sequences and fail to parse.
         format!(
-            "[tool.fastskill]\nskills_directory = \"{}\"\n\n[dependencies]\n\
+            "[tool.fastskill]\nskills_directory = '{}'\n\n[dependencies]\n\
              widget = {{ origin = {{ type = \"repository\", repo = \"myreg\", skill = \"widget\" }} }}\n",
             store.display()
         ),
@@ -1197,7 +1203,10 @@ async fn registry_skill_versions_unknown_id_is_empty_not_404() {
     fs::write(
         &f.project_file_path,
         format!(
-            "[dependencies]\n\n[[tool.fastskill.repositories]]\nname = \"localrepo\"\ntype = \"local\"\npath = \"{}\"\npriority = 0\n",
+            // TOML literal string (single quotes) for the path: a Windows
+            // path contains backslashes, which a basic string ("...") would
+            // parse as escape sequences and fail to parse.
+            "[dependencies]\n\n[[tool.fastskill.repositories]]\nname = \"localrepo\"\ntype = \"local\"\npath = '{}'\npriority = 0\n",
             repo_dir.path().display()
         ),
     )
@@ -1227,7 +1236,10 @@ async fn registry_skill_versions_populated_and_sorted_descending() {
     fs::write(
         &f.project_file_path,
         format!(
-            "[dependencies]\n\n[[tool.fastskill.repositories]]\nname = \"localrepo\"\ntype = \"local\"\npath = \"{}\"\npriority = 0\n",
+            // TOML literal string (single quotes) for the path: a Windows
+            // path contains backslashes, which a basic string ("...") would
+            // parse as escape sequences and fail to parse.
+            "[dependencies]\n\n[[tool.fastskill.repositories]]\nname = \"localrepo\"\ntype = \"local\"\npath = '{}'\npriority = 0\n",
             repo_dir.path().display()
         ),
     )


### PR DESCRIPTION
> **Please wait for `Test (Windows, core unit + integration tests)` to go green before merging.** Earlier PRs in this chain were merged at a commit that predated the fix already pushed to the branch, which left main red each time.

## What

The Windows job currently runs only fastskill-core's **library unit** tests (446). This widens it to the integration tests as well — **646 tests**, a 45% increase in Windows coverage — by adding `--test '*'` and excluding only the three binaries that spin up a real `git daemon`.

## Why those three are excluded

Not because they're known broken on Windows — because their fixture is **unported**. It kills the daemon by finding its child process through `/proc/<pid>/task/<pid>/children`, which doesn't exist on Windows. Git for Windows *does* ship `git-daemon`, so they may well work once that fixture uses a portable process-tree kill (`taskkill /F /T /PID` on Windows).

That's Phase 2b. The fixture is currently **triplicated** across the three files, so it wants extracting into a shared test module and porting once rather than three times.

## Also fixed

Four more instances of a bug already fixed today in `project_config.rs`: interpolating a temp-dir path into a TOML **basic** string. Windows paths contain backslashes, which a basic string parses as escape sequences (`\U`, `\T`, …), so the document fails to parse and the test errors out *before* reaching the behaviour it means to exercise. All four are in `http_handler_route_tests.rs` and are now TOML **literal** strings.

This is the same defect class that has now appeared in five places across the suite — worth remembering as a review rule: **never interpolate a path into a TOML basic string.**

## Not done

- **No test is gated or weakened.** `#[cfg(unix)]` was deliberately avoided; it's only legitimate when the thing under test is genuinely unix-only.
- No existing ubuntu job is modified.

## Verification

- Linux, exact CI command: **646 passed**.
- Linux, full suite: **1140 passed**, unchanged (1153 under the pre-push suite).
- Windows behaviour is verified by this PR's own job — it cannot be checked locally, since `ring` and `onig_sys` need MSVC tooling to cross-compile.

The audit beyond the four TOML sites was static inspection: real signal, but not equivalent to a green run. `--no-fail-fast` is retained so this run reports **every** remaining failure at once rather than one per CI round-trip.