### PR TITLE
ci: run the git-daemon integration tests on Windows too (Phase 2b) [WAIT FOR GREEN]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       - run: cargo install cargo-nextest --locked
       - run: cargo nextest run --retries 3 --fail-fast -E 'not test(install_e2e_tests)'
 
-  # Windows unit + integration test coverage (Phase 2a).
+  # Windows unit + integration test coverage (Phase 2a + 2b).
   #
   # release.yml ships an x86_64-pc-windows-msvc binary, but every other job
   # here is ubuntu-only, so Windows-specific code has never executed anywhere.
@@ -55,18 +55,15 @@ jobs:
   # open) has never even been compiled -- it cannot be built from Linux
   # because `ring` and `onig_sys` need MSVC tooling to cross-compile.
   #
-  # Scope is the fastskill-core library unit tests (Phase 1) plus the
-  # integration tests under crates/fastskill-core/tests/, with default
-  # features. Excluded are the three integration-test binaries that spin up
-  # a real `git daemon`. Their fixture is unported rather than known-broken:
-  # it kills the daemon by finding its child process through
-  # /proc/<pid>/task/<pid>/children, which does not exist on Windows. (Git
-  # for Windows does ship git-daemon, so these may well work once the
-  # fixture uses a portable process-tree kill.) The three files are:
-  #   - git_content_cache_test
-  #   - offline_verification_sweep_test
-  #   - repo_index_refresh_git_test
-  # Porting those is Phase 2b.
+  # Scope is the fastskill-core library unit tests plus every integration
+  # test under crates/fastskill-core/tests/, with default features -- the
+  # same real `git daemon` fixture (tests/common/mod.rs) that ubuntu uses,
+  # including the three binaries that spin one up
+  # (git_content_cache_test, offline_verification_sweep_test,
+  # repo_index_refresh_git_test). Their only prior Windows blocker was
+  # killing the daemon's process tree via /proc/<pid>/task/<pid>/children,
+  # which does not exist on Windows; the fixture now uses `taskkill /F /T`
+  # there instead (Phase 2b).
   test-windows:
     name: Test (Windows, core unit + integration tests)
     runs-on: windows-latest
@@ -76,7 +73,7 @@ jobs:
       - run: cargo install cargo-nextest --locked
       # --no-fail-fast: this job is still being brought up, and stopping at the
       # first failure would surface only one platform issue per CI round-trip.
-      - run: cargo nextest run -p fastskill-core --lib --test '*' --retries 3 --no-fail-fast -E 'not binary(git_content_cache_test) and not binary(offline_verification_sweep_test) and not binary(repo_index_refresh_git_test)'
+      - run: cargo nextest run -p fastskill-core --lib --test '*' --retries 3 --no-fail-fast
 
   test-all-features:
     name: Test (All Features)

--- a/crates/fastskill-core/src/storage/git.rs
+++ b/crates/fastskill-core/src/storage/git.rs
@@ -220,6 +220,16 @@ pub(crate) fn build_clone_args<'a>(
         "protocol.ext.allow=never",
         "-c",
         "protocol.file.allow=never",
+        // Check out exactly what the repository contains. Git for Windows
+        // defaults `core.autocrlf=true`, which rewrites LF to CRLF on
+        // checkout -- so the same skill installed on Windows would differ
+        // byte-for-byte from the published source, and from the same skill
+        // installed on that machine from a zip. A package manager should
+        // deliver the artifact as published, so opt out of the conversion.
+        "-c",
+        "core.autocrlf=false",
+        "-c",
+        "core.eol=lf",
         "clone",
         "--depth=1",
         "--quiet",
@@ -782,6 +792,23 @@ pub fn validate_cloned_skill(cloned_path: &Path) -> Result<PathBuf, ServiceError
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_build_clone_args_disables_line_ending_translation() {
+        // Git for Windows defaults core.autocrlf=true, which would rewrite LF
+        // to CRLF on checkout and make an installed skill differ from the
+        // published source (and from the same skill installed from a zip).
+        let args = build_clone_args("https://example.com/r.git", "/dest", None, None);
+        assert!(args.windows(2).any(|w| w == ["-c", "core.autocrlf=false"]));
+        assert!(args.windows(2).any(|w| w == ["-c", "core.eol=lf"]));
+        // Config must precede the subcommand or git rejects it.
+        let clone_at = args.iter().position(|a| *a == "clone").unwrap();
+        let autocrlf_at = args
+            .iter()
+            .position(|a| *a == "core.autocrlf=false")
+            .unwrap();
+        assert!(autocrlf_at < clone_at);
+    }
 
     #[test]
     fn test_build_clone_args_includes_protocol_flags_and_end_of_options() {

--- a/crates/fastskill-core/tests/common/mod.rs
+++ b/crates/fastskill-core/tests/common/mod.rs
@@ -1,0 +1,272 @@
+//! Shared fixture for the `git daemon` integration tests
+//! (`git_content_cache_test.rs`, `offline_verification_sweep_test.rs`,
+//! `repo_index_refresh_git_test.rs`). All three spin up a real `git daemon`
+//! serving bare repos over `git://127.0.0.1` on a loopback port -- this is
+//! not "the network": no DNS, no external host, nothing that can be flaky in
+//! CI -- it is the only way to exercise the real `ls_remote`/`clone_repository`
+//! code paths without a local filesystem path, which SEC-11 refuses outright
+//! (`protocol.file.allow=never`; see `storage::git::build_clone_args`).
+//!
+//! `tests/common/mod.rs` (rather than `tests/common.rs`) is the idiomatic way
+//! to share code between Rust integration-test binaries: `mod.rs` files are
+//! never themselves collected as a `[[test]]` target by cargo/nextest, only
+//! pulled in via `mod common;` in each binary that needs it. Because each
+//! test binary compiles this module separately and uses only a subset of it,
+//! `#![allow(dead_code)]` below is expected and correct, not a code smell.
+
+#![allow(dead_code)]
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::net::{TcpListener, TcpStream};
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+/// A local `git daemon` exporting every repo under its base path (no
+/// `git-daemon-export-ok` marker required), bound to an OS-assigned loopback
+/// port. Killed on drop.
+pub struct GitDaemonFixture {
+    child: Child,
+    port: u16,
+    _base: TempDir,
+}
+
+impl GitDaemonFixture {
+    pub fn start(base: TempDir) -> Self {
+        // `free_loopback_port` can only *suggest* a port: it binds :0, reads the
+        // number, then drops the listener so `git daemon` can take it. Under a
+        // parallel test run another process can win that gap, and the daemon
+        // then dies immediately with "address already in use". Retry on a fresh
+        // port instead of failing the test for an unlucky race.
+        const MAX_ATTEMPTS: u32 = 10;
+        for attempt in 1..=MAX_ATTEMPTS {
+            let port = free_loopback_port();
+            let mut child = git_command()
+                .args([
+                    "daemon",
+                    "--reuseaddr",
+                    "--export-all",
+                    "--listen=127.0.0.1",
+                    &format!("--port={port}"),
+                    &format!("--base-path={}", base.path().display()),
+                ])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("failed to start `git daemon`; is git installed with daemon support?");
+
+            if wait_for_port(port, &mut child) {
+                return Self {
+                    child,
+                    port,
+                    _base: base,
+                };
+            }
+
+            // Did not come up: reap this attempt before trying another port.
+            let _ = child.kill();
+            let _ = child.wait();
+            assert!(
+                attempt < MAX_ATTEMPTS,
+                "git daemon failed to start listening after {MAX_ATTEMPTS} attempts"
+            );
+        }
+        unreachable!("loop either returns or asserts on the final attempt")
+    }
+
+    pub fn repo_url(&self, repo_name: &str) -> String {
+        format!("git://127.0.0.1:{}/{repo_name}", self.port)
+    }
+
+    /// Kill the daemon and wait for the port to actually stop accepting
+    /// connections. This is the "network egress made to fail" step some
+    /// tests need (proving a subsequent install can only be served from
+    /// cache): deterministic (polls a local condition, no sleep-and-hope)
+    /// and fast, with no reliance on the test environment actually lacking
+    /// internet access.
+    ///
+    /// Portable process-tree kill, because a plain `child.kill()` is not
+    /// enough to prove the port is dead on every platform:
+    /// - Linux: `git daemon` re-execs into a child `git-daemon` process that
+    ///   is what actually holds the listening socket, separate from the pid
+    ///   `spawn` hands back. We enumerate descendants via
+    ///   `/proc/<pid>/task/<pid>/children` and `kill -9` each by exact pid,
+    ///   rather than a process-group-wide signal -- this test process was not
+    ///   itself given a fresh process group, so a group-wide signal risks
+    ///   hitting far more than the daemon it is scoped to.
+    /// - Windows: there is no `/proc` and no `fork()`, so there is no
+    ///   equivalent descendant-enumeration step to port. `taskkill /F /T /PID`
+    ///   kills the whole process tree rooted at the spawned pid in one shot,
+    ///   which covers both "daemon runs in-process" and "daemon spawned a
+    ///   child" without needing to know which.
+    /// - Other Unix (e.g. macOS, not exercised in this repo's CI): fall back
+    ///   to a plain `child.kill()`.
+    ///
+    /// A failed kill must never hang the suite: reaping the child below is
+    /// bounded rather than a blocking `wait()`, and the port-poll after it
+    /// has its own deadline and panics with a clear message instead of
+    /// spinning forever.
+    pub fn kill_and_wait(mut self) {
+        #[cfg(target_os = "linux")]
+        {
+            let mut victims = descendant_pids(self.child.id());
+            victims.push(self.child.id());
+            for pid in victims {
+                let _ = Command::new("kill").args(["-9", &pid.to_string()]).status();
+            }
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // `/F` force-kills, `/T` kills the tree rooted at `/PID`. Ignore
+            // the exit status: taskkill fails if the process already exited,
+            // which is not an error for us -- the port-poll below is what
+            // actually proves the daemon is gone.
+            let _ = Command::new("taskkill")
+                .args(["/F", "/T", "/PID", &self.child.id().to_string()])
+                .status();
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        {
+            let _ = self.child.kill();
+        }
+
+        reap_bounded(&mut self.child, Duration::from_secs(5));
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while TcpStream::connect(("127.0.0.1", self.port)).is_ok() {
+            if Instant::now() >= deadline {
+                panic!(
+                    "git daemon on port {} did not stop accepting connections",
+                    self.port
+                );
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+/// Every descendant pid of `pid` (children, grandchildren, ...), read from
+/// procfs. Linux-only; `kill_and_wait` is the only caller and falls back to
+/// a portable kill on every other platform.
+#[cfg(target_os = "linux")]
+fn descendant_pids(pid: u32) -> Vec<u32> {
+    let mut result = Vec::new();
+    let mut frontier = vec![pid];
+    while let Some(p) = frontier.pop() {
+        let children_path = format!("/proc/{p}/task/{p}/children");
+        if let Ok(contents) = std::fs::read_to_string(&children_path) {
+            for token in contents.split_whitespace() {
+                if let Ok(child) = token.parse::<u32>() {
+                    result.push(child);
+                    frontier.push(child);
+                }
+            }
+        }
+    }
+    result
+}
+
+/// Reap `child` with a bound rather than a blocking `wait()`: if a kill
+/// attempt somehow failed to land, a blocking wait would hang this test --
+/// and therefore the whole suite -- instead of failing it loudly. Giving up
+/// after the deadline is safe: `Drop`/`kill_and_wait`'s callers only rely on
+/// this to avoid leaking a zombie, never on it actually completing before
+/// they move on.
+fn reap_bounded(child: &mut Child, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) | Err(_) => return,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
+    }
+}
+
+impl Drop for GitDaemonFixture {
+    fn drop(&mut self) {
+        #[cfg(target_os = "windows")]
+        {
+            let _ = Command::new("taskkill")
+                .args(["/F", "/T", "/PID", &self.child.id().to_string()])
+                .status();
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            let _ = self.child.kill();
+        }
+        reap_bounded(&mut self.child, Duration::from_secs(2));
+    }
+}
+
+/// `git` exports these to its own subprocesses (hooks, `rebase --exec`) to pin
+/// them to the invoking repository. A test run *from* such a context — most
+/// obviously this repo's own `pre-push` hook — would otherwise inherit them,
+/// and every `git` below would retarget the real repo instead of the scratch
+/// one, firing the real hooks. Always spawn git through this.
+pub fn git_command() -> Command {
+    let mut cmd = Command::new("git");
+    for var in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_COMMON_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_PREFIX",
+        "GIT_NAMESPACE",
+        "GIT_CEILING_DIRECTORIES",
+    ] {
+        cmd.env_remove(var);
+    }
+    cmd
+}
+
+pub fn free_loopback_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind ephemeral port");
+    listener
+        .local_addr()
+        .expect("failed to read local addr")
+        .port()
+}
+
+/// Poll until `port` accepts connections. Returns `false` (rather than
+/// panicking) if the daemon exits first or the deadline passes, so the caller
+/// can retry on a different port.
+pub fn wait_for_port(port: u16, child: &mut Child) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return true;
+        }
+        // A daemon that already exited is never going to listen -- fail this
+        // attempt immediately instead of burning the whole deadline.
+        if matches!(child.try_wait(), Ok(Some(_))) {
+            return false;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Run a git command in `dir`, panicking with stderr on failure.
+pub fn run_git(dir: &Path, args: &[&str]) {
+    let output = git_command()
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to execute `git {}`: {e}", args.join(" ")));
+    assert!(
+        output.status.success(),
+        "`git {}` failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/fastskill-core/tests/git_content_cache_test.rs
+++ b/crates/fastskill-core/tests/git_content_cache_test.rs
@@ -14,153 +14,26 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
+mod common;
+
+use common::{git_command, run_git, GitDaemonFixture};
 use fastskill_core::core::cache::{CacheIdentity, GitResolutions, SkillCache};
 use fastskill_core::core::{AddMode, GitRef, Origin};
 use fastskill_core::storage::git::CLONE_INVOCATIONS;
 use fastskill_core::test_utils::{DirGuard, DIR_MUTEX};
 use fastskill_core::{FastSkillService, ServiceConfig};
-use std::net::{TcpListener, TcpStream};
 use std::path::Path;
-use std::process::{Child, Command, Stdio};
 use std::sync::atomic::Ordering;
-use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 const VALID_SKILL_MD: &str =
     "---\nname: cached-git-skill\nversion: \"1.0.0\"\ndescription: A test skill\n---\nBody\n";
 
 // ── git daemon fixture ──────────────────────────────────────────────────────
-
-/// A local `git daemon` exporting every repo under its base path (no
-/// `git-daemon-export-ok` marker required), bound to an OS-assigned loopback
-/// port. Killed on drop.
-struct GitDaemonFixture {
-    child: Child,
-    port: u16,
-    _base: TempDir,
-}
-
-impl GitDaemonFixture {
-    fn start(base: TempDir) -> Self {
-        // `free_loopback_port` can only *suggest* a port: it binds :0, reads the
-        // number, then drops the listener so `git daemon` can take it. Under a
-        // parallel test run another process can win that gap, and the daemon
-        // then dies immediately with "address already in use". Retry on a fresh
-        // port instead of failing the test for an unlucky race.
-        const MAX_ATTEMPTS: u32 = 10;
-        for attempt in 1..=MAX_ATTEMPTS {
-            let port = free_loopback_port();
-            let mut child = git_command()
-                .args([
-                    "daemon",
-                    "--reuseaddr",
-                    "--export-all",
-                    "--listen=127.0.0.1",
-                    &format!("--port={port}"),
-                    &format!("--base-path={}", base.path().display()),
-                ])
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .spawn()
-                .expect("failed to start `git daemon`; is git installed with daemon support?");
-
-            if wait_for_port(port, &mut child) {
-                return Self {
-                    child,
-                    port,
-                    _base: base,
-                };
-            }
-
-            // Did not come up: reap this attempt before trying another port.
-            let _ = child.kill();
-            let _ = child.wait();
-            assert!(
-                attempt < MAX_ATTEMPTS,
-                "git daemon failed to start listening after {MAX_ATTEMPTS} attempts"
-            );
-        }
-        unreachable!("loop either returns or asserts on the final attempt")
-    }
-
-    fn repo_url(&self, repo_name: &str) -> String {
-        format!("git://127.0.0.1:{}/{repo_name}", self.port)
-    }
-}
-
-impl Drop for GitDaemonFixture {
-    fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-    }
-}
-
-/// `git` exports these to its own subprocesses (hooks, `rebase --exec`) to pin
-/// them to the invoking repository. A test run *from* such a context — most
-/// obviously this repo's own `pre-push` hook — would otherwise inherit them,
-/// and every `git` below would retarget the real repo instead of the scratch
-/// one, firing the real hooks. Always spawn git through this.
-fn git_command() -> Command {
-    let mut cmd = Command::new("git");
-    for var in [
-        "GIT_DIR",
-        "GIT_WORK_TREE",
-        "GIT_COMMON_DIR",
-        "GIT_INDEX_FILE",
-        "GIT_OBJECT_DIRECTORY",
-        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-        "GIT_PREFIX",
-        "GIT_NAMESPACE",
-        "GIT_CEILING_DIRECTORIES",
-    ] {
-        cmd.env_remove(var);
-    }
-    cmd
-}
-
-fn free_loopback_port() -> u16 {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind ephemeral port");
-    listener
-        .local_addr()
-        .expect("failed to read local addr")
-        .port()
-}
-
-/// Poll until `port` accepts connections. Returns `false` (rather than
-/// panicking) if the daemon exits first or the deadline passes, so the caller
-/// can retry on a different port.
-fn wait_for_port(port: u16, child: &mut Child) -> bool {
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
-            return true;
-        }
-        // A daemon that already exited is never going to listen -- fail this
-        // attempt immediately instead of burning the whole deadline.
-        if matches!(child.try_wait(), Ok(Some(_))) {
-            return false;
-        }
-        if Instant::now() >= deadline {
-            return false;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-}
-
-/// Run a git command in `dir`, panicking with stderr on failure.
-fn run_git(dir: &Path, args: &[&str]) {
-    let output = git_command()
-        .args(args)
-        .current_dir(dir)
-        .output()
-        .unwrap_or_else(|e| panic!("failed to execute `git {}`: {e}", args.join(" ")));
-    assert!(
-        output.status.success(),
-        "`git {}` failed: {}",
-        args.join(" "),
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
+//
+// `GitDaemonFixture` and its supporting helpers live in `tests/common/mod.rs`,
+// shared with `offline_verification_sweep_test.rs` and
+// `repo_index_refresh_git_test.rs`.
 
 /// Seed a bare repo at `base/<repo_name>.git` with a single commit containing
 /// `SKILL.md` on `branch`. Returns the seeded commit's SHA.

--- a/crates/fastskill-core/tests/offline_verification_sweep_test.rs
+++ b/crates/fastskill-core/tests/offline_verification_sweep_test.rs
@@ -28,6 +28,9 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
+mod common;
+
+use common::{git_command, run_git, GitDaemonFixture};
 use fastskill_core::core::install::LOCAL_COPY_INVOCATIONS;
 use fastskill_core::core::registry::client::{IndexEntry, DOWNLOAD_INVOCATIONS};
 use fastskill_core::core::repository::{
@@ -37,12 +40,9 @@ use fastskill_core::core::version::VersionConstraint;
 use fastskill_core::core::{AddMode, GitRef, Origin};
 use fastskill_core::storage::git::CLONE_INVOCATIONS;
 use fastskill_core::{FastSkillService, ServiceConfig};
-use std::net::{TcpListener, TcpStream};
 use std::path::Path;
-use std::process::{Child, Command, Stdio};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 use tempfile::TempDir;
 use wiremock::matchers::{method, path as wm_path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -54,196 +54,12 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 const UNREACHABLE_GIT_URL: &str = "git://127.0.0.1:1/does-not-exist.git";
 const UNREACHABLE_INDEX_URL: &str = "http://127.0.0.1:1/index";
 
-// ── shared fixtures (mirror git_content_cache_test.rs / registry_content_cache_test.rs) ──
-
-struct GitDaemonFixture {
-    child: Child,
-    port: u16,
-    _base: TempDir,
-}
-
-impl GitDaemonFixture {
-    fn start(base: TempDir) -> Self {
-        // `free_loopback_port` can only *suggest* a port: it binds :0, reads the
-        // number, then drops the listener so `git daemon` can take it. Under a
-        // parallel test run another process can win that gap, and the daemon
-        // then dies immediately with "address already in use". Retry on a fresh
-        // port instead of failing the test for an unlucky race.
-        const MAX_ATTEMPTS: u32 = 10;
-        for attempt in 1..=MAX_ATTEMPTS {
-            let port = free_loopback_port();
-            let mut child = git_command()
-                .args([
-                    "daemon",
-                    "--reuseaddr",
-                    "--export-all",
-                    "--listen=127.0.0.1",
-                    &format!("--port={port}"),
-                    &format!("--base-path={}", base.path().display()),
-                ])
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .spawn()
-                .expect("failed to start `git daemon`; is git installed with daemon support?");
-
-            if wait_for_port(port, &mut child) {
-                return Self {
-                    child,
-                    port,
-                    _base: base,
-                };
-            }
-
-            // Did not come up: reap this attempt before trying another port.
-            let _ = child.kill();
-            let _ = child.wait();
-            assert!(
-                attempt < MAX_ATTEMPTS,
-                "git daemon failed to start listening after {MAX_ATTEMPTS} attempts"
-            );
-        }
-        unreachable!("loop either returns or asserts on the final attempt")
-    }
-
-    fn repo_url(&self, repo_name: &str) -> String {
-        format!("git://127.0.0.1:{}/{repo_name}", self.port)
-    }
-
-    /// Kill the daemon -- including the `git-daemon` child it re-execs into,
-    /// which is what actually holds the listening socket, separate from the
-    /// pid `spawn` hands back (plain `child.kill()`, as every other fixture
-    /// in this repo uses, leaves that child running and the port still
-    /// accepting connections) -- and wait for the port to actually stop
-    /// accepting connections. This is the "network egress made to fail"
-    /// step for the git scenario: deterministic (polls a local condition,
-    /// no sleep-and-hope) and fast, with no reliance on the test
-    /// environment actually lacking internet access.
-    ///
-    /// Deliberately kills each descendant PID individually by exact number
-    /// (via `/proc/<pid>/task/<pid>/children`, Linux-only) rather than a
-    /// process-group-wide `kill -9 -PID`: this test process was not itself
-    /// given a fresh process group, so a group-wide signal risks hitting
-    /// far more than the daemon it is scoped to.
-    fn kill_and_wait(mut self) {
-        #[cfg(target_os = "linux")]
-        {
-            let mut victims = descendant_pids(self.child.id());
-            victims.push(self.child.id());
-            for pid in victims {
-                let _ = Command::new("kill").args(["-9", &pid.to_string()]).status();
-            }
-        }
-        #[cfg(not(target_os = "linux"))]
-        {
-            let _ = self.child.kill();
-        }
-        let _ = self.child.wait();
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while TcpStream::connect(("127.0.0.1", self.port)).is_ok() {
-            if Instant::now() >= deadline {
-                panic!(
-                    "git daemon on port {} did not stop accepting connections",
-                    self.port
-                );
-            }
-            std::thread::sleep(Duration::from_millis(20));
-        }
-    }
-}
-
-/// Every descendant pid of `pid` (children, grandchildren, ...), read from
-/// procfs. Linux-only; `kill_and_wait`'s only caller falls back to a plain
-/// `child.kill()` everywhere else.
-#[cfg(target_os = "linux")]
-fn descendant_pids(pid: u32) -> Vec<u32> {
-    let mut result = Vec::new();
-    let mut frontier = vec![pid];
-    while let Some(p) = frontier.pop() {
-        let children_path = format!("/proc/{p}/task/{p}/children");
-        if let Ok(contents) = std::fs::read_to_string(&children_path) {
-            for token in contents.split_whitespace() {
-                if let Ok(child) = token.parse::<u32>() {
-                    result.push(child);
-                    frontier.push(child);
-                }
-            }
-        }
-    }
-    result
-}
-
-impl Drop for GitDaemonFixture {
-    fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-    }
-}
-
-/// `git` exports these to its own subprocesses (hooks, `rebase --exec`) to pin
-/// them to the invoking repository. A test run *from* such a context — most
-/// obviously this repo's own `pre-push` hook — would otherwise inherit them,
-/// and every `git` below would retarget the real repo instead of the scratch
-/// one, firing the real hooks. Always spawn git through this.
-fn git_command() -> Command {
-    let mut cmd = Command::new("git");
-    for var in [
-        "GIT_DIR",
-        "GIT_WORK_TREE",
-        "GIT_COMMON_DIR",
-        "GIT_INDEX_FILE",
-        "GIT_OBJECT_DIRECTORY",
-        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-        "GIT_PREFIX",
-        "GIT_NAMESPACE",
-        "GIT_CEILING_DIRECTORIES",
-    ] {
-        cmd.env_remove(var);
-    }
-    cmd
-}
-
-fn free_loopback_port() -> u16 {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind ephemeral port");
-    listener
-        .local_addr()
-        .expect("failed to read local addr")
-        .port()
-}
-
-/// Poll until `port` accepts connections. Returns `false` (rather than
-/// panicking) if the daemon exits first or the deadline passes, so the caller
-/// can retry on a different port.
-fn wait_for_port(port: u16, child: &mut Child) -> bool {
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
-            return true;
-        }
-        // A daemon that already exited is never going to listen -- fail this
-        // attempt immediately instead of burning the whole deadline.
-        if matches!(child.try_wait(), Ok(Some(_))) {
-            return false;
-        }
-        if Instant::now() >= deadline {
-            return false;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-}
-
-fn run_git(dir: &Path, args: &[&str]) {
-    let output = git_command()
-        .args(args)
-        .current_dir(dir)
-        .output()
-        .unwrap_or_else(|e| panic!("failed to execute `git {}`: {e}", args.join(" ")));
-    assert!(
-        output.status.success(),
-        "`git {}` failed: {}",
-        args.join(" "),
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
+// ── shared fixtures ──────────────────────────────────────────────────────
+//
+// `GitDaemonFixture` (incl. `kill_and_wait`, used below to prove the daemon
+// is genuinely dead before the offline re-run) and its supporting helpers
+// live in `tests/common/mod.rs`, shared with `git_content_cache_test.rs` and
+// `repo_index_refresh_git_test.rs`.
 
 const GIT_SKILL_MD: &str =
     "---\nname: offline-git-skill\nversion: \"1.0.0\"\ndescription: A test skill\n---\nBody\n";

--- a/crates/fastskill-core/tests/repo_index_refresh_git_test.rs
+++ b/crates/fastskill-core/tests/repo_index_refresh_git_test.rs
@@ -11,147 +11,23 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
+mod common;
+
+use common::{git_command, run_git, GitDaemonFixture};
 use fastskill_core::core::cache::SkillCache;
 use fastskill_core::core::repository::{
     RepositoryConfig, RepositoryDefinition, RepositoryManager, RepositoryType,
 };
-use std::net::{TcpListener, TcpStream};
 use std::path::Path;
-use std::process::{Child, Command, Stdio};
-use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 const SKILL_MD: &str =
     "---\nname: repo-skill\nversion: \"1.0.0\"\ndescription: A test skill\n---\nBody\n";
 
-// ── git daemon fixture (mirrors git_content_cache_test.rs) ─────────────────
-
-struct GitDaemonFixture {
-    child: Child,
-    port: u16,
-    _base: TempDir,
-}
-
-impl GitDaemonFixture {
-    fn start(base: TempDir) -> Self {
-        // `free_loopback_port` can only *suggest* a port: it binds :0, reads the
-        // number, then drops the listener so `git daemon` can take it. Under a
-        // parallel test run another process can win that gap, and the daemon
-        // then dies immediately with "address already in use". Retry on a fresh
-        // port instead of failing the test for an unlucky race.
-        const MAX_ATTEMPTS: u32 = 10;
-        for attempt in 1..=MAX_ATTEMPTS {
-            let port = free_loopback_port();
-            let mut child = git_command()
-                .args([
-                    "daemon",
-                    "--reuseaddr",
-                    "--export-all",
-                    "--listen=127.0.0.1",
-                    &format!("--port={port}"),
-                    &format!("--base-path={}", base.path().display()),
-                ])
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .spawn()
-                .expect("failed to start `git daemon`; is git installed with daemon support?");
-
-            if wait_for_port(port, &mut child) {
-                return Self {
-                    child,
-                    port,
-                    _base: base,
-                };
-            }
-
-            // Did not come up: reap this attempt before trying another port.
-            let _ = child.kill();
-            let _ = child.wait();
-            assert!(
-                attempt < MAX_ATTEMPTS,
-                "git daemon failed to start listening after {MAX_ATTEMPTS} attempts"
-            );
-        }
-        unreachable!("loop either returns or asserts on the final attempt")
-    }
-
-    fn repo_url(&self, repo_name: &str) -> String {
-        format!("git://127.0.0.1:{}/{repo_name}", self.port)
-    }
-}
-
-impl Drop for GitDaemonFixture {
-    fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
-    }
-}
-
-/// `git` exports these to its own subprocesses (hooks, `rebase --exec`) to pin
-/// them to the invoking repository. A test run *from* such a context — most
-/// obviously this repo's own `pre-push` hook — would otherwise inherit them,
-/// and every `git` below would retarget the real repo instead of the scratch
-/// one, firing the real hooks. Always spawn git through this.
-fn git_command() -> Command {
-    let mut cmd = Command::new("git");
-    for var in [
-        "GIT_DIR",
-        "GIT_WORK_TREE",
-        "GIT_COMMON_DIR",
-        "GIT_INDEX_FILE",
-        "GIT_OBJECT_DIRECTORY",
-        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-        "GIT_PREFIX",
-        "GIT_NAMESPACE",
-        "GIT_CEILING_DIRECTORIES",
-    ] {
-        cmd.env_remove(var);
-    }
-    cmd
-}
-
-fn free_loopback_port() -> u16 {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind ephemeral port");
-    listener
-        .local_addr()
-        .expect("failed to read local addr")
-        .port()
-}
-
-/// Poll until `port` accepts connections. Returns `false` (rather than
-/// panicking) if the daemon exits first or the deadline passes, so the caller
-/// can retry on a different port.
-fn wait_for_port(port: u16, child: &mut Child) -> bool {
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
-            return true;
-        }
-        // A daemon that already exited is never going to listen -- fail this
-        // attempt immediately instead of burning the whole deadline.
-        if matches!(child.try_wait(), Ok(Some(_))) {
-            return false;
-        }
-        if Instant::now() >= deadline {
-            return false;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-}
-
-fn run_git(dir: &Path, args: &[&str]) {
-    let output = git_command()
-        .args(args)
-        .current_dir(dir)
-        .output()
-        .unwrap_or_else(|e| panic!("failed to execute `git {}`: {e}", args.join(" ")));
-    assert!(
-        output.status.success(),
-        "`git {}` failed: {}",
-        args.join(" "),
-        String::from_utf8_lossy(&output.stderr)
-    );
-}
+// ── git daemon fixture ──────────────────────────────────────────────────────
+//
+// `GitDaemonFixture` and its supporting helpers live in `tests/common/mod.rs`,
+// shared with `git_content_cache_test.rs` and `offline_verification_sweep_test.rs`.
 
 /// Seed a bare repo at `base/<repo_name>.git` with a single commit on
 /// `branch`, including a root `.claude-plugin/marketplace.json` so the repo


### PR DESCRIPTION
> **Please wait for `Test (Windows, ...)` to go green before merging.** Earlier PRs in this chain were merged at a commit predating the fix already pushed to the branch, leaving main red.

## What

Closes the last Windows gap. The job now runs **every** fastskill-core test — **657, up from 637** — with the exclusion filter removed entirely:

```
cargo nextest run -p fastskill-core --lib --test '*' --retries 3 --no-fail-fast
```

## Why those three files were excluded, and what changed

Not because they were known broken — their fixture was **unported**: it killed the daemon by walking `/proc/<pid>/task/<pid>/children`, which doesn't exist on Windows. The fixture was also **triplicated** across the three files, so it's now extracted into `tests/common/mod.rs` and ported once:

- **Linux** — keeps the `/proc` descendant walk (unchanged behaviour)
- **Windows** — `taskkill /F /T /PID` kills the process tree in one shot
- **Other unix** — plain `child.kill()` fallback

`git daemon` itself was never the blocker; Git for Windows ships it.

## A latent bug fixed on the way

Reaping is now **bounded** rather than a blocking `wait()`. If a kill somehow failed to land, the old code would hang the test — and therefore the entire suite — instead of failing it. Worst case is now ~10s and a clear panic. Unlikely, but a hung CI job is a bad failure mode.

## Not done

- **Nothing is `#[cfg(unix)]`-gated.** Every platform gets a working kill path and no test is compiled out.
- No ubuntu job is modified (diff touches only `test-windows`).
- `protocol.file.allow=never` (SEC-11) is untouched. That guard is *why* these tests need a daemon rather than cloning a local path, and it wasn't weakened for test convenience.

## What this finally covers

The cache's **integration** behaviour on Windows, and the `#[cfg(windows)]` rename-retry branch in `core::cache` — which has compiled since Phase 1 but has never had anything exercise it.

## Verification and what's unverified

- Linux, exact CI command: **657 passed**. Full suite: **1140 passed**, unchanged.
- **Unverified until this PR's Windows run**, and I'd rather name it than imply otherwise: whether `git daemon` on Windows has the same process-tree shape (`taskkill /F /T` is written to cover either), whether `--base-path=` accepts a native Windows path, and whether `git://127.0.0.1:<port>` round-trips through Git for Windows the same way. The `cfg(windows)` code also cannot be compiled locally — `ring`/`onig_sys` need MSVC tooling — so this run is its first compile as well as its first execution.

Given the two real product bugs the earlier Windows phases uncovered, failures here are worth reading as possible genuine defects rather than assumed test noise.