### PR TITLE
fix(test): close two cwd-mutex gaps causing flaky tests

### DIFF
--- a/crates/fastskill-cli/src/commands/update.rs
+++ b/crates/fastskill-cli/src/commands/update.rs
@@ -531,6 +531,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_update_invalid_strategy() {
+        let _lock = fastskill_core::test_utils::DIR_MUTEX
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+
         let temp_dir = TempDir::new().unwrap();
 
         // Get original directory immediately and handle potential errors

--- a/crates/fastskill-core/src/search/remote.rs
+++ b/crates/fastskill-core/src/search/remote.rs
@@ -132,13 +132,11 @@ fn load_repository_definitions() -> Result<Vec<RepositoryDefinition>, SearchErro
 )]
 mod tests {
     use super::*;
-    use once_cell::sync::Lazy;
+    use crate::test_utils::DIR_MUTEX as CWD_LOCK;
     use std::fs;
     use std::path::Path;
-    use std::sync::{Mutex, MutexGuard};
+    use std::sync::MutexGuard;
     use tempfile::TempDir;
-
-    static CWD_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
     struct CurrentDirGuard {
         previous: std::path::PathBuf,
@@ -159,7 +157,7 @@ mod tests {
     }
 
     fn enter_temp_workspace() -> (MutexGuard<'static, ()>, TempDir, CurrentDirGuard) {
-        let lock = CWD_LOCK.lock().expect("failed to lock cwd mutex");
+        let lock = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
         let guard = CurrentDirGuard::set(temp_dir.path());
         (lock, temp_dir, guard)


### PR DESCRIPTION
## Root cause

Two intermittent test failures, both caused by the same class of bug: a test
mutates the process-global current working directory without synchronizing
against *every other* test in the same test binary that does the same. When
`cargo test` runs multi-threaded (the default), unsynchronized `cwd` changes
are a data race — one test's `set_current_dir` can be observed by another
test running concurrently on a different thread, and cwd-dependent code
(e.g. manifest resolution, which walks up from cwd looking for
`skill-project.toml`) reads the wrong directory.

**1. `commands::registry::repo_ops::tests::test_execute_add_then_list`
(fastskill-cli)**

This test itself correctly takes `fastskill_core::test_utils::DIR_MUTEX`.
The actual gap was a sibling in the same binary:
`commands::update::tests::test_execute_update_invalid_strategy` called
`std::env::set_current_dir()` (via its own `DirGuard`) **without** taking
`DIR_MUTEX`, unlike every other cwd-mutating test in the crate. Any test
that resolves `skill-project.toml` (which is cwd-dependent even though it
never mentions cwd directly) could race against it.

**2. `search::remote::tests::remote_repo_filter_returns_repository_error_on_client_init_failure`
(fastskill-core)**

`search/remote.rs`'s test module defined its own **private** `CWD_LOCK`
static (`Lazy<Mutex<()>>`), separate from the crate-wide
`fastskill_core::test_utils::DIR_MUTEX` used by every other cwd-mutating
test in the crate (`core::install`, `core::change_detection`, etc.). Two
disjoint mutexes provide no mutual exclusion against each other — the
remote-search test (whose `execute_remote_search` depends on
`env::current_dir()` via `load_repository_definitions`) could race with
any concurrently-running test in `core::install` or elsewhere that changes
cwd under the shared lock.

## Fix

- `crates/fastskill-cli/src/commands/update.rs`: added the missing
  `DIR_MUTEX` acquisition to `test_execute_update_invalid_strategy`,
  matching its sibling tests in the same file.
- `crates/fastskill-core/src/search/remote.rs`: removed the private
  `CWD_LOCK` static and repointed the test module at the shared
  `crate::test_utils::DIR_MUTEX`, so all cwd-mutating tests in the crate
  serialize against the same lock instead of two independent ones.

Both fixes eliminate the shared-state race directly (unify on the one lock
that already exists) rather than adding new locking scope or serializing
the whole suite.

## Verification

Ran each command 5 consecutive full times, no `--test-threads=1`, no
retries/`#[ignore]`/sleeps added anywhere:

- `cargo test -p fastskill-cli --bin fastskill`: **228 passed, 0 failed** — 5/5 runs
- `cargo test -p fastskill-core --lib`: **460 passed, 0 failed** — 5/5 runs

`cargo fmt --all -- --check` passes. `cargo clippy --workspace --all-targets --all-features` exits 0 (pre-existing warnings only, none introduced by this change).

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HPWdJZDbVTzy3rBcgbP1E8