### PR TITLE
[WAIT FOR GREEN BEFORE MERGING] chore(deps): drop the unused inquire dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
- "crossterm 0.28.1",
+ "crossterm",
  "dirs 5.0.1",
  "http 1.4.0",
  "httpdate",
@@ -912,22 +912,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crossterm"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio 0.8.11",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
 
 [[package]]
 name = "crossterm"
@@ -1358,7 +1342,6 @@ dependencies = [
  "fastskill-core",
  "fastskill-evals",
  "fs2",
- "inquire",
  "insta",
  "num_cpus",
  "once_cell",
@@ -1669,24 +1652,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "fuzzy-matcher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
-dependencies = [
- "thread_local",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -2266,23 +2231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inquire"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
-dependencies = [
- "bitflags 2.11.1",
- "crossterm 0.25.0",
- "dyn-clone",
- "fuzzy-matcher",
- "fxhash",
- "newline-converter",
- "once_cell",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "insta"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,15 +2629,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "newline-converter"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "normalize-line-endings"
@@ -4079,7 +4018,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 0.8.11",
  "mio 1.2.0",
  "signal-hook",
 ]
@@ -4846,12 +4784,6 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Configuration
 config = "0.15"
 clap = { version = "4.4", features = ["derive"] }
-inquire = "0.7"
 
 # URL parsing
 url = "2.5"

--- a/crates/fastskill-cli/Cargo.toml
+++ b/crates/fastskill-cli/Cargo.toml
@@ -29,7 +29,6 @@ aikit-skillopt.workspace = true
 
 # CLI-specific dependencies
 clap.workspace = true
-inquire.workspace = true
 
 # Async runtime
 tokio.workspace = true


### PR DESCRIPTION
## Summary

`inquire` is declared as a dependency in the workspace root `Cargo.toml` and re-declared in `crates/fastskill-cli/Cargo.toml`, but nothing in the codebase actually calls it:

```
$ grep -rn "inquire" --include='*.rs' .
(no output)
```

It entered via the original CLI scaffold commit and was never wired up. `fastskill-cli` has no non-default features (`[features] default = []`), and there is no `cfg(feature = ...)` gating anywhere in the repo, so this holds true under `--all-features` too.

This is strictly better than bumping the version (dependabot #139, 0.7.5 → 0.9.4) since nothing calls it — **this PR supersedes and should replace dependabot#139, which can be closed once this merges.**

## Changes
- Removed `inquire = "0.7"` from the workspace `[workspace.dependencies]` in the root `Cargo.toml`.
- Removed `inquire.workspace = true` from `crates/fastskill-cli/Cargo.toml`.
- Regenerated `Cargo.lock` via `cargo build --all-features` (no hand-editing).

### Transitive crates dropped from Cargo.lock
Only crates that were exclusively pulled in by `inquire` were dropped (confirmed via reverse-dependency check before removing):
- `inquire` 0.7.5
- `crossterm` 0.25.0 — the older duplicate pulled in only by `inquire`; `cli-framework`'s `crossterm` 0.28.1 remains
- `fuzzy-matcher` 0.3.7
- `fxhash` 0.2.1
- `newline-converter` 0.3.0
- `unicode-width` 0.1.14

`convert_case` and `derive_more` were checked and are unaffected: `convert_case` is a dependency of the unrelated `config` crate, and `derive_more` was never in the lockfile in the first place.

## Test plan
- [x] `cargo build --all-features` — succeeds
- [x] `cargo clippy --workspace --all-targets --all-features` — clean (0 errors; only pre-existing, unrelated warnings)
- [x] `cargo nextest run --retries 3 -E 'not test(install_e2e_tests)'` — 1147 passed, 15 skipped
- [x] `cargo nextest run --retries 3 --all-features -E 'not test(install_e2e_tests)'` — 1147 passed, 15 skipped
- [x] `cargo fmt --all -- --check` — clean
- [x] pre-commit and pre-push hooks (clippy + unit tests + full nextest + doc build) passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmpE6bvMsDtWDjmUP9wfu