### PR TITLE
[WAIT FOR GREEN BEFORE MERGING] ci: serialize auto-release runs to stop the version-bump push race

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -21,6 +21,43 @@ permissions:
   contents: write
   actions: read
 
+# When several PRs merge to main back-to-back, each merge push triggers its own run of
+# this workflow, and every run tries to commit+push a version bump to main. Without
+# serialization these race: run A pushes its bump commit, then run B -- which had already
+# fetched main before A's push landed -- tries to push its own bump on top of the
+# now-stale tip and gets a plain (non-force) `git push` rejection:
+#
+#   ! [rejected]        main -> main (non-fast-forward)
+#   error: failed to push some refs to 'https://github.com/gofastskill/fastskill'
+#   hint: Updates were rejected because the tip of your current branch is behind
+#
+# Real occurrence: run 32085196409, triggered by the push of PR #246, failed at
+# "Commit version bump" with exactly this error because PR #245's auto-release run
+# pushed its own bump commit in between this run's checkout and its push. A later run
+# still wins and the release happens, so today this is cosmetic (red CI, not a stuck
+# release) -- but it will keep recurring on every merge burst, and in principle could
+# strand a bump if the "later run" also loses its race.
+#
+# `cancel-in-progress: false` is deliberate: cancelling a queued run mid-flight could
+# drop its version bump instead of just delaying it, which is worse than making it wait.
+# The group is keyed on `github.ref` (this workflow only ever runs on push to `main`, so
+# in practice this is a single global lane) rather than `github.sha`, precisely so that
+# runs from *different* commits queue behind each other instead of racing.
+#
+# Serializing is only correct because this workflow's "Checkout code" step (below) does
+# NOT pin to the commit that triggered the run. It passes no `ref:`, so actions/checkout
+# resolves the push event's branch ref (`refs/heads/main`) and runs
+# `git checkout -B main refs/remotes/origin/main` -- i.e. it re-fetches and checks out
+# whatever main's tip *is at the time the step executes*, not a snapshot of `github.sha`
+# from when the run was queued (confirmed in run 32085196409's log: the "Checking out
+# the ref" group shows exactly that checkout command). So once runs are serialized, a
+# queued run's checkout happens strictly after the previous run's push, and it picks up
+# that bump commit as its new base -- no stale-ref fix (explicit `ref: main`, or a
+# pre-push `git pull --rebase`) is needed on top of the concurrency group.
+concurrency:
+  group: auto-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   auto-release:
     name: Auto Release

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -38,8 +38,17 @@ permissions:
 # release) -- but it will keep recurring on every merge burst, and in principle could
 # strand a bump if the "later run" also loses its race.
 #
-# `cancel-in-progress: false` is deliberate: cancelling a queued run mid-flight could
-# drop its version bump instead of just delaying it, which is worse than making it wait.
+# `cancel-in-progress: false` is deliberate: cancelling a run mid-flight could drop its
+# version bump instead of just delaying it, which is worse than making it wait.
+#
+# Note what this does NOT prevent, because it is GitHub's behaviour and not something
+# `cancel-in-progress` controls: only ONE run per group may sit in the pending queue, so
+# when a third run arrives while one is running and one is pending, the *pending* one is
+# cancelled in favour of the newer arrival. A burst of N merges therefore yields the
+# first run plus the last, not N runs -- so it produces roughly one release covering the
+# whole burst rather than one release per merge (today's burst of four produced 0.9.173
+# through 0.9.176). That is a deliberate improvement, not a loss: the surviving run
+# checks out main's tip, so its release still contains every merged change.
 # The group is keyed on `github.ref` (this workflow only ever runs on push to `main`, so
 # in practice this is a single global lane) rather than `github.sha`, precisely so that
 # runs from *different* commits queue behind each other instead of racing.


### PR DESCRIPTION
## Observed failure

Four PRs merged into `main` within ~30 seconds. Each merge push triggers `.github/workflows/auto-release.yml`, which bumps the version and pushes the bump commit back to `main`. The runs raced; one failed at `Commit version bump`:

```
! [rejected]        main -> main (non-fast-forward)
error: failed to push some refs to 'https://github.com/gofastskill/fastskill'
hint: Updates were rejected because the tip of your current branch is behind its remote counterpart.
```

Real failing run: https://github.com/gofastskill/fastskill/actions/runs/32085196409 (triggered by PR #246's merge; PR #245's auto-release run pushed its own bump commit in between this run's checkout and its push). A later run still wins and the release happens today, so it's cosmetic (red CI, not a stuck release) — but it recurs on every merge burst and could in principle strand a bump.

No workflow in this repo had a `concurrency:` block.

## Fix

Added a `concurrency:` block to `auto-release.yml`:

```yaml
concurrency:
  group: auto-release-${{ github.ref }}
  cancel-in-progress: false
```

- **Group key**: `github.ref` rather than `github.sha`. This workflow only ever runs on `push` to `main`, so in practice this is effectively one global lane per workflow — the point is that runs triggered by *different* commits (which is exactly what races: PR #245's push and PR #246's push) get funneled into the same queue instead of running in parallel.
- **`cancel-in-progress: false`**: cancelling a queued run mid-flight could drop its version bump instead of just delaying it, which is worse than making it wait.

## Why serializing alone is sufficient (the subtle part)

Queuing only helps if the second run, once it starts, operates on the *post-first-run* state of `main`. I checked what `actions/checkout` in this workflow actually pins to:

`.github/workflows/auto-release.yml:42-46` (pre-fix, unchanged by this PR):
```yaml
      - name: Checkout code
        uses: actions/checkout@v4
        with:
          fetch-depth: 0
          token: ${{ steps.app-token.outputs.token }}
```

No `ref:` is passed. I pulled the raw log for the failing run (`gh run view 32085196409 --log`) to see what actions/checkout actually does in that case — it does **not** pin to `github.sha`:

```
Auto Release  Checkout code  ##[group]Checking out the ref
Auto Release  Checkout code  [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
Auto Release  Checkout code  Switched to a new branch 'main'
```

Because the workflow only triggers on `push` to a branch (not a PR or a tag), `github.context.ref` resolves to `refs/heads/main`, and actions/checkout treats that as a **branch ref**, not a pinned commit: it fetches all refs (`fetch-depth: 0`) and does `git checkout -B main refs/remotes/origin/main`, i.e. whatever `main`'s tip is *at the moment the step executes*, not a snapshot of the commit that triggered the run. (In that specific run the checked-out SHA happened to equal `github.sha` only because no other push had landed yet by the time its checkout ran — it was the first of the four to reach that step.)

**Consequence**: once runs are serialized, a queued run's "Checkout code" step only executes after the previous run's `git push` has landed (concurrency queueing gates the whole job, including checkout — it doesn't pre-fetch before the queue slot opens). So the queued run picks up the prior run's bump commit as its new base and its own push is a clean fast-forward. No `ref: main` override or pre-push `git pull --rebase` is needed on top of the concurrency group — I verified the smallest change (just the concurrency block) is already correct, per the evidence above, rather than reflexively adding a resync step.

One second-order effect worth calling out (not fixed here, not the reported bug): since a serialized later run re-reads `Cargo.toml` and the last tag fresh, if an earlier run in the burst already bumped+tagged, the later run's `Get current and last released versions` step will find `CURRENT == LAST` and skip its own bump (`needs_bump=false`) — so a burst of N merges now produces exactly one net version bump instead of racing to produce N, which matches today's already-observed "a later run wins" behavior. It will still call `Trigger release workflow` again for that same (already-existing) tag, which downstream `release.yml` already handles idempotently (`Create and push tag` skips if the tag exists; `Delete existing release if present` deletes+recreates). This is unverified end-to-end since the workflow only triggers on real pushes to `main` and can't be exercised from a branch/PR.

## `release.yml`: no change

`release.yml` is tag-triggered (`push: tags: v*.*.*`) plus `workflow_dispatch`, not branch-push-triggered, so it doesn't have this workflow's specific exposure: given the auto-release skip-if-already-tagged logic above, a merge burst now converges on a single tag/version, so distinct `release.yml` runs operate on distinct, non-colliding release objects and matrix artifacts (uploaded under per-target names, keyed by version). The one real overlap risk — the double trigger per tag (tag-push + the explicit `workflow_dispatch` call `auto-release.yml` makes) racing on the same release — is already handled by the existing "delete existing release if present, then recreate" idempotency in `create-release`, and any residual race on the downstream `homebrew-cli`/`scoop-bucket` pushes is a separate, pre-existing concern orthogonal to the bug reported here (different repos, different trigger, doesn't reproduce the non-fast-forward failure). Not changing it purely for symmetry.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/auto-release.yml')); print('YAML OK')"` → `YAML OK`
- Local pre-commit/pre-push hooks (fmt, clippy, full nextest suite, docs build) all passed.
- **Cannot be tested end-to-end**: this workflow only triggers on pushes to `main`, so the actual race/queueing behavior is unverified beyond the log-based reasoning above. Watching this PR's own CI checks next.

## Test plan

- [ ] CI checks on this PR are green
- [ ] After merge, watch the next burst of merges (or manually trigger overlapping pushes) to confirm runs queue instead of racing, and that a queued run's push is a clean fast-forward