### PR TITLE
[WAIT FOR GREEN BEFORE MERGING] build(deps): bump zip from 0.6.6 to 2.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
  "tracing",
  "uuid",
  "walkdir",
- "zip 2.4.2",
+ "zip",
 ]
 
 [[package]]
@@ -1381,7 +1381,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "wiremock",
- "zip 0.6.6",
+ "zip",
 ]
 
 [[package]]
@@ -1428,7 +1428,7 @@ dependencies = [
  "validator",
  "walkdir",
  "wiremock",
- "zip 0.6.6",
+ "zip",
 ]
 
 [[package]]
@@ -5796,18 +5796,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ walkdir = "2.5"
 fs2 = "0.4"
 
 # Archive handling
-zip = { version = "0.6", default-features = false, features = ["deflate"] }
+zip = { version = "2.4", default-features = false, features = ["deflate"] }
 
 # HTTP client for embedding API (rustls for musl compatibility)
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls"] }

--- a/crates/fastskill-cli/src/commands/add/mod.rs
+++ b/crates/fastskill-cli/src/commands/add/mod.rs
@@ -911,13 +911,13 @@ mod tests {
         let server = MockServer::start().await;
         let zip_bytes = {
             use std::io::Write;
-            use zip::write::FileOptions;
+            use zip::write::SimpleFileOptions;
             let mut buf = Vec::new();
             {
                 let cursor = std::io::Cursor::new(&mut buf);
                 let mut writer = zip::ZipWriter::new(cursor);
                 let opts =
-                    FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+                    SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
                 writer.start_file("zip-url-skill/SKILL.md", opts).unwrap();
                 writer
                     .write_all(

--- a/crates/fastskill-cli/src/commands/add/sources.rs
+++ b/crates/fastskill-cli/src/commands/add/sources.rs
@@ -470,12 +470,13 @@ mod tests {
     /// Build an in-memory zip containing the given (path, contents) entries.
     fn build_zip(entries: &[(&str, &str)]) -> Vec<u8> {
         use std::io::Write;
-        use zip::write::FileOptions;
+        use zip::write::SimpleFileOptions;
         let mut buf = Vec::new();
         {
             let cursor = std::io::Cursor::new(&mut buf);
             let mut writer = zip::ZipWriter::new(cursor);
-            let opts = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+            let opts =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
             for (name, contents) in entries {
                 writer.start_file(*name, opts).unwrap();
                 writer.write_all(contents.as_bytes()).unwrap();

--- a/crates/fastskill-cli/src/utils/install_utils.rs
+++ b/crates/fastskill-cli/src/utils/install_utils.rs
@@ -580,12 +580,13 @@ mod tests {
     /// Build an in-memory zip containing a single skill under `test-skill/`.
     fn build_skill_zip() -> Vec<u8> {
         use std::io::Write;
-        use zip::write::FileOptions;
+        use zip::write::SimpleFileOptions;
         let mut buf = Vec::new();
         {
             let cursor = std::io::Cursor::new(&mut buf);
             let mut writer = zip::ZipWriter::new(cursor);
-            let opts = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+            let opts =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
             writer.start_file("test-skill/SKILL.md", opts).unwrap();
             writer.write_all(VALID_SKILL_MD.as_bytes()).unwrap();
             writer.finish().unwrap();

--- a/crates/fastskill-core/src/core/install.rs
+++ b/crates/fastskill-core/src/core/install.rs
@@ -1699,12 +1699,13 @@ mod tests {
 
     fn build_skill_zip() -> Vec<u8> {
         use std::io::Write;
-        use zip::write::FileOptions;
+        use zip::write::SimpleFileOptions;
         let mut buf = Vec::new();
         {
             let cursor = std::io::Cursor::new(&mut buf);
             let mut writer = zip::ZipWriter::new(cursor);
-            let opts = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+            let opts =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
             writer.start_file("test-skill/SKILL.md", opts).unwrap();
             writer.write_all(VALID_SKILL_MD.as_bytes()).unwrap();
             writer.finish().unwrap();
@@ -2267,12 +2268,12 @@ mod tests {
 
     fn build_local_skill_zip(compression: zip::CompressionMethod) -> Vec<u8> {
         use std::io::Write;
-        use zip::write::FileOptions;
+        use zip::write::SimpleFileOptions;
         let mut buf = Vec::new();
         {
             let cursor = std::io::Cursor::new(&mut buf);
             let mut writer = zip::ZipWriter::new(cursor);
-            let opts = FileOptions::default().compression_method(compression);
+            let opts = SimpleFileOptions::default().compression_method(compression);
             writer.start_file("test-skill/SKILL.md", opts).unwrap();
             writer.write_all(VALID_SKILL_MD.as_bytes()).unwrap();
             writer.finish().unwrap();

--- a/crates/fastskill-core/src/storage/zip.rs
+++ b/crates/fastskill-core/src/storage/zip.rs
@@ -267,7 +267,7 @@ mod tests {
     use std::fs::File;
     use std::io::Write;
     use tempfile::TempDir;
-    use zip::write::FileOptions;
+    use zip::write::SimpleFileOptions;
     use zip::ZipWriter;
 
     /// Helper to create a ZIP archive with specified entries
@@ -277,7 +277,8 @@ mod tests {
 
         let file = File::create(&zip_path).unwrap();
         let mut zip = ZipWriter::new(file);
-        let options = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
 
         for (name, content) in entries {
             if name.ends_with('/') {
@@ -451,7 +452,8 @@ mod tests {
         let zip_path = temp_dir.path().join("test.zip");
         let file = File::create(&zip_path).unwrap();
         let mut zip = ZipWriter::new(file);
-        let options = FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
         for (name, content) in entries {
             zip.start_file(*name, options).unwrap();
             zip.write_all(content).unwrap();
@@ -466,7 +468,8 @@ mod tests {
         let zip_path = temp_dir.path().join("many.zip");
         let file = File::create(&zip_path).unwrap();
         let mut zip = ZipWriter::new(file);
-        let options = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
         for i in 0..n {
             zip.start_file(format!("f{}.txt", i), options).unwrap();
             zip.write_all(b"x").unwrap();
@@ -627,7 +630,8 @@ mod tests {
         {
             let file = File::create(&zip_path).unwrap();
             let mut zip = ZipWriter::new(file);
-            let options = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+            let options =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
             zip.add_symlink("link", "/etc/passwd", options).unwrap();
             zip.finish().unwrap();
         }
@@ -698,15 +702,114 @@ mod tests {
 
     /// A file entry whose path already exists (duplicate entry) exercises the
     /// `outpath.exists()` canonicalize-existing branch.
+    ///
+    /// zip 2.x's `ZipWriter` rejects duplicate filenames at write time
+    /// (`InvalidArchive("Duplicate filename")`), so `create_test_zip` above can no
+    /// longer be used to build a fixture with two same-named entries. Nothing stops
+    /// an archive built by another tool from containing duplicate names though, and
+    /// real-world unzip semantics treat the last entry as authoritative, so this
+    /// hand-assembles the raw ZIP bytes to keep covering that read-path behavior.
+    fn crc32(data: &[u8]) -> u32 {
+        let mut crc: u32 = 0xFFFF_FFFF;
+        for &b in data {
+            crc ^= b as u32;
+            for _ in 0..8 {
+                let mask = (crc & 1).wrapping_neg();
+                crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+            }
+        }
+        !crc
+    }
+
+    fn build_duplicate_name_zip(name: &str, first: &[u8], second: &[u8]) -> Vec<u8> {
+        fn local_header(name: &[u8], data: &[u8]) -> Vec<u8> {
+            let mut h = Vec::new();
+            h.extend_from_slice(&0x0403_4b50u32.to_le_bytes());
+            h.extend_from_slice(&20u16.to_le_bytes()); // version needed
+            h.extend_from_slice(&0u16.to_le_bytes()); // flags
+            h.extend_from_slice(&0u16.to_le_bytes()); // method: stored
+            h.extend_from_slice(&0u16.to_le_bytes()); // mod time
+            h.extend_from_slice(&0u16.to_le_bytes()); // mod date
+            h.extend_from_slice(&crc32(data).to_le_bytes());
+            h.extend_from_slice(&(data.len() as u32).to_le_bytes()); // compressed size
+            h.extend_from_slice(&(data.len() as u32).to_le_bytes()); // uncompressed size
+            h.extend_from_slice(&(name.len() as u16).to_le_bytes());
+            h.extend_from_slice(&0u16.to_le_bytes()); // extra len
+            h.extend_from_slice(name);
+            h
+        }
+
+        fn central_header(offset: u32, name: &[u8], data: &[u8]) -> Vec<u8> {
+            let mut c = Vec::new();
+            c.extend_from_slice(&0x0201_4b50u32.to_le_bytes());
+            c.extend_from_slice(&20u16.to_le_bytes()); // version made by
+            c.extend_from_slice(&20u16.to_le_bytes()); // version needed
+            c.extend_from_slice(&0u16.to_le_bytes()); // flags
+            c.extend_from_slice(&0u16.to_le_bytes()); // method
+            c.extend_from_slice(&0u16.to_le_bytes()); // time
+            c.extend_from_slice(&0u16.to_le_bytes()); // date
+            c.extend_from_slice(&crc32(data).to_le_bytes());
+            c.extend_from_slice(&(data.len() as u32).to_le_bytes());
+            c.extend_from_slice(&(data.len() as u32).to_le_bytes());
+            c.extend_from_slice(&(name.len() as u16).to_le_bytes());
+            c.extend_from_slice(&0u16.to_le_bytes()); // extra len
+            c.extend_from_slice(&0u16.to_le_bytes()); // comment len
+            c.extend_from_slice(&0u16.to_le_bytes()); // disk number
+            c.extend_from_slice(&0u16.to_le_bytes()); // internal attrs
+            c.extend_from_slice(&0u32.to_le_bytes()); // external attrs
+            c.extend_from_slice(&offset.to_le_bytes());
+            c.extend_from_slice(name);
+            c
+        }
+
+        let name_bytes = name.as_bytes();
+        let mut bytes = Vec::new();
+
+        let offset1 = bytes.len() as u32;
+        bytes.extend_from_slice(&local_header(name_bytes, first));
+        bytes.extend_from_slice(first);
+
+        let offset2 = bytes.len() as u32;
+        bytes.extend_from_slice(&local_header(name_bytes, second));
+        bytes.extend_from_slice(second);
+
+        let cd_start = bytes.len() as u32;
+        let cd1 = central_header(offset1, name_bytes, first);
+        let cd2 = central_header(offset2, name_bytes, second);
+        bytes.extend_from_slice(&cd1);
+        bytes.extend_from_slice(&cd2);
+        let cd_size = (cd1.len() + cd2.len()) as u32;
+
+        bytes.extend_from_slice(&0x0605_4b50u32.to_le_bytes());
+        bytes.extend_from_slice(&0u16.to_le_bytes()); // disk number
+        bytes.extend_from_slice(&0u16.to_le_bytes()); // disk with cd
+        bytes.extend_from_slice(&2u16.to_le_bytes()); // entries this disk
+        bytes.extend_from_slice(&2u16.to_le_bytes()); // total entries
+        bytes.extend_from_slice(&cd_size.to_le_bytes());
+        bytes.extend_from_slice(&cd_start.to_le_bytes());
+        bytes.extend_from_slice(&0u16.to_le_bytes()); // comment len
+
+        bytes
+    }
+
     #[test]
     fn test_extract_duplicate_file_entry() {
-        let (_t, zip_path) = create_test_zip(&[("dup.txt", b"first"), ("dup.txt", b"second")]);
+        let bytes = build_duplicate_name_zip("dup.txt", b"first", b"second");
+        let temp_dir = TempDir::new().unwrap();
+        let zip_path = temp_dir.path().join("test.zip");
+        std::fs::write(&zip_path, &bytes).unwrap();
+
         let extract_dir = TempDir::new().unwrap();
         let handler = ZipHandler::new().unwrap();
         handler
             .extract_to_dir(&zip_path, extract_dir.path())
             .unwrap();
         assert!(extract_dir.path().join("dup.txt").exists());
+        assert_eq!(
+            std::fs::read_to_string(extract_dir.path().join("dup.txt")).unwrap(),
+            "second",
+            "last entry should win, matching real-world unzip semantics"
+        );
     }
 
     /// A directory entry that appears *after* a file already created it exercises

--- a/crates/fastskill-core/src/validation/zip_validator.rs
+++ b/crates/fastskill-core/src/validation/zip_validator.rs
@@ -38,7 +38,7 @@ mod tests {
     use std::io::Write;
     use std::path::PathBuf;
     use tempfile::TempDir;
-    use zip::write::FileOptions;
+    use zip::write::SimpleFileOptions;
     use zip::ZipWriter;
 
     fn write_zip(entries: &[(&str, &[u8])]) -> (TempDir, PathBuf) {
@@ -46,7 +46,8 @@ mod tests {
         let zip_path = temp_dir.path().join("test.zip");
         let file = File::create(&zip_path).unwrap();
         let mut zip = ZipWriter::new(file);
-        let options = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
         for (name, content) in entries {
             zip.start_file(*name, options).unwrap();
             zip.write_all(content).unwrap();
@@ -103,7 +104,8 @@ mod tests {
         let zip_path = temp_dir.path().join("many.zip");
         let file = File::create(&zip_path).unwrap();
         let mut zip = ZipWriter::new(file);
-        let options = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
         for i in 0..(MAX_ENTRIES + 1) {
             zip.start_file(format!("f{i}.txt"), options).unwrap();
             zip.write_all(b"x").unwrap();

--- a/crates/fastskill-core/tests/http_handler_route_tests.rs
+++ b/crates/fastskill-core/tests/http_handler_route_tests.rs
@@ -632,12 +632,12 @@ async fn update_version_check_mode_ignores_version() {
 
 fn build_zip_with_skill_md(skill_dir_name: &str, skill_md: &str) -> Vec<u8> {
     use std::io::Write;
-    use zip::write::FileOptions;
+    use zip::write::SimpleFileOptions;
     let mut buf = Vec::new();
     {
         let cursor = std::io::Cursor::new(&mut buf);
         let mut writer = zip::ZipWriter::new(cursor);
-        let opts = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        let opts = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
         writer
             .start_file(format!("{skill_dir_name}/SKILL.md"), opts)
             .unwrap();

--- a/crates/fastskill-core/tests/offline_verification_sweep_test.rs
+++ b/crates/fastskill-core/tests/offline_verification_sweep_test.rs
@@ -226,12 +226,12 @@ fn skill_md(version: &str) -> String {
 
 fn build_zip(version: &str) -> Vec<u8> {
     use std::io::Write;
-    use zip::write::FileOptions;
+    use zip::write::SimpleFileOptions;
     let mut buf = Vec::new();
     {
         let cursor = std::io::Cursor::new(&mut buf);
         let mut writer = zip::ZipWriter::new(cursor);
-        let opts = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        let opts = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
         writer
             .start_file(format!("{SKILL_ID}/SKILL.md"), opts)
             .unwrap();

--- a/crates/fastskill-core/tests/registry_content_cache_test.rs
+++ b/crates/fastskill-core/tests/registry_content_cache_test.rs
@@ -40,12 +40,12 @@ fn skill_md(version: &str) -> String {
 
 fn build_zip(version: &str) -> Vec<u8> {
     use std::io::Write;
-    use zip::write::FileOptions;
+    use zip::write::SimpleFileOptions;
     let mut buf = Vec::new();
     {
         let cursor = std::io::Cursor::new(&mut buf);
         let mut writer = zip::ZipWriter::new(cursor);
-        let opts = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        let opts = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
         writer
             .start_file(format!("{SKILL_ID}/SKILL.md"), opts)
             .unwrap();

--- a/crates/fastskill-core/tests/zip_url_cache_test.rs
+++ b/crates/fastskill-core/tests/zip_url_cache_test.rs
@@ -36,12 +36,12 @@ fn skill_md(marker: &str) -> String {
 /// baked into the content so different builds are byte-distinguishable.
 fn build_zip(marker: &str) -> Vec<u8> {
     use std::io::Write;
-    use zip::write::FileOptions;
+    use zip::write::SimpleFileOptions;
     let mut buf = Vec::new();
     {
         let cursor = std::io::Cursor::new(&mut buf);
         let mut writer = zip::ZipWriter::new(cursor);
-        let opts = FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        let opts = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
         writer
             .start_file(format!("{SKILL_ID}/SKILL.md"), opts)
             .unwrap();

--- a/tests/http_tests.rs
+++ b/tests/http_tests.rs
@@ -19,7 +19,7 @@ use std::process::{Child, Command};
 use std::thread;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
-use zip::write::FileOptions;
+use zip::write::SimpleFileOptions;
 
 fn wait_for_port(port: u16, timeout_secs: u64) -> bool {
     let start = Instant::now();
@@ -51,7 +51,8 @@ fn create_test_publish_zip() -> Vec<u8> {
     let mut cursor = std::io::Cursor::new(Vec::new());
     {
         let mut zip = zip::ZipWriter::new(&mut cursor);
-        let options = FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
 
         zip.start_file("SKILL.md", options).expect("start SKILL.md");
         zip.write_all(b"---\nname: demo-skill\ndescription: Demo\n---\n\n# Demo")


### PR DESCRIPTION
## Summary

- Bumps `zip` from `0.6.6` to `2.4.2` in the workspace root `Cargo.toml` (`[workspace.dependencies]`). Both `fastskill-core` and `fastskill-cli` consume it via `zip.workspace = true` — no crate-level version pins to update separately.
- **What broke and why**: `zip::write::FileOptions` became generic over a compression-extension type parameter in 2.x (`FileOptions<'k, T: FileOptionExtension>`), so `FileOptions::default().compression_method(...)` no longer type-infers (`E0283`). Fixed by switching to `zip::write::SimpleFileOptions::default()`, the documented drop-in replacement, and updating the corresponding `use` statements.
- **All 16 changed call sites are test-only** — every one lives inside a `#[cfg(test)] mod tests` block or under `tests/`. This repo never writes ZIP archives outside of test fixtures; production code only reads archives.
- **Production read path and its path-traversal/symlink protection are untouched.** `ZipArchive::new`, `.len()`, `.by_index()`, `file.name()`, `.is_dir()`, `.size()`, `.compressed_size()`, `.unix_mode()` are semantically identical between 0.6.6 and 2.4.2. The containment check in `crates/fastskill-core/src/storage/zip.rs` (fixed for Windows in #236, validates `file.name()` directly rather than using `enclosed_name()`/`mangled_name()`) sits entirely outside the changed test blocks — verified line-by-line in the diff.
- One test needed a behavioral adjustment: `test_extract_duplicate_file_entry` in `storage/zip.rs` used to build its fixture via `ZipWriter::start_file` with two identically-named entries. zip 2.x's writer now rejects duplicate filenames at write time (`InvalidArchive("Duplicate filename")`), so that fixture can no longer be constructed via this crate's own writer. The test now hand-assembles the raw ZIP bytes instead — and this let us confirm the **production read path is unaffected**: a duplicate-name archive built by an external tool (Python's `zipfile`, which still permits this) still extracts successfully via `extract_to_dir`, with the last entry winning, matching real-world unzip semantics and 0.6.6's prior behavior.
- **Deduplicates `zip` in `Cargo.lock`.** `aikit-sdk` already pulled in `zip 2.4.2` transitively, so before this change the lockfile carried two copies (`0.6.6` + `2.4.2`); after, there's a single `zip` entry.
- Supersedes/closes #106 (stale Dependabot PR, 4.5 months old, failed to compile, had lockfile conflicts) on merge.

## Test plan

- [x] `cargo build --all-features` — clean
- [x] `cargo clippy --workspace --all-targets --all-features` — exit 0, only pre-existing unrelated warnings (unused import in `core/sources/mod.rs`, `panic!` in test code in `storage/git.rs` and CLI tests)
- [x] `cargo nextest run --retries 3 -E 'not test(install_e2e_tests)'` — 1147 passed, 15 skipped
- [x] same, with `--all-features` — 1147 passed, 15 skipped
- [x] `cargo nextest run -E 'test(zip)'` — 52/52 passed, including path-traversal (`test_safe_extract_rejects_path_traversal`, `test_safe_extract_rejects_absolute_paths`, `test_safe_extract_rejects_mixed_traversal`, `test_safe_extract_rejects_windows_path_traversal`, `test_safe_extract_does_not_create_dirs_outside_root`) and symlink-rejection (`test_extract_rejects_symlink_entry`, `test_extract_rejects_parent_symlink_escape`, `test_extract_rejects_dir_entry_symlink_escape`) tests, plus the adjusted `test_extract_duplicate_file_entry`
- [x] `cargo fmt --all -- --check` — clean
- [x] Confirmed `Cargo.lock` zip dedup: two `name = "zip"` blocks (0.6.6, 2.4.2) before → one (2.4.2) after
- [x] Local pre-commit/pre-push hooks (fmt, clippy, full nextest suite incl. e2e, doc build) all passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqmpE6bvMsDtWDjmUP9wfu