### PR TITLE
ci(quality): gateway connectivity smoke for the spec-005 quality tier

### DIFF
--- a/.github/workflows/quality-gateway-smoke.yml
+++ b/.github/workflows/quality-gateway-smoke.yml
@@ -20,13 +20,13 @@ name: Quality Gateway Smoke
 # LLM_GATEWAY_EMBEDDING_MODEL must match what the key permits — changing either
 # pin means re-minting the key.
 
+# On demand only. This is a diagnostic you reach for when the quality tier fails
+# and you need to know whether the gateway path or the tier logic is at fault —
+# not something that should fire on every push. Verified green on
+# ci/gateway-connectivity-smoke (run 32073317516) before the push trigger was
+# removed.
 on:
   workflow_dispatch: {}
-  # Temporary: run on pushes to this branch so the wiring can be verified before
-  # merge. Remove this trigger once it has gone green once.
-  push:
-    branches:
-      - "ci/gateway-connectivity-smoke"
 
 permissions:
   contents: read

--- a/.github/workflows/quality-gateway-smoke.yml
+++ b/.github/workflows/quality-gateway-smoke.yml
@@ -1,0 +1,89 @@
+name: Quality Gateway Smoke
+
+# Proves the LLM-gateway path used by the spec-005 quality tier actually works
+# from CI: Tailnet join → gateway reachable → key accepted → both pinned models
+# answer. Deliberately tiny and dependency-free (curl + python3, no Docker, no
+# Rust build) so it can be run on demand to isolate "is the gateway wiring OK?"
+# from "is the quality tier logic OK?".
+#
+# This is NOT the quality tier itself (that is spec 005 P4, `quality.yml`); it is
+# the connectivity prerequisite that tier assumes.
+#
+# Required repo secrets (all six, else the job skips rather than fails):
+#   TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET  — Tailscale OAuth client, tag:ci
+#   LLM_GATEWAY_URL                       — gateway base URL on the Tailnet
+#   LLM_GATEWAY_KEY                       — virtual key (sk-…), budget-scoped
+#   LLM_GATEWAY_MODEL                     — chat model pin
+#   LLM_GATEWAY_EMBEDDING_MODEL           — embedding model pin
+#
+# The virtual key is scoped to a model allow-list, so LLM_GATEWAY_MODEL and
+# LLM_GATEWAY_EMBEDDING_MODEL must match what the key permits — changing either
+# pin means re-minting the key.
+
+on:
+  workflow_dispatch: {}
+  # Temporary: run on pushes to this branch so the wiring can be verified before
+  # merge. Remove this trigger once it has gone green once.
+  push:
+    branches:
+      - "ci/gateway-connectivity-smoke"
+
+permissions:
+  contents: read
+  # Required by tailscale/github-action to mint an OIDC token for OAuth.
+  id-token: write
+
+concurrency:
+  group: quality-gateway-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Gateway reachable + both pinned models answer
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Verify secrets are configured
+        id: guard
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          LLM_GATEWAY_URL: ${{ secrets.LLM_GATEWAY_URL }}
+          LLM_GATEWAY_KEY: ${{ secrets.LLM_GATEWAY_KEY }}
+          LLM_GATEWAY_MODEL: ${{ secrets.LLM_GATEWAY_MODEL }}
+          LLM_GATEWAY_EMBEDDING_MODEL: ${{ secrets.LLM_GATEWAY_EMBEDDING_MODEL }}
+        run: |
+          missing=""
+          for v in TS_OAUTH_CLIENT_ID TS_OAUTH_SECRET LLM_GATEWAY_URL \
+                   LLM_GATEWAY_KEY LLM_GATEWAY_MODEL LLM_GATEWAY_EMBEDDING_MODEL; do
+            [ -z "${!v}" ] && missing="$missing $v"
+          done
+          if [ -n "$missing" ]; then
+            echo "::warning::gateway secrets not configured — skipping:$missing"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout code
+        if: steps.guard.outputs.run == 'true'
+        uses: actions/checkout@v6
+
+      - name: Connect to the Tailnet
+        if: steps.guard.outputs.run == 'true'
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          # Must be authorized in the Tailscale ACL `tagOwners`; the node is
+          # ephemeral and auto-removed when the job ends.
+          tags: tag:ci
+
+      - name: Probe the gateway
+        if: steps.guard.outputs.run == 'true'
+        env:
+          LLM_GATEWAY_URL: ${{ secrets.LLM_GATEWAY_URL }}
+          LLM_GATEWAY_KEY: ${{ secrets.LLM_GATEWAY_KEY }}
+          LLM_GATEWAY_MODEL: ${{ secrets.LLM_GATEWAY_MODEL }}
+          LLM_GATEWAY_EMBEDDING_MODEL: ${{ secrets.LLM_GATEWAY_EMBEDDING_MODEL }}
+        run: python3 ci/quality/gateway_smoke.py

--- a/ci/quality/gateway_smoke.py
+++ b/ci/quality/gateway_smoke.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Connectivity smoke for the spec-005 LLM gateway path.
+
+Asserts, in order, that CI can:
+
+1. reach the gateway on the Tailnet at all (``/v1/models``),
+2. authenticate with the virtual key,
+3. see both pinned models in the key's allow-list,
+4. get a real embedding from ``LLM_GATEWAY_EMBEDDING_MODEL``,
+5. get a real completion from ``LLM_GATEWAY_MODEL``.
+
+Failing loudly here is the point: every later phase of the quality tier assumes
+this chain works, and a mis-scoped key or a repointed alias is invisible until
+something actually calls the gateway.
+
+Stdlib only, on purpose -- this must run before any project dependency exists.
+
+Secret hygiene: the key is read from the environment and sent in a header. It is
+never printed, and error bodies are truncated, since LiteLLM echoes a prefix of
+the presented key in auth errors.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+TIMEOUT = 120
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL  {msg}")
+    sys.exit(1)
+
+
+def env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        fail(f"{name} is empty -- the workflow guard should have caught this")
+    return value
+
+
+def call(url: str, key: str, payload: dict | None = None) -> dict:
+    """GET (payload=None) or POST JSON, returning the decoded body.
+
+    Raises RuntimeError with a truncated body on any non-2xx or non-JSON reply.
+    """
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+        },
+        method="POST" if data else "GET",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")[:300]
+        raise RuntimeError(f"HTTP {exc.code}: {body}") from exc
+    except urllib.error.URLError as exc:
+        # Most likely the Tailnet join failed or MagicDNS did not resolve.
+        raise RuntimeError(f"could not reach {url}: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"non-JSON reply from {url}: {exc}") from exc
+
+
+def main() -> None:
+    base = env("LLM_GATEWAY_URL").rstrip("/")
+    key = env("LLM_GATEWAY_KEY")
+    chat_model = env("LLM_GATEWAY_MODEL")
+    embed_model = env("LLM_GATEWAY_EMBEDDING_MODEL")
+
+    print(f"gateway   {base}")
+    print(f"chat      {chat_model}")
+    print(f"embedding {embed_model}")
+    print("-" * 60)
+
+    # 1-3. Reachable, authenticated, and both pins are in the key's allow-list.
+    try:
+        models = call(f"{base}/v1/models", key)
+    except RuntimeError as exc:
+        fail(f"/v1/models -- {exc}")
+    available = sorted(m.get("id", "") for m in models.get("data", []))
+    if not available:
+        fail(f"/v1/models returned no models: {json.dumps(models)[:200]}")
+    print(f"OK    /v1/models -> {len(available)} model(s): {', '.join(available)}")
+
+    for label, name in (("chat", chat_model), ("embedding", embed_model)):
+        if name not in available:
+            fail(
+                f"{label} pin {name!r} is not in the key's allow-list "
+                f"({', '.join(available)}). Re-mint the virtual key with this "
+                f"model, or correct the LLM_GATEWAY_{label.upper()}_MODEL secret."
+            )
+    print("OK    both pinned models are permitted by this key")
+
+    # 4. A real embedding. Dimensionality is reported, not asserted, so swapping
+    #    the embedding model does not break this smoke -- but note that changing
+    #    it DOES invalidate any existing fastskill index (3840-dim kalm-embed vs
+    #    1536-dim text-embedding-3-small), which is a reindex, not a config flip.
+    try:
+        emb = call(
+            f"{base}/v1/embeddings",
+            key,
+            {"model": embed_model, "input": "fastskill gateway smoke"},
+        )
+    except RuntimeError as exc:
+        fail(f"/v1/embeddings -- {exc}")
+    vectors = emb.get("data") or []
+    if not vectors or not vectors[0].get("embedding"):
+        fail(f"/v1/embeddings returned no vector: {json.dumps(emb)[:200]}")
+    print(f"OK    /v1/embeddings -> {len(vectors[0]['embedding'])} dimensions")
+
+    # 5. A real completion.
+    #
+    #    Assert on completion_tokens, NOT on non-empty content: the pinned model
+    #    may be a reasoning model that emits a <think> block, and it can spend
+    #    its entire budget there and return empty visible content. That is a
+    #    working gateway, so treating it as a failure would be wrong. Budget is
+    #    generous for the same reason.
+    try:
+        chat = call(
+            f"{base}/v1/chat/completions",
+            key,
+            {
+                "model": chat_model,
+                "messages": [{"role": "user", "content": "Reply with the word OK."}],
+                "max_tokens": 512,
+            },
+        )
+    except RuntimeError as exc:
+        fail(f"/v1/chat/completions -- {exc}")
+    produced = (chat.get("usage") or {}).get("completion_tokens", 0)
+    if produced <= 0:
+        fail(f"/v1/chat/completions produced no tokens: {json.dumps(chat)[:200]}")
+    content = ((chat.get("choices") or [{}])[0].get("message") or {}).get("content", "")
+    print(f"OK    /v1/chat/completions -> {produced} completion tokens")
+    print(f"      visible content: {content.strip()[:80]!r}")
+    if not content.strip():
+        print("      note: empty visible content is expected for a model whose")
+        print("            reasoning block consumed the token budget.")
+
+    print("-" * 60)
+    print("PASS  gateway path is healthy end-to-end from CI")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Six LLM-gateway/Tailscale secrets are now provisioned on this repo, but nothing here read them — so they were unverified. Every phase of the spec-005 quality tier assumes that chain works, and a mis-scoped virtual key or a repointed model alias stays invisible until something actually calls the gateway.

This adds a small, dependency-free diagnostic that proves the chain from CI:

**Tailnet join → gateway reachable → key accepted → both pinned models in the key allow-list → real embedding → real completion.**

Stdlib-only Python, no Docker, no Rust build, so a failure isolates cleanly to "gateway wiring" rather than anything else. `workflow_dispatch` only — it is what you reach for when the quality tier fails and you need to know which half is at fault.

## Verified green in real CI

Run [32073317516](https://github.com/gofastskill/fastskill/actions/runs/32073317516), via a temporary push trigger since removed:

```
OK    /v1/models -> 2 model(s): ***, ***
OK    both pinned models are permitted by this key
OK    /v1/embeddings -> 3840 dimensions
OK    /v1/chat/completions -> 2 completion tokens
PASS  gateway path is healthy end-to-end from CI
```

All five real steps `success`, none skipped. With a scoped key `/v1/models` returns only the permitted models (2 of the gateway’s 9), so the allow-list assertion genuinely catches a key/pin mismatch rather than being decorative.

## Two assertions encode findings from verifying the gateway by hand

- **Chat asserts on `usage.completion_tokens`, not on non-empty content.** The pinned chat model reasons *non-deterministically*: the same prompt produced 63 completion tokens wrapped in a `<think>` block locally, and 2 tokens (`OK`) in CI. Asserting on visible content would be intermittently flaky in exactly the way that wastes an afternoon.
- **Embedding dimensionality is reported, not asserted**, so swapping the embedding model does not break this smoke — with a comment recording that it is still not a config flip, since 3840-d `kalm-embed` vs 1536-d `text-embedding-3-small` invalidates any existing index.

## Behaviour without secrets

Skips with a `::warning::` rather than failing, matching the guard pattern in aikit’s `nightly-agent-e2e.yml`, so forks and secret-less contexts stay green.

No untrusted input is interpolated — all values arrive via `env:` from `secrets.*`, so there is no workflow-injection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)