### PR TITLE
ci: smoke-test the built binary before archiving it (Windows Phase 4) [WAIT FOR GREEN BEFORE MERGING]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,23 @@ jobs:
           mkdir -p release
           cp target/${{ matrix.target }}/release/${{ matrix.binary-name }} release/
 
+      # This CLI builds its command tree at RUNTIME (cli-framework AppBuilder::register /
+      # register_out in main()), not at compile time -- a duplicate command path or a bad
+      # CommandSpec is a panic when the binary starts, not a compiler error. Every job above
+      # only compiles the binary; nothing ever executes it. A shipped binary that fails to
+      # start (missing DLL, bad linkage, a runtime panic while building the command tree)
+      # would go completely undetected -- every CI job would still be green. So actually run
+      # the exact binary that gets archived, on every target in this matrix. See
+      # scripts/smoke-binary.sh for what it checks and why.
+      #
+      # All five (target, runner) pairs in this matrix are native: x86_64-unknown-linux-musl
+      # is cross-built via `cross`, but it is still a static x86_64 binary and runs fine
+      # directly on the ubuntu-latest (x86_64) runner -- no emulation needed. So there is
+      # nothing here to guard with an `if:`; every leg can execute its own binary.
+      - name: Smoke test the built binary
+        shell: bash
+        run: bash scripts/smoke-binary.sh "release/${{ matrix.binary-name }}"
+
       - name: Create README for release
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --all-features
 
+      # `cargo build --all-features` above already produces target/debug/fastskill, so
+      # this is nearly free and it's the only place release.yml's smoke step (tag-only,
+      # so it never runs in PR CI) gets exercised on Linux before a release. See
+      # scripts/smoke-binary.sh for what it checks and why.
+      - name: Smoke test fastskill binary
+        run: bash scripts/smoke-binary.sh target/debug/fastskill
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -74,6 +81,26 @@ jobs:
       # --no-fail-fast: this job is still being brought up, and stopping at the
       # first failure would surface only one platform issue per CI round-trip.
       - run: cargo nextest run -p fastskill-core --lib --test '*' --retries 3 --no-fail-fast
+
+      # fastskill-cli itself has never been compiled on Windows -- only fastskill-core
+      # is built/tested above. release.yml cross-builds and ships an
+      # x86_64-pc-windows-msvc *binary* of fastskill-cli, but only at tag time, so a
+      # Windows-only compile failure (or a runtime failure -- this CLI builds its
+      # command tree at RUNTIME via cli-framework's AppBuilder::register/register_out
+      # in main(), so a duplicate command path or bad CommandSpec panics on startup,
+      # not at compile time) would first be discovered mid-release instead of on a PR.
+      # Debug build is enough: the failure modes we're guarding against (missing
+      # symbols/DLLs, unix-only code paths, a panic while building the command tree)
+      # show up in debug just as well as release, for a fraction of the build time.
+      - name: Build fastskill-cli (debug)
+        run: cargo build -p fastskill-cli
+
+      # See scripts/smoke-binary.sh for what it checks and why. Deliberately includes
+      # check 3 (offline init + list) here, not just --version/--help: filesystem-write
+      # paths on Windows are exactly where this repo's real bugs have been.
+      - name: Smoke test fastskill-cli
+        shell: bash
+        run: bash scripts/smoke-binary.sh target/debug/fastskill.exe
 
   test-all-features:
     name: Test (All Features)

--- a/scripts/smoke-binary.sh
+++ b/scripts/smoke-binary.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Smoke-test a built fastskill binary.
+#
+# This CLI builds its command tree at RUNTIME (cli-framework AppBuilder::register /
+# register_out in main()), not at compile time -- a duplicate command path or a bad
+# CommandSpec is a panic when the binary starts, not a compiler error. Compiling the
+# binary (or cross-compiling it, in release.yml) never executes it, so a binary that
+# fails to start (missing DLL, bad linkage, a runtime panic while building the command
+# tree) would go completely undetected -- every CI job would still be green. This
+# script actually runs the exact binary under test.
+#
+# Used by both release.yml (against the archived, per-target binary on every matrix
+# leg) and test.yml (against the ubuntu and windows debug builds on every PR), so the
+# checks below only ever need to be written -- and kept correct -- once.
+#
+# Usage: scripts/smoke-binary.sh <path-to-binary>
+#
+# Checks:
+#   1. `<bin> --version` exits 0 and reports the version from the top-level Cargo.toml.
+#   2. `<bin> --help` exits 0 and produces non-empty output.
+#   3. In a fresh temp dir: `<bin> init --yes --skills-dir ./skills` then `<bin> list`,
+#      both exit 0. This is the filesystem-write path, run offline.
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <path-to-binary>" >&2
+  exit 1
+fi
+
+BIN_ARG="$1"
+
+if [ ! -f "$BIN_ARG" ]; then
+  echo "FAIL: binary not found at '$BIN_ARG'" >&2
+  exit 1
+fi
+
+# Resolve to an absolute path before we ever cd, and independent of the caller's cwd,
+# so the binary can still be invoked after we change directories below.
+case "$BIN_ARG" in
+  /*) BIN_ABS="$BIN_ARG" ;;
+  *) BIN_ABS="$PWD/$BIN_ARG" ;;
+esac
+
+# Find Cargo.toml relative to the repo root (this script's parent directory), not the
+# caller's cwd -- the caller may invoke us from anywhere.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+CARGO_TOML="$REPO_ROOT/Cargo.toml"
+
+if [ ! -f "$CARGO_TOML" ]; then
+  echo "FAIL: could not find top-level Cargo.toml at '$CARGO_TOML'" >&2
+  exit 1
+fi
+
+echo "Smoke-testing $BIN_ABS"
+
+EXPECTED_VERSION=$(grep '^version = ' "$CARGO_TOML" | head -1 | sed 's/version = "\(.*\)"/\1/')
+echo "Expected version (from $CARGO_TOML): $EXPECTED_VERSION"
+
+echo "--- Check 1: '$BIN_ABS --version' exits 0 and reports version $EXPECTED_VERSION ---"
+VERSION_OUTPUT=$("$BIN_ABS" --version)
+echo "Output: $VERSION_OUTPUT"
+if [[ "$VERSION_OUTPUT" != *"$EXPECTED_VERSION"* ]]; then
+  echo "FAIL: --version output does not contain expected version '$EXPECTED_VERSION'" >&2
+  echo "This usually means a stale/mis-cached build shipped the wrong binary." >&2
+  exit 1
+fi
+
+echo "--- Check 2: '$BIN_ABS --help' exits 0 and produces non-empty output ---"
+HELP_OUTPUT=$("$BIN_ABS" --help)
+if [ -z "$HELP_OUTPUT" ]; then
+  echo "FAIL: --help produced no output" >&2
+  exit 1
+fi
+echo "First lines of --help output:"
+echo "$HELP_OUTPUT" | head -5
+
+echo "--- Check 3: offline 'init' + 'list' in a fresh temp dir ---"
+# `fastskill init` derives a default skill/project identifier from the current
+# directory's basename, which must be alphanumeric/hyphens/underscores only.
+# `mktemp -d` alone produces a basename like `tmp.XXXXXXXXXX` (dot -- invalid), so
+# nest a cleanly-named subdirectory inside it rather than cd-ing straight into the
+# mktemp dir.
+SMOKE_PARENT=$(mktemp -d)
+SMOKE_DIR="$SMOKE_PARENT/smoke-test"
+mkdir -p "$SMOKE_DIR"
+pushd "$SMOKE_DIR" >/dev/null
+
+echo "Running: fastskill init --yes --skills-dir ./skills"
+"$BIN_ABS" init --yes --skills-dir ./skills
+
+echo "Running: fastskill list"
+"$BIN_ABS" list
+
+popd >/dev/null
+rm -rf "$SMOKE_PARENT"
+
+echo "Smoke test passed for $BIN_ABS"


### PR DESCRIPTION
## The gap

`release.yml` builds a binary for five targets — including `x86_64-pc-windows-msvc` — copies each into `release/`, archives it, and uploads it. **Nothing ever executes any of them.** The `fastskill --version` strings already in that file are release-notes markdown, not steps.

So a binary that fails to *start* would ship with every CI job green. That is not hypothetical here: this CLI builds its command tree at **runtime**, in `main()`, via `cli-framework`'s `AppBuilder::register` / `register_out`. A duplicate command path or a bad `CommandSpec` is a panic on startup, not a compile error. Unit tests never link the real binary, so they cannot catch it.

Windows is the sharpest case — `fastskill-cli` has never been compiled on Windows at all; the Windows job covers `fastskill-core` only.

## What this does

Adds `scripts/smoke-binary.sh <binary>`, which runs the binary under test:

1. `--version` exits 0 and reports the version parsed from the top-level `Cargo.toml` (catches a stale/mis-cached build shipping the wrong binary).
2. `--help` exits 0 and is non-empty — this exercises full command-tree construction.
3. In a fresh temp dir, `init --yes --skills-dir ./skills` then `list`, both exit 0 — the filesystem-write path, offline (verified with `strace -f -e trace=network`: zero `connect`/`getaddrinfo`).

Wired into three places:

| Workflow | Job | Binary |
|---|---|---|
| `release.yml` | `build` (all 5 targets) | the archived `release/<bin>` |
| `test.yml` | `build` (ubuntu) | `target/debug/fastskill` |
| `test.yml` | `test-windows` | `target/debug/fastskill.exe` |

One script, called from all three, so the checks are written and kept correct once.

## Why it's also in `test.yml`

`release.yml` is tag-only, so a step added there would never run in PR CI — we'd be merging something we had never seen execute, and discovering breakage mid-release. Calling the same script from the PR workflow on both Linux and Windows means the script itself is proven before any tag exists.

The Windows leg deliberately gets check 3 rather than just `--version`/`--help`: filesystem-write paths on Windows are exactly where this repo's real bugs have been (see #236, #239).

## Note on the Windows job

`cargo build -p fastskill-cli` on `windows-latest` is the **first time this crate has ever been compiled for MSVC**. Audit says it should work — the only platform-specific code in non-test sources is `utils/install_utils.rs:73-93`, which is fully gated `#[cfg(unix)]` / `#[cfg(windows)]` / fallback, and no unix-only crates appear in its dependency tree. But that is an audit, not a build. **This job failing is a real finding, not a flake.**

## Verification

Run locally against `target/release/fastskill` (0.9.172):

- Passes from the repo root, and from an unrelated cwd (proves repo-root resolution + absolute-path handling).
- Fails correctly: wrong binary (`/bin/true`) → exit 1 with the version mismatch explained; nonexistent path → exit 1; no args → usage, exit 1.
- `shellcheck` clean; both workflow files parse as YAML.

One real bug was caught during that verification: `mktemp -d` produces a basename like `tmp.XXXXXXXXXX`, and `fastskill init` derives its default identifier from the directory basename, which rejects the dot. The first draft of check 3 would have failed in CI. The script now nests a cleanly-named subdirectory inside the temp dir, with a comment saying why.

## Scope

CI only — no production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmpE6bvMsDtWDjmUP9wfu