### PR TITLE
feat(config): let the environment override the embedding endpoint and model (K4)

### DIFF
--- a/crates/fastskill-cli/src/commands/doctor.rs
+++ b/crates/fastskill-cli/src/commands/doctor.rs
@@ -116,11 +116,19 @@ pub async fn execute_doctor(service: &FastSkillService, args: DoctorArgs) -> Cli
     checks.push(project_file_check);
 
     // Check 3: Embedding configuration present
-    let embedding_check = if service.config().embedding.is_some() {
+    let embedding_check = if let Some(embedding) = service.config().embedding.as_ref() {
+        // Report the *effective* endpoint and model, not just that config
+        // exists. These are environment-overridable (see `config_file`), so
+        // "configuration found" alone cannot tell you whether you are talking to
+        // OpenAI or to an internal gateway — which is exactly the question you
+        // are asking when embeddings misbehave.
         DoctorCheckResult {
             check: "embedding_config".to_string(),
             status: DoctorStatus::Pass,
-            message: "Embedding configuration found.".to_string(),
+            message: format!(
+                "Embedding configuration found (endpoint: {}, model: {}).",
+                embedding.openai_base_url, embedding.embedding_model
+            ),
         }
     } else {
         DoctorCheckResult {

--- a/crates/fastskill-cli/src/config_file.rs
+++ b/crates/fastskill-cli/src/config_file.rs
@@ -83,11 +83,14 @@ pub fn load_config_from_skill_project(current_dir: &Path) -> CliResult<Option<Fa
     let tool_config = project.tool.and_then(|t| t.fastskill);
 
     if let Some(config) = tool_config {
-        // Convert EmbeddingConfigToml to EmbeddingConfig
-        let embedding = config.embedding.map(|e| EmbeddingConfig {
-            openai_base_url: e.openai_base_url,
-            embedding_model: e.embedding_model,
-            index_path: e.index_path,
+        // Convert EmbeddingConfigToml to EmbeddingConfig, then let the
+        // environment override the non-secret fields (K4).
+        let embedding = config.embedding.map(|e| {
+            embedding_with_env_overrides(EmbeddingConfig {
+                openai_base_url: e.openai_base_url,
+                embedding_model: e.embedding_model,
+                index_path: e.index_path,
+            })
         });
 
         // Convert HttpServerConfigToml to HttpServerConfig
@@ -108,6 +111,59 @@ pub fn load_config_from_skill_project(current_dir: &Path) -> CliResult<Option<Fa
     }
 }
 
+/// Environment override for [`EmbeddingConfig::openai_base_url`].
+///
+/// Named to match `OPENAI_API_KEY` and the variable the OpenAI SDKs themselves
+/// read, so pointing FastSkill at an OpenAI-compatible gateway uses the same
+/// spelling as every other tool in the stack.
+pub const ENV_OPENAI_BASE_URL: &str = "OPENAI_BASE_URL";
+
+/// Environment override for [`EmbeddingConfig::embedding_model`].
+///
+/// Deliberately *not* `OPENAI_EMBEDDING_MODEL`: there is no such OpenAI
+/// convention, and the value is frequently not an OpenAI model at all (a
+/// self-hosted gateway may serve something else entirely).
+pub const ENV_EMBEDDING_MODEL: &str = "FASTSKILL_EMBEDDING_MODEL";
+
+/// Apply environment overrides to the embedding config read from the manifest.
+///
+/// **Environment wins over the manifest.** `skill-project.toml` is committed and
+/// shared by everyone on the project; the environment is per-deployment. Pointing
+/// one machine (or one CI job) at a different embedding endpoint must not require
+/// editing — let alone committing — a tracked file.
+///
+/// This closes the asymmetry recorded as K4: the base URL and model were
+/// manifest-only while the API key was environment-only, so a gateway
+/// redirection had to be split across two mechanisms. Note the fix is to make the
+/// *non-secret* fields environment-overridable, **not** to add an API-key field
+/// to the manifest — a committed file is the wrong home for a secret.
+///
+/// Takes a lookup closure rather than reading the process environment directly so
+/// it can be tested without `set_var`, which is process-global and races with any
+/// other test running in parallel.
+fn apply_embedding_env_overrides(
+    mut embedding: EmbeddingConfig,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> EmbeddingConfig {
+    // An empty or whitespace-only value is treated as unset. `FOO=` in a shell
+    // profile or a CI matrix that leaves a variable blank should not silently
+    // blank out a working manifest setting.
+    let present = |name: &str| lookup(name).filter(|v| !v.trim().is_empty());
+
+    if let Some(base_url) = present(ENV_OPENAI_BASE_URL) {
+        embedding.openai_base_url = base_url.trim().to_string();
+    }
+    if let Some(model) = present(ENV_EMBEDDING_MODEL) {
+        embedding.embedding_model = model.trim().to_string();
+    }
+    embedding
+}
+
+/// [`apply_embedding_env_overrides`] against the real process environment.
+pub fn embedding_with_env_overrides(embedding: EmbeddingConfig) -> EmbeddingConfig {
+    apply_embedding_env_overrides(embedding, |name| std::env::var(name).ok())
+}
+
 /// Get OpenAI API key from environment
 pub fn get_openai_api_key() -> CliResult<String> {
     std::env::var("OPENAI_API_KEY")
@@ -120,5 +176,96 @@ pub fn load_auto_reindex_config() -> bool {
         config.auto_reindex
     } else {
         true
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
+mod embedding_env_override_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn manifest_config() -> EmbeddingConfig {
+        EmbeddingConfig {
+            openai_base_url: "https://api.openai.com/v1".to_string(),
+            embedding_model: "text-embedding-3-small".to_string(),
+            index_path: None,
+        }
+    }
+
+    /// Build a lookup over a fixed map — no process env, so these tests are
+    /// safe to run in parallel with everything else.
+    fn env_of(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |name: &str| map.get(name).cloned()
+    }
+
+    #[test]
+    fn manifest_values_survive_when_no_env_is_set() {
+        let out = apply_embedding_env_overrides(manifest_config(), env_of(&[]));
+        assert_eq!(out.openai_base_url, "https://api.openai.com/v1");
+        assert_eq!(out.embedding_model, "text-embedding-3-small");
+    }
+
+    #[test]
+    fn env_overrides_base_url_and_model() {
+        let out = apply_embedding_env_overrides(
+            manifest_config(),
+            env_of(&[
+                (ENV_OPENAI_BASE_URL, "https://llm-gateway.example.ts.net/v1"),
+                (ENV_EMBEDDING_MODEL, "kalm-embed"),
+            ]),
+        );
+        assert_eq!(out.openai_base_url, "https://llm-gateway.example.ts.net/v1");
+        assert_eq!(out.embedding_model, "kalm-embed");
+    }
+
+    #[test]
+    fn each_override_is_independent() {
+        let out = apply_embedding_env_overrides(
+            manifest_config(),
+            env_of(&[(ENV_OPENAI_BASE_URL, "https://gateway.internal/v1")]),
+        );
+        assert_eq!(out.openai_base_url, "https://gateway.internal/v1");
+        assert_eq!(
+            out.embedding_model, "text-embedding-3-small",
+            "overriding the base URL must not disturb the model"
+        );
+    }
+
+    /// A blank value in a shell profile or CI matrix must not silently blank out
+    /// a working manifest setting — that failure is near-impossible to diagnose
+    /// from the resulting "connection refused to ''".
+    #[test]
+    fn blank_env_values_are_treated_as_unset() {
+        let out = apply_embedding_env_overrides(
+            manifest_config(),
+            env_of(&[(ENV_OPENAI_BASE_URL, ""), (ENV_EMBEDDING_MODEL, "   ")]),
+        );
+        assert_eq!(out.openai_base_url, "https://api.openai.com/v1");
+        assert_eq!(out.embedding_model, "text-embedding-3-small");
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_trimmed() {
+        let out = apply_embedding_env_overrides(
+            manifest_config(),
+            env_of(&[(ENV_EMBEDDING_MODEL, "  kalm-embed\n")]),
+        );
+        assert_eq!(out.embedding_model, "kalm-embed");
+    }
+
+    #[test]
+    fn index_path_is_never_touched_by_env() {
+        let mut cfg = manifest_config();
+        cfg.index_path = Some(PathBuf::from("/custom/index"));
+        let out = apply_embedding_env_overrides(
+            cfg,
+            env_of(&[(ENV_OPENAI_BASE_URL, "https://gateway.internal/v1")]),
+        );
+        assert_eq!(out.index_path, Some(PathBuf::from("/custom/index")));
     }
 }

--- a/webdocs/configuration/init-command.mdx
+++ b/webdocs/configuration/init-command.mdx
@@ -130,6 +130,43 @@ Set the API key via the environment; if it is unset, semantic search is silently
 export OPENAI_API_KEY="your-key-here"
 ```
 
+### Pointing at a different endpoint
+
+`skill-project.toml` is committed and shared by everyone on the project, so it is
+the wrong place to record that *your* machine — or one CI job — talks to a
+different embedding endpoint. Both non-secret fields can be overridden from the
+environment, and the environment wins:
+
+| Variable | Overrides | Example |
+|---|---|---|
+| `OPENAI_BASE_URL` | `openai_base_url` | `https://gateway.internal/v1` |
+| `FASTSKILL_EMBEDDING_MODEL` | `embedding_model` | `my-embed-model` |
+
+```bash
+export OPENAI_BASE_URL="https://gateway.internal/v1"
+export FASTSKILL_EMBEDDING_MODEL="my-embed-model"
+export OPENAI_API_KEY="your-gateway-key"
+```
+
+An empty or whitespace-only value counts as unset, so a blank variable in a shell
+profile or CI matrix will not silently blank out a working manifest setting.
+
+Run `fastskill doctor` to see which endpoint and model are actually in effect:
+
+```
+[PASS] embedding_config: Embedding configuration found
+       (endpoint: https://gateway.internal/v1, model: my-embed-model).
+```
+
+<Callout type="warn">
+**Changing the embedding model invalidates your index.** Vectors from different
+models are not comparable — and often not even the same length. After switching
+models, run `fastskill reindex` before searching, or results will be meaningless.
+</Callout>
+
+The API key stays environment-only on purpose: a committed manifest is the wrong
+home for a secret.
+
 ## Troubleshooting
 
 ### "skill-project.toml already exists. Use --force to overwrite."


### PR DESCRIPTION
Closes **K4** and completes **spec 005 P1**.

## The problem

Embedding settings were split across two mechanisms that could not be used together:

| Setting | Readable from |
|---|---|
| `openai_base_url` | `skill-project.toml` only |
| `embedding_model` | `skill-project.toml` only |
| API key | `OPENAI_API_KEY` only |

So pointing FastSkill at an OpenAI-compatible gateway meant editing — and usually committing — a tracked file that everyone on the project shares, purely to express a per-machine or per-CI-job fact.

## The change

Two overrides; **environment wins over manifest**:

```
OPENAI_BASE_URL            -> openai_base_url
FASTSKILL_EMBEDDING_MODEL  -> embedding_model
```

`OPENAI_BASE_URL` matches `OPENAI_API_KEY` and the variable the OpenAI SDKs themselves read, so redirecting FastSkill uses the same spelling as everything else in the stack. The model variable is deliberately **not** `OPENAI_EMBEDDING_MODEL` — no such OpenAI convention exists, and the value is frequently not an OpenAI model at all.

**The asymmetry is resolved by making the non-secret fields environment-overridable, not by adding an API-key field to the manifest.** A committed file is the wrong home for a secret, so that half of K4 stays as-is on purpose.

### Details worth reviewing

- **Blank counts as unset.** `OPENAI_BASE_URL=` in a shell profile or an unset CI matrix entry will not silently blank out a working manifest setting — that failure is near-undiagnosable from the resulting connection error.
- **Testable without `set_var`.** The override is a pure function over a lookup closure, so its tests never mutate the process environment, which is global and races with any test running in parallel.
- **`doctor` now reports the effective endpoint and model** rather than just "configuration found" — which could not answer the question you actually have when embeddings misbehave: *am I talking to OpenAI or to my gateway?*

```
[PASS] embedding_config: Embedding configuration found
       (endpoint: https://gateway.internal/v1, model: my-embed-model).
```

## Verified end-to-end, not just unit-tested

Against a real OpenAI-compatible gateway serving a non-OpenAI embedding model. With the overrides set, `reindex` embedded two skills **through the gateway** — confirmed against the gateway’s own spend log rather than by trusting a success message — storing 3840-dimensional vectors. Semantic search then ranked correctly on queries with **no lexical overlap** with either skill:

| Query | Top hit | Runner-up |
|---|---|---|
| "why is my container restarting" | **k8s-debug** 0.504 | pdf-tools 0.311 |
| "read a document and pull out a table" | **pdf-tools** 0.552 | k8s-debug 0.357 |

The ranking flips correctly, which is the actual proof that retrieval works rather than that the call merely succeeded.

## Docs

`webdocs/configuration/init-command.mdx` gains the override table and a warning this exercise surfaced: **changing the embedding model invalidates the index.** Vectors from different models are not comparable and often not even the same length (3840-d here vs 1536-d for `text-embedding-3-small`), so switching is a reindex, not a config flip.

## Pre-existing issues observed, not addressed here

- Two flaky tests — `test_execute_add_then_list` and `remote_repo_filter_returns_repository_error_on_client_init_failure` — each failed once then passed 3/3 in isolation and 2/2 in full runs. The first mutates process-global cwd under a `DIR_MUTEX`, which only holds if every cwd-dependent test takes the same lock. `nextest --retries 3` masks this in CI.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` is red on `main`; CI runs the same command without `-D warnings`. CI-exact clippy exits 0 on both `main` and this branch.
- `fastskill search "query"` defaults to **Remote** scope, so with no registry configured it prints "No skills found" even when local skills are indexed and would match. `--local` is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)