### PR TITLE
[WAIT FOR GREEN BEFORE MERGING] deps: bump sha2 from 0.10.9 to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
  "async-trait",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
@@ -210,7 +210,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -221,7 +221,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -473,6 +473,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,7 +630,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -806,6 +815,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +986,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,9 +1150,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1170,7 +1205,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1283,7 +1318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1369,7 +1404,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
@@ -1412,7 +1447,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
@@ -1868,7 +1903,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1976,6 +2011,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2054,7 +2098,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -2722,7 +2766,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2943,7 +2987,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -2993,7 +3037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3189,7 +3233,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -3227,7 +3271,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3718,7 +3762,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3776,7 +3820,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4027,7 +4071,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4038,7 +4082,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4157,7 +4212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4304,10 +4359,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.4.1",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5216,7 +5271,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ validator = { version = "0.20", features = ["derive"] }
 rusqlite = { version = "0.40", features = ["bundled"] }
 
 # SHA256 hashing for file integrity
-sha2 = "0.10"
+sha2 = "0.11"
 
 # Base64 encoding/decoding for JWT parsing
 base64 = "0.22"

--- a/crates/fastskill-core/src/core/change_detection.rs
+++ b/crates/fastskill-core/src/core/change_detection.rs
@@ -175,7 +175,7 @@ pub fn calculate_skill_hash(skill_path: &Path) -> Result<String, ServiceError> {
         hasher.update(&content);
     }
 
-    let hash = format!("sha256:{:x}", hasher.finalize());
+    let hash = format!("sha256:{}", crate::utils::to_hex_lower(&hasher.finalize()));
     Ok(hash)
 }
 
@@ -235,6 +235,35 @@ mod tests {
     fn write_single_file_skill(dir: &Path, file_name: &str, content: &str) {
         fs::create_dir_all(dir).unwrap();
         fs::write(dir.join(file_name), content).unwrap();
+    }
+
+    // --- sha2 0.10 -> 0.11 bump: pin the exact cache-key string ---
+    //
+    // `calculate_skill_hash`'s result is persisted as a build-cache key
+    // (see `BuildCache`) and compared byte-for-byte across runs. The bump
+    // to sha2 0.11 changed `Sha256::finalize()`'s return type from
+    // `GenericArray<u8, N>` to `hybrid_array::Array<u8, N>`, which does not
+    // implement `LowerHex`, forcing the `format!("{:x}", ...)` call above to
+    // become `format!("sha256:{}", to_hex_lower(&hasher.finalize()))`. This
+    // test pins a known input's exact output (including the `sha256:`
+    // prefix) so a future change to the hex encoding — case, padding,
+    // truncation — fails loudly here instead of silently invalidating every
+    // cached entry that keys off this string.
+    #[test]
+    fn test_calculate_skill_hash_matches_known_value() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("known_skill");
+        write_single_file_skill(&dir, "a.txt", "hi");
+
+        let hash = calculate_skill_hash(&dir).unwrap();
+
+        // Independently computed (Python hashlib) from the same
+        // length-prefixed(path) + length-prefixed(content) scheme:
+        //   sha256(len("a.txt").to_le_bytes(8) + b"a.txt" + len("hi").to_le_bytes(8) + b"hi")
+        assert_eq!(
+            hash, "sha256:d94190b242cc00cb896909e8322401c230fef8ea9403e8b99073e759b5e80616",
+            "hash format/value for a known single-file skill must be stable"
+        );
     }
 
     #[test]

--- a/crates/fastskill-core/src/core/install.rs
+++ b/crates/fastskill-core/src/core/install.rs
@@ -1280,7 +1280,7 @@ fn compute_local_tree_hash(root: &Path) -> Result<String, ServiceError> {
         hasher.update((content.len() as u64).to_le_bytes());
         hasher.update(content);
     }
-    Ok(format!("{:x}", hasher.finalize()))
+    Ok(crate::utils::to_hex_lower(&hasher.finalize()))
 }
 
 /// Recursively collect `(relative_path, content)` pairs for every regular
@@ -1319,7 +1319,7 @@ fn collect_tree_entries(dir: &Path, root: &Path) -> Result<Vec<(String, Vec<u8>)
 fn hash_bytes(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
-    format!("{:x}", hasher.finalize())
+    crate::utils::to_hex_lower(&hasher.finalize())
 }
 
 /// Resolve `HEAD`'s commit SHA in a freshly-cloned git repository.

--- a/crates/fastskill-core/src/core/registry/client.rs
+++ b/crates/fastskill-core/src/core/registry/client.rs
@@ -273,7 +273,10 @@ impl RegistryClient {
             .map_err(|e| ServiceError::Custom(format!("Failed to read package data: {}", e)))?;
 
         // Verify checksum
-        let calculated = format!("sha256:{:x}", sha2::Sha256::digest(&bytes));
+        let calculated = format!(
+            "sha256:{}",
+            crate::utils::to_hex_lower(&sha2::Sha256::digest(&bytes))
+        );
         if calculated != entry.cksum {
             return Err(ServiceError::Custom(format!(
                 "Checksum mismatch: expected {}, got {}",
@@ -534,7 +537,10 @@ mod tests {
     async fn test_download_success_verifies_checksum() {
         let server = MockServer::start().await;
         let payload = b"skill-package-bytes";
-        let cksum = format!("sha256:{:x}", sha2::Sha256::digest(payload));
+        let cksum = format!(
+            "sha256:{}",
+            crate::utils::to_hex_lower(&sha2::Sha256::digest(payload))
+        );
         let dl_url = format!("{}/dl", server.uri());
         let entries = vec![make_entry("d", "1.0.0", &dl_url, &cksum)];
         mount_index(&server, "d", &entries).await;

--- a/crates/fastskill-core/src/core/reindex.rs
+++ b/crates/fastskill-core/src/core/reindex.rs
@@ -230,7 +230,7 @@ fn calculate_file_hash(file_path: &Path) -> Result<String, ServiceError> {
     let mut hasher = Sha256::new();
     hasher.update(&content);
     let hash_bytes = hasher.finalize();
-    Ok(format!("{:x}", hash_bytes))
+    Ok(crate::utils::to_hex_lower(&hash_bytes))
 }
 
 #[cfg(test)]

--- a/crates/fastskill-core/src/core/repository/client.rs
+++ b/crates/fastskill-core/src/core/repository/client.rs
@@ -893,7 +893,10 @@ mod tests {
 
         let server = MockServer::start().await;
         let payload = b"pkg-bytes";
-        let cksum = format!("sha256:{:x}", sha2::Sha256::digest(payload));
+        let cksum = format!(
+            "sha256:{}",
+            crate::utils::to_hex_lower(&sha2::Sha256::digest(payload))
+        );
         let dl_url = format!("{}/dl", server.uri());
 
         let entry = IndexEntry {

--- a/crates/fastskill-core/src/utils.rs
+++ b/crates/fastskill-core/src/utils.rs
@@ -1,8 +1,29 @@
 //! Utility functions for the fastskill-core crate
 
+use std::fmt::Write as _;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+
+/// Encode `bytes` as lowercase hex, e.g. for rendering a SHA-256 digest as a
+/// cache key / integrity checksum string.
+///
+/// This exists instead of a `format!("{:x}", digest)` call (which relied on
+/// `GenericArray`'s `LowerHex` impl) because `digest` 0.11 switched to
+/// `hybrid_array::Array`, which does **not** implement `LowerHex`. Pulling in
+/// the `hex` crate for one function was not worth a new dependency, so this
+/// is a small local equivalent — output is byte-for-byte identical to the
+/// old `{:x}` formatting (lowercase, no separators, two hex digits per byte),
+/// which matters because these strings are persisted as cache-identity keys
+/// (see `core::change_detection` and `core::install`).
+pub fn to_hex_lower(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        // `write!` to a `String` is infallible.
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
 
 /// Write `bytes` to `path` atomically: write to a **per-writer unique** temp file
 /// in the same directory → sync → atomic rename over `path`.
@@ -51,6 +72,36 @@ pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    /// Regression test for the sha2 0.10 -> 0.11 bump: `hybrid_array::Array`
+    /// (which `Sha256::digest`/`finalize` now return) does not implement
+    /// `LowerHex`, so every hashing call site switched from
+    /// `format!("{:x}", digest)` to `to_hex_lower(&digest)`. This pins the
+    /// exact output for a known input so a future change to the hex
+    /// encoding (case, padding, separators) fails loudly instead of quietly
+    /// invalidating every cache entry that uses this string as a key.
+    #[test]
+    fn test_to_hex_lower_matches_known_sha256() {
+        use sha2::{Digest, Sha256};
+
+        let digest = Sha256::digest(b"hello world");
+        let hex = to_hex_lower(&digest);
+
+        assert_eq!(
+            hex, "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+            "hex encoding of a known SHA-256 digest must be stable"
+        );
+    }
+
+    #[test]
+    fn test_to_hex_lower_empty_input() {
+        assert_eq!(to_hex_lower(&[]), "");
+    }
+
+    #[test]
+    fn test_to_hex_lower_is_lowercase_and_zero_padded() {
+        assert_eq!(to_hex_lower(&[0x00, 0x0f, 0xab, 0xff]), "000fabff");
+    }
     use tempfile::TempDir;
 
     #[test]

--- a/crates/fastskill-core/tests/http_handler_route_tests.rs
+++ b/crates/fastskill-core/tests/http_handler_route_tests.rs
@@ -681,7 +681,10 @@ async fn update_version_pin_happy_path_repository_origin() {
         "widget",
         "---\nname: widget\nversion: \"2.0.0\"\ndescription: A registry skill\n---\nBody\n",
     );
-    let cksum = format!("sha256:{:x}", sha2::Sha256::digest(&zip_bytes));
+    let cksum = format!(
+        "sha256:{}",
+        fastskill_core::utils::to_hex_lower(&sha2::Sha256::digest(&zip_bytes))
+    );
 
     let entries = [
         IndexEntry {

--- a/crates/fastskill-core/tests/offline_verification_sweep_test.rs
+++ b/crates/fastskill-core/tests/offline_verification_sweep_test.rs
@@ -243,8 +243,11 @@ fn build_zip(version: &str) -> Vec<u8> {
 
 async fn mount_version(server: &MockServer, version: &str) {
     let zip_bytes = build_zip(version);
-    let cksum = format!("sha256:{:x}", sha2::Sha256::digest(&zip_bytes));
     use sha2::Digest;
+    let cksum = format!(
+        "sha256:{}",
+        fastskill_core::utils::to_hex_lower(&sha2::Sha256::digest(&zip_bytes))
+    );
     let entry = IndexEntry {
         name: SKILL_ID.to_string(),
         vers: version.to_string(),

--- a/crates/fastskill-core/tests/registry_content_cache_test.rs
+++ b/crates/fastskill-core/tests/registry_content_cache_test.rs
@@ -58,7 +58,10 @@ fn build_zip(version: &str) -> Vec<u8> {
 /// Mount an index entry + download endpoint for `version` on `server`.
 async fn mount_version(server: &MockServer, version: &str) {
     let zip_bytes = build_zip(version);
-    let cksum = format!("sha256:{:x}", sha2::Sha256::digest(&zip_bytes));
+    let cksum = format!(
+        "sha256:{}",
+        fastskill_core::utils::to_hex_lower(&sha2::Sha256::digest(&zip_bytes))
+    );
     let entry = IndexEntry {
         name: SKILL_ID.to_string(),
         vers: version.to_string(),

--- a/crates/fastskill-core/tests/zip_url_cache_test.rs
+++ b/crates/fastskill-core/tests/zip_url_cache_test.rs
@@ -210,7 +210,7 @@ async fn conditional_200_redownloads_and_updates_recorded_hash() {
     let cache = SkillCache::at_root(cache_root.path());
     let validators = cache.read_zip_validators().unwrap();
     let recorded = validators.get(&url).expect("validator must be recorded");
-    let expected_hash = format!("{:x}", sha2::Sha256::digest(&zip_v2));
+    let expected_hash = fastskill_core::utils::to_hex_lower(&sha2::Sha256::digest(&zip_v2));
     assert_eq!(
         recorded.content_hash, expected_hash,
         "the recorded hash must be updated to the new content's hash"
@@ -331,7 +331,7 @@ async fn offline_install_with_a_cached_hash_succeeds() {
     let cache = SkillCache::at_root(cache_root.path());
 
     let zip_bytes = build_zip("v1");
-    let content_hash = format!("{:x}", sha2::Sha256::digest(&zip_bytes));
+    let content_hash = fastskill_core::utils::to_hex_lower(&sha2::Sha256::digest(&zip_bytes));
 
     // Prime the content cache with the previously-fetched, already-extracted
     // skill content under its recorded hash.


### PR DESCRIPTION
## Hash-stability evidence (read this first)

The critical risk in this bump is that fastskill content-addresses its local skill cache using SHA-256 hex strings (`sha256:<hex>`) as **cache keys and integrity checksums** (`change_detection.rs`, `install.rs`). Any change to the hex encoding — case, padding, length — would silently invalidate every cache entry or break a checksum comparison.

Ground truth was captured **before** touching any code (sha2 0.10.9, via the same `format!("{:x}", ...)` call pattern used throughout the repo) and re-captured **after** the bump + fix (sha2 0.11.0, via the new helper). They are byte-for-byte identical:

| input | before (0.10.9) | after (0.11.0) |
|---|---|---|
| `b"hello world"` | `b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9` | `b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9` |
| `b""` | `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` | `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` |
| binary bytes `[0,1,2,3,255,254,253,128,127,10,13,0]` | `2f4b84bcabcee64f8855ea93d4c15106e6755949a7808ca32f5af142a67c6b55` | `2f4b84bcabcee64f8855ea93d4c15106e6755949a7808ca32f5af142a67c6b55` |

The `hello world` value also matches an independent cross-check: `echo -n "hello world" | sha256sum` → same string.

## Why #140 (dependabot) failed to compile

`digest` 0.11 (a transitive dep of `sha2`) replaced `generic-array` with `hybrid-array`. `Sha256::digest()` / `.finalize()` now return `hybrid_array::Array<u8, N>` instead of `GenericArray<u8, N>`, and **`hybrid_array::Array` does not implement `LowerHex`**. This repo formats hashes with `format!("{:x}", ...)` at 12 call sites across 9 files — every one failed to compile under `sha2` 0.11.

## Fix

`hex` was not already a workspace dependency, so rather than add a new dependency for one function, this adds a small local helper — `fastskill_core::utils::to_hex_lower(bytes: &[u8]) -> String` — and switches all 12 call sites to it. Its output is byte-for-byte identical to the old `{:x}` formatting (lowercase, zero-padded, no separators), which is exactly what the hash-stability table above proves.

Changed sites:
- `crates/fastskill-core/src/core/change_detection.rs` — `calculate_skill_hash` (build-cache key)
- `crates/fastskill-core/src/core/install.rs` — `compute_local_tree_hash`, `hash_bytes` (×2)
- `crates/fastskill-core/src/core/reindex.rs` — `calculate_file_hash`
- `crates/fastskill-core/src/core/repository/client.rs` — test fixture
- `crates/fastskill-core/src/core/registry/client.rs` — checksum verification (production) + test fixture
- `crates/fastskill-core/tests/offline_verification_sweep_test.rs`, `http_handler_route_tests.rs`, `zip_url_cache_test.rs` (×2), `registry_content_cache_test.rs` — integration test fixtures

## New regression tests

- `utils::tests::test_to_hex_lower_matches_known_sha256` — pins `to_hex_lower` output for `b"hello world"` to the literal string above.
- `change_detection::tests::test_calculate_skill_hash_matches_known_value` — pins the actual cache-key producer's output (including the `sha256:` prefix) for a known single-file skill, independently cross-checked against Python `hashlib`.

Both exist specifically to catch a silent future format change before it reaches a cache key.

## Dependency graph note

`Cargo.lock` now carries two `sha2`/`digest` majors: our own code (`sha2.workspace = true` in both `fastskill-core` and `fastskill-cli`) resolves to `sha2` 0.11.0 / `digest` 0.11.3 / `hybrid-array` 0.4.14 everywhere. `pest_meta` (a build-dependency, transitively via `config`→`json5`) and `aikit-textgrad` (external crate) remain on `sha2` 0.10.9; `hmac`/`pbkdf2`/`sha1`/`zip` remain on `digest` 0.10.7. None of these cross our own API boundaries — this is expected and does not affect the hash-stability guarantee above.

## Supersedes

Supersedes #140 (dependabot), which failed to compile and had gone stale with lockfile conflicts.

## Verification run locally

- `cargo build --all-features` — clean
- `cargo clippy --workspace --all-targets --all-features` — 0 errors (pre-existing warnings only, in files untouched by this PR)
- `cargo nextest run --retries 3 -E 'not test(install_e2e_tests)'` — 1151 passed, 15 skipped
- same with `--all-features` — 1151 passed, 15 skipped
- `cargo fmt --all -- --check` — clean
- No insta snapshot diffs were produced by this change.