### PR TITLE
feat(lock): migrate v1.0.0 project locks instead of rejecting them

### DIFF
--- a/crates/fastskill-cli/tests/lock_migration_test.rs
+++ b/crates/fastskill-cli/tests/lock_migration_test.rs
@@ -7,13 +7,20 @@
 //!   re-saving it stripped those fields.
 //! - AC 18: v1.0.0 format files loaded without error (backward compat).
 //!
-//! The Origin/Resolved reshape (ADR-0005) removed the migrator entirely: any lock
-//! whose `metadata.version` isn't the current `LOCK_FORMAT_VERSION` ("3.0") is now
-//! rejected with an actionable `LockError::UnsupportedVersion` telling the caller to
-//! delete the lock file and re-run `fastskill install`. These tests now assert that
-//! rejection instead of a successful migration.
+//! The Origin/Resolved reshape (ADR-0005) removed the migrator entirely: any lock whose
+//! `metadata.version` wasn't the current `LOCK_FORMAT_VERSION` ("3.0") was rejected with
+//! an actionable `LockError::UnsupportedVersion` telling the caller to delete the lock and
+//! re-run `fastskill install`.
+//!
+//! That rejection has now been REVERSED for the v1.0.0 project lock, and these tests
+//! assert migration again. The reason is specific to what a lock is: it records *pinned*
+//! versions. "Delete it and re-run install" re-resolves every dependency against whatever
+//! is current, which silently upgrades a working installation — a real cost that the
+//! reshape's clean break did not account for. Rejection is still correct for any version
+//! we have no specimen of, and for the global lock, which is untouched here.
 
 use fastskill_core::core::lock::{LockError, ProjectSkillsLock, LOCK_FORMAT_VERSION};
+use fastskill_core::core::origin::Origin;
 use std::fs;
 use tempfile::TempDir;
 
@@ -35,32 +42,76 @@ depth = 0
 "#;
 
 #[test]
-fn pre_origin_lock_is_rejected_not_migrated() {
-    // Superseded AC 11: there is no migrator anymore. A v1.0.0 lock (predating the
-    // Origin/Resolved reshape) must be rejected with an actionable error rather
-    // than silently loaded, stripped, and re-saved.
+fn pre_origin_lock_is_migrated_not_rejected() {
+    // Restores AC 11's intent: a v1.0.0 lock loads, and its pins survive. The fixture's
+    // entry is a legacy `source = "source"` (a configured-repository install), which is
+    // now `Origin::Repository` -- including the version constraint the source table
+    // carried, since dropping it would turn a pinned dependency into "newest allowed".
     let tmp = TempDir::new().unwrap();
     let lock_path = tmp.path().join("skills.lock");
     fs::write(&lock_path, V1_LOCK_FIXTURE).unwrap();
 
-    let err = ProjectSkillsLock::load_from_file(&lock_path).unwrap_err();
-    match err {
-        LockError::UnsupportedVersion { found } => assert_eq!(found, "1.0.0"),
-        other => panic!("expected UnsupportedVersion, got {other:?}"),
+    let lock = ProjectSkillsLock::load_from_file(&lock_path)
+        .expect("a v1.0.0 project lock must now migrate rather than fail");
+
+    assert_eq!(lock.metadata.version, LOCK_FORMAT_VERSION);
+    assert_eq!(lock.skills.len(), 1);
+
+    let entry = &lock.skills[0];
+    assert_eq!(entry.id, "legacy-skill");
+    assert_eq!(entry.name, "Legacy Skill");
+    // The pinned version is the whole point of migrating rather than re-resolving.
+    assert_eq!(entry.resolved.version, "1.0.0");
+    match &entry.origin {
+        Origin::Repository {
+            repo,
+            skill,
+            version,
+        } => {
+            assert_eq!(repo, "default");
+            assert_eq!(skill, "legacy-skill");
+            assert!(
+                version.is_some(),
+                "the requested constraint must survive migration"
+            );
+        }
+        other => panic!("expected a repository origin, got {other:?}"),
     }
+    // v1.0.0 never recorded a commit hash, so absent is honest rather than lossy.
+    assert!(entry.resolved.commit_hash.is_none());
 }
 
 #[test]
-fn v1_lock_is_rejected_before_touching_skill_shape() {
-    // Superseded AC 18: backward compat with pre-3.0 formats is intentionally
-    // dropped. The lightweight version pre-check must reject the file before any
-    // attempt to deserialize the (now-incompatible) `[[skills]]` shape.
+fn loading_a_v1_lock_does_not_rewrite_it() {
+    // Replaces AC 18's rejection check. Backward compat is restored, but reading must
+    // stay read-only: a legacy lock keeps working untouched until something saves it
+    // for its own reasons. Rewriting on read would mutate a file the user never asked
+    // to change, and would do it on every command.
     let tmp = TempDir::new().unwrap();
     let lock_path = tmp.path().join("skills.lock");
     fs::write(&lock_path, V1_LOCK_FIXTURE).unwrap();
 
-    let result = ProjectSkillsLock::load_from_file(&lock_path);
-    assert!(matches!(result, Err(LockError::UnsupportedVersion { .. })));
+    let _ = ProjectSkillsLock::load_from_file(&lock_path).unwrap();
+
+    let on_disk = fs::read_to_string(&lock_path).unwrap();
+    assert!(
+        on_disk.contains("version = \"1.0.0\""),
+        "load must leave the file alone, got:\n{on_disk}"
+    );
+}
+
+#[test]
+fn a_lock_version_we_have_no_specimen_of_is_still_rejected() {
+    // Migration is only safe where the shape is known. Anything else -- including a
+    // version newer than this build -- must still fail loudly rather than be guessed at.
+    let tmp = TempDir::new().unwrap();
+    let lock_path = tmp.path().join("skills.lock");
+    fs::write(&lock_path, "[metadata]\nversion = \"2.0\"\n").unwrap();
+
+    match ProjectSkillsLock::load_from_file(&lock_path) {
+        Err(LockError::UnsupportedVersion { found }) => assert_eq!(found, "2.0"),
+        other => panic!("expected UnsupportedVersion, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/fastskill-core/src/core/lock.rs
+++ b/crates/fastskill-core/src/core/lock.rs
@@ -4,7 +4,7 @@
 //! - `ProjectSkillsLock`: deterministic, timestamp-free, for `skills.lock` at project root
 //! - `GlobalSkillsLock`: operational, with timestamps, for `global-skills.lock` in user config dir
 
-use crate::core::origin::{Origin, Resolved};
+use crate::core::origin::{GitRef, Origin, Resolved};
 use crate::core::skill_manager::SkillDefinition;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -14,6 +14,14 @@ use std::path::{Path, PathBuf};
 /// (Phase 0). Lock files from before this version cannot be read — see
 /// [`LockError::UnsupportedVersion`].
 pub const LOCK_FORMAT_VERSION: &str = "3.0";
+
+/// The pre-`Origin` project lock format, which [`ProjectSkillsLock::load_from_file`] migrates.
+///
+/// Only the project lock is migrated. The global lock's legacy shape carried operational
+/// timestamps (`installed_at` and friends) that the 1.0.0 project entries never had, and no
+/// specimen of a legacy global lock was available to verify against — so it keeps the
+/// original hard rejection rather than a migration written from guesswork.
+const LEGACY_PROJECT_LOCK_VERSION: &str = "1.0.0";
 
 // ── Project Lock ─────────────────────────────────────────────────────────────
 
@@ -65,16 +73,34 @@ impl ProjectSkillsLock {
         }
     }
 
+    /// Load the project lock, migrating a [`LEGACY_PROJECT_LOCK_VERSION`] file in memory.
+    ///
+    /// Migrating rather than rejecting matters here specifically because a lock records
+    /// *pinned* versions. Telling someone with a working installation to delete it and
+    /// re-run `install` re-resolves every dependency against whatever is current now — a
+    /// silent upgrade they did not ask for. Reading never writes; the 3.0 form reaches disk
+    /// only when something saves the lock for its own reasons.
     pub fn load_from_file(path: &Path) -> Result<Self, LockError> {
         if !path.exists() {
             return Err(LockError::NotFound(path.to_path_buf()));
         }
         let safe_path = path.canonicalize().map_err(LockError::Io)?;
         let content = std::fs::read_to_string(&safe_path).map_err(LockError::Io)?;
-        check_lock_format_version(&content)?;
-        let lock: ProjectSkillsLock =
-            toml::from_str(&content).map_err(|e| LockError::Parse(e.to_string()))?;
-        Ok(lock)
+
+        match read_lock_format_version(&content)?.as_str() {
+            LOCK_FORMAT_VERSION => {
+                toml::from_str(&content).map_err(|e| LockError::Parse(e.to_string()))
+            }
+            LEGACY_PROJECT_LOCK_VERSION => {
+                let legacy: LegacyProjectSkillsLock =
+                    toml::from_str(&content).map_err(|e| LockError::Parse(e.to_string()))?;
+                legacy.upgrade()
+            }
+            // Anything else — including a version newer than this build — is still refused.
+            found => Err(LockError::UnsupportedVersion {
+                found: found.to_string(),
+            }),
+        }
     }
 
     pub fn save_to_file(&self, path: &Path) -> Result<(), LockError> {
@@ -178,6 +204,191 @@ impl ProjectSkillsLock {
 
     fn sort_entries(&mut self) {
         self.skills.sort_by(|a, b| a.id.cmp(&b.id));
+    }
+}
+
+// ── Legacy project lock (format 1.0.0) ───────────────────────────────────────
+//
+// The pre-`Origin` project lock spelled provenance as flat `source_url`/`source_branch`
+// fields plus a nested `[skills.source]` table:
+//
+//     [[skills]]
+//     id = "example"
+//     version = "1.0.2"
+//     source_url = "https://github.com/org/repo"
+//     source_branch = "main"
+//     editable = false
+//     depth = 0
+//
+//     [skills.source]
+//     type = "git"
+//     url = "https://github.com/org/repo"
+//     branch = "main"
+//
+// Read-only support: nothing writes this shape, so there is no round trip to preserve.
+
+/// The nested `[skills.source]` table of a legacy entry.
+#[derive(Debug, Clone, Deserialize)]
+struct LegacyLockSource {
+    r#type: String,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    branch: Option<String>,
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    zip_url: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    skill: Option<String>,
+    /// The requested constraint for a repository install. Distinct from the entry-level
+    /// `version`, which is the concrete version that was resolved.
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    editable: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LegacyProjectLockedSkill {
+    id: String,
+    #[serde(default)]
+    name: Option<String>,
+    version: String,
+    #[serde(default)]
+    source: Option<LegacyLockSource>,
+    /// Flat fallbacks, present on every 1.0.0 entry even when `[skills.source]` is too.
+    #[serde(default)]
+    source_url: Option<String>,
+    #[serde(default)]
+    source_branch: Option<String>,
+    #[serde(default)]
+    dependencies: Vec<String>,
+    #[serde(default)]
+    groups: Vec<String>,
+    #[serde(default)]
+    editable: bool,
+    #[serde(default)]
+    depth: u32,
+    #[serde(default)]
+    parent_skill: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct LegacyProjectSkillsLock {
+    #[serde(default)]
+    skills: Vec<LegacyProjectLockedSkill>,
+}
+
+impl LegacyProjectLockedSkill {
+    fn upgrade(self) -> Result<ProjectLockedSkillEntry, LockError> {
+        let id = self.id;
+        let missing = |field: &str| {
+            LockError::Parse(format!(
+                "legacy lock entry '{id}' cannot be migrated: its source is '{field}' but that \
+             field is missing. Delete skills.lock and re-run `fastskill install` to rebuild it."
+            ))
+        };
+
+        // `[skills.source]` is authoritative; the flat `source_url`/`source_branch` fields are
+        // the fallback for entries that predate it.
+        let (kind, url, branch, path, zip_url, repo_name, repo_skill, src_editable, req_version) =
+            match self.source {
+                Some(s) => (
+                    s.r#type, s.url, s.branch, s.path, s.zip_url, s.name, s.skill, s.editable,
+                    s.version,
+                ),
+                None => (
+                    "git".to_string(),
+                    self.source_url.clone(),
+                    self.source_branch.clone(),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+            };
+
+        let origin = match kind.as_str() {
+            "git" => Origin::Git {
+                url: url.or(self.source_url).ok_or_else(|| missing("url"))?,
+                // No branch meant the repository default — NOT a branch named "main".
+                r#ref: match branch.or(self.source_branch) {
+                    Some(b) => GitRef::Branch(b),
+                    None => GitRef::Default,
+                },
+                subdir: None,
+            },
+            "local" => Origin::Local {
+                path: PathBuf::from(path.ok_or_else(|| missing("path"))?),
+                // The nested table won if it said anything; otherwise the entry-level flag.
+                editable: src_editable.unwrap_or(self.editable),
+            },
+            "zip-url" => Origin::ZipUrl {
+                url: zip_url.or(url).ok_or_else(|| missing("zip_url"))?,
+            },
+            // Legacy called a configured-repository install "source".
+            "source" | "repository" => Origin::Repository {
+                repo: repo_name.ok_or_else(|| missing("name"))?,
+                skill: repo_skill.unwrap_or_else(|| id.clone()),
+                // The legacy source table carried the requested constraint; dropping it
+                // would turn a pinned repository dependency into "newest allowed".
+                version: match req_version {
+                    Some(raw) => Some(
+                        crate::core::version::VersionConstraint::parse(&raw).map_err(|e| {
+                            LockError::Parse(format!(
+                                "legacy lock entry '{id}' has an unparseable version constraint '{raw}': {e}"
+                            ))
+                        })?,
+                    ),
+                    None => None,
+                },
+            },
+            other => {
+                return Err(LockError::Parse(format!(
+                    "legacy lock entry '{id}' has unknown source type '{other}'. Delete \
+                     skills.lock and re-run `fastskill install` to rebuild it."
+                )))
+            }
+        };
+
+        Ok(ProjectLockedSkillEntry {
+            name: self.name.unwrap_or_else(|| id.clone()),
+            id,
+            origin,
+            // 1.0.0 never recorded a commit hash or checksum, so there is nothing to carry
+            // over. The migrated lock is exactly as precise as the file it came from — just
+            // less precise than one produced by a fresh resolve.
+            resolved: Resolved {
+                version: self.version,
+                commit_hash: None,
+                checksum: None,
+            },
+            dependencies: self.dependencies,
+            groups: self.groups,
+            depth: self.depth,
+            parent_skill: self.parent_skill,
+        })
+    }
+}
+
+impl LegacyProjectSkillsLock {
+    fn upgrade(self) -> Result<ProjectSkillsLock, LockError> {
+        let mut skills = Vec::with_capacity(self.skills.len());
+        for entry in self.skills {
+            skills.push(entry.upgrade()?);
+        }
+        Ok(ProjectSkillsLock {
+            metadata: ProjectLockMetadata {
+                version: LOCK_FORMAT_VERSION.to_string(),
+                fastskill_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            },
+            skills,
+        })
     }
 }
 
@@ -346,6 +557,18 @@ pub enum LockError {
 /// missing `origin` field), which would otherwise surface as an opaque
 /// `LockError::Parse` instead of the actionable `UnsupportedVersion` guard.
 fn check_lock_format_version(content: &str) -> Result<(), LockError> {
+    let found = read_lock_format_version(content)?;
+    if found != LOCK_FORMAT_VERSION {
+        return Err(LockError::UnsupportedVersion { found });
+    }
+    Ok(())
+}
+
+/// Read `metadata.version` alone, without parsing the rest.
+///
+/// A legacy lock does not deserialize as the current shape, so the version has to be read
+/// in its own pass before deciding how to parse the file.
+fn read_lock_format_version(content: &str) -> Result<String, LockError> {
     #[derive(Deserialize)]
     struct VersionOnly {
         version: String,
@@ -357,12 +580,7 @@ fn check_lock_format_version(content: &str) -> Result<(), LockError> {
 
     let parsed: MetadataOnly =
         toml::from_str(content).map_err(|e| LockError::Parse(e.to_string()))?;
-    if parsed.metadata.version != LOCK_FORMAT_VERSION {
-        return Err(LockError::UnsupportedVersion {
-            found: parsed.metadata.version,
-        });
-    }
-    Ok(())
+    Ok(parsed.metadata.version)
 }
 
 // ── Routing helpers ───────────────────────────────────────────────────────────
@@ -648,5 +866,206 @@ depth = 0
         // Last write wins: the file is a complete copy of the second writer's content.
         let reloaded = ProjectSkillsLock::load_from_file(&lock_path).unwrap();
         assert_eq!(reloaded.skills.len(), 1);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic, clippy::expect_used)]
+mod legacy_lock_migration_tests {
+    use super::*;
+
+    const LEGACY: &str = r#"
+[metadata]
+version = "1.0.0"
+fastskill_version = "0.9.136"
+
+[[skills]]
+id = "adapt-to-ai"
+name = "adapt-to-ai"
+version = "1.0.2"
+source_url = "https://github.com/org/skills"
+source_branch = "main"
+dependencies = []
+groups = ["docs"]
+editable = false
+depth = 0
+
+[skills.source]
+type = "git"
+url = "https://github.com/org/skills"
+branch = "main"
+
+[[skills]]
+id = "pinned-default"
+name = "pinned-default"
+version = "2.0.0"
+source_url = "https://github.com/org/other"
+dependencies = []
+groups = []
+editable = false
+depth = 1
+
+[skills.source]
+type = "git"
+url = "https://github.com/org/other"
+
+[[skills]]
+id = "win"
+name = "win"
+version = "0.3.0"
+source_url = "/srv/skills/win"
+dependencies = []
+groups = []
+editable = true
+depth = 0
+
+[skills.source]
+type = "local"
+path = "/srv/skills/win"
+editable = true
+"#;
+
+    fn entry<'a>(lock: &'a ProjectSkillsLock, id: &str) -> &'a ProjectLockedSkillEntry {
+        lock.skills
+            .iter()
+            .find(|s| s.id == id)
+            .unwrap_or_else(|| panic!("missing entry {id}"))
+    }
+
+    fn load(content: &str) -> ProjectSkillsLock {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skills.lock");
+        std::fs::write(&path, content).unwrap();
+        ProjectSkillsLock::load_from_file(&path).expect("legacy lock must load")
+    }
+
+    #[test]
+    fn legacy_lock_is_migrated_instead_of_rejected() {
+        let lock = load(LEGACY);
+        assert_eq!(lock.metadata.version, LOCK_FORMAT_VERSION);
+        assert_eq!(lock.skills.len(), 3);
+    }
+
+    #[test]
+    fn pinned_versions_are_preserved() {
+        // The entire reason to migrate rather than tell people to delete the file.
+        let lock = load(LEGACY);
+        assert_eq!(entry(&lock, "adapt-to-ai").resolved.version, "1.0.2");
+        assert_eq!(entry(&lock, "pinned-default").resolved.version, "2.0.0");
+        assert_eq!(entry(&lock, "win").resolved.version, "0.3.0");
+    }
+
+    #[test]
+    fn git_branch_and_absent_branch_are_distinguished() {
+        let lock = load(LEGACY);
+        match &entry(&lock, "adapt-to-ai").origin {
+            Origin::Git { url, r#ref, .. } => {
+                assert_eq!(url, "https://github.com/org/skills");
+                assert_eq!(*r#ref, GitRef::Branch("main".to_string()));
+            }
+            other => panic!("expected git origin, got {other:?}"),
+        }
+        // No branch meant the repository default — treating it as a branch named "main"
+        // would silently re-point the dependency.
+        match &entry(&lock, "pinned-default").origin {
+            Origin::Git { r#ref, .. } => assert_eq!(*r#ref, GitRef::Default),
+            other => panic!("expected git origin, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn local_entries_keep_path_and_editable() {
+        let lock = load(LEGACY);
+        match &entry(&lock, "win").origin {
+            Origin::Local { path, editable } => {
+                assert_eq!(path, &PathBuf::from("/srv/skills/win"));
+                assert!(*editable);
+            }
+            other => panic!("expected local origin, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn groups_and_depth_survive() {
+        let lock = load(LEGACY);
+        assert_eq!(entry(&lock, "adapt-to-ai").groups, vec!["docs".to_string()]);
+        assert_eq!(entry(&lock, "pinned-default").depth, 1);
+    }
+
+    /// 1.0.0 never recorded these, so `None` is honest rather than lossy.
+    #[test]
+    fn commit_hash_and_checksum_are_absent_not_invented() {
+        let lock = load(LEGACY);
+        let e = entry(&lock, "adapt-to-ai");
+        assert!(e.resolved.commit_hash.is_none());
+        assert!(e.resolved.checksum.is_none());
+    }
+
+    #[test]
+    fn migrated_lock_round_trips_through_save() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skills.lock");
+        std::fs::write(&path, LEGACY).unwrap();
+
+        let migrated = ProjectSkillsLock::load_from_file(&path).unwrap();
+        migrated.save_to_file(&path).unwrap();
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            written.contains("version = \"3.0\""),
+            "not stamped:\n{written}"
+        );
+        assert!(
+            !written.contains("source_url"),
+            "legacy fields survived:\n{written}"
+        );
+
+        let reloaded = ProjectSkillsLock::load_from_file(&path).unwrap();
+        assert_eq!(reloaded.skills.len(), 3);
+        assert_eq!(entry(&reloaded, "win").resolved.version, "0.3.0");
+    }
+
+    /// Reading must not rewrite: a legacy lock keeps working until something saves it.
+    #[test]
+    fn loading_does_not_rewrite_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skills.lock");
+        std::fs::write(&path, LEGACY).unwrap();
+        let _ = ProjectSkillsLock::load_from_file(&path).unwrap();
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            on_disk.contains("version = \"1.0.0\""),
+            "load rewrote the file"
+        );
+    }
+
+    /// A version we have never seen is still refused — migrating would be guesswork.
+    #[test]
+    fn unknown_lock_version_is_still_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skills.lock");
+        std::fs::write(&path, "[metadata]\nversion = \"2.0\"\n").unwrap();
+        match ProjectSkillsLock::load_from_file(&path) {
+            Err(LockError::UnsupportedVersion { found }) => assert_eq!(found, "2.0"),
+            other => panic!("expected UnsupportedVersion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_source_type_is_reported_by_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("skills.lock");
+        std::fs::write(
+            &path,
+            "[metadata]\nversion = \"1.0.0\"\n\n[[skills]]\nid = \"weird\"\nname = \"weird\"\n\
+             version = \"1.0.0\"\n\n[skills.source]\ntype = \"telepathy\"\n",
+        )
+        .unwrap();
+        let err = ProjectSkillsLock::load_from_file(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("weird") && msg.contains("telepathy"),
+            "unhelpful: {msg}"
+        );
     }
 }


### PR DESCRIPTION
> **Reviewer note: this reverses a deliberate decision.** ADR-0005 removed the v1.0.0 lock migrator on purpose, and `lock_migration_test.rs` was rewritten to assert the rejection. This PR restores migration for the project lock and rewrites those tests back. That warrants a real read, not a rubber stamp — the argument is below and you may disagree with it.

## Why reverse it

The reshape’s reasoning was sound in general: a lock is a **derived** artifact, so "delete it and re-run `fastskill install`" is a legitimate remedy.

It is the wrong remedy for the case that actually occurs — someone who already has skills installed. A lock records **pinned** versions. Re-resolving every dependency against whatever is current today silently upgrades a working installation, and the error message recommends precisely that, with no diff and no consent. On a real workspace this meant 64 dependencies quietly moving.

## Scope, deliberately narrow

| | |
|---|---|
| v1.0.0 **project** lock | migrated |
| Any other version, incl. newer than this build | **still rejected**, unchanged |
| **Global** lock | **untouched** — still rejects |

The global lock keeps its rejection because its legacy shape carried operational timestamps (`installed_at` and friends) that v1.0.0 project entries never had, and no legacy global lock was available to verify against. Writing that migration from guesswork is exactly what this PR argues against.

**Reading never writes.** A legacy lock keeps working untouched until something saves it for its own reasons. Rewriting on read would mutate a file the user never asked to change, on every command.

## Migration coverage

Taken from a real 1.0.0 specimen rather than inferred. `[skills.source]` is authoritative, with the flat `source_url`/`source_branch` fields as fallback.

| Legacy | → |
|---|---|
| `type = "git"` | `Origin::Git` — **absent branch means the repository default, NOT a branch named `main`** |
| `type = "local"` | `Origin::Local` — `editable` from the source table, falling back to the entry-level flag |
| `type = "zip-url"` | `Origin::ZipUrl` (either spelling) |
| `type = "source"` | `Origin::Repository` — **including the version constraint**, see below |
| `version` (entry level) | `resolved.version` |
| — | `commit_hash`/`checksum` → `None`; 1.0.0 never recorded them |

### A bug the old fixture caught

The existing test fixture used `source = { type = "source", …, version = "1.0.0" }` — a legacy repository install carrying a version **constraint**, distinct from the resolved version. My first pass dropped it, which would have turned a pinned repository dependency into "newest allowed": precisely the silent-drift failure this PR exists to prevent. Fixed, and now asserted.

## Test changes

`pre_origin_lock_is_rejected_not_migrated` and `v1_lock_is_rejected_before_touching_skill_shape` asserted the behaviour being reversed. Replaced by tests for migration + pin survival, for read-only-ness, and for continued rejection of unknown versions. The file header records the reversal and the reasoning, so the next person to read it isn’t left guessing why the intent flipped.

Ten further unit tests cover branch-vs-default, local `editable`, groups/depth, absent `commit_hash`, save round-trip, and unknown source types being reported by name.

## Verification

Against a **real 64-entry v1.0.0 lock** alongside a **65-skill installation**:

- `fastskill list`: hard error → every skill listed, **no "missing from lock" flags**
- `fastskill doctor`: passes
- Both `skills.lock` and `skill-project.toml` **byte-identical afterwards** (verified by `diff`)

Full suite **1171/1171**. `cargo fmt --all -- --check` and CI-exact clippy both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)