### PR TITLE
feat(quality): error-quality judge + calibration gate (spec 005 P2)

### DIFF
--- a/ci/quality/error_quality/README.md
+++ b/ci/quality/error_quality/README.md
@@ -1,0 +1,100 @@
+# Error-message-quality judge (spec 005, P2)
+
+Scores fastskill's error messages against a fixed rubric using an LLM, and — first —
+checks whether the LLM can do that job at all.
+
+```
+run a known error-producing command  →  capture (command, output, exit_code)
+     →  gateway LLM + fixed rubric  →  {score, pass, justification}  →  3-trial majority
+```
+
+The **capture is deterministic**; only the **scoring** is LLM. Per spec 005 Q3 this can
+never become a PR gate: anything with an LLM in the verdict path stays in the nightly
+soft tier. If a check becomes stable enough to gate on, rewrite it as a deterministic
+assertion instead.
+
+## Files
+
+| | |
+|---|---|
+| `cases.json` | Calibration fixture — human verdicts on real fastskill errors |
+| `judge.py` | Rubric, gateway client, majority vote |
+| `calibrate.py` | Scores the judge against the fixture. The go/no-go gate. |
+
+## Running calibration
+
+```bash
+LLM_GATEWAY_URL=... LLM_GATEWAY_KEY=... LLM_GATEWAY_MODEL=... \
+    python3 ci/quality/error_quality/calibrate.py --trials 3
+```
+
+Exit 0 = calibrated, 1 = below threshold, 2 = could not run. 10 cases × 3 trials = 30
+gateway requests, well inside the 300-request cap.
+
+**Run this before trusting any judge output, and again on every model change** (spec 005
+Q4). It is cheap and it is the only thing standing between "we have a judge" and "we have
+a plausible-sounding random number generator".
+
+## Calibration results (2026-08-18)
+
+Measured, not assumed:
+
+| Model | Backing | Agreement | Verdict |
+|---|---|---|---|
+| `claude-haiku-4-5` | real Anthropic | **100%** (10/10) | CALIBRATED |
+| `claude-sonnet-4-6` | local gemma4 on gx10 | **70%** (7/10) | not calibrated |
+
+Baseline for the fixture is 50% (it is deliberately balanced 5 pass / 5 fail, so a judge
+that always answers the same way scores 50%).
+
+### Why the local model failed, specifically
+
+It got every *good* message right and both *raw panics* right. It failed on exactly one
+class: **messages that are clean but useless** — `repos_skills_unknown_argument`,
+`generic_invalid_input`, `serde_error_leak`. It conflates "no stack trace" with "good".
+
+The clearest symptom is `generic_invalid_input` (`Error: invalid input`), where the model
+wrote *"does not provide specific details or actionable steps"* and then returned
+`pass: true` with a mean score of 2.7 — contradicting both its own reasoning and the
+rubric's rule that pass requires ≥ 3.
+
+**No prompt tuning was attempted before switching models.** Tuning against the same
+fixture that measures success would fit the judge to these ten cases and inflate the
+number without improving the judgement.
+
+### Cost
+
+From the gateway's own spend log:
+
+| Model | per call | per 30-call run |
+|---|---|---|
+| `claude-haiku-4-5` | $0.00070 | ~$0.02 |
+| `claude-sonnet-4-6` | $0.00251 | ~$0.08 |
+
+The local model is billed **3.5× more**, because the alias is named `claude-sonnet-4-6`
+and LiteLLM prices by alias regardless of the gx10 route. So the usual "use the local
+model to save money" argument does not apply here — it is both less accurate *and* more
+expensive in the ledger.
+
+## Two implementation details that are not incidental
+
+**`<think>` stripping.** The pinned local model emits reasoning preambles
+*non-deterministically* — the same prompt produced a 143-token `<think>` block in one call
+and a bare 2-token answer in another. Stripping cannot be conditioned on the model name or
+assumed away; it runs on every response. An unterminated `<think>` means the budget ran
+out mid-reasoning, so there is no JSON to recover.
+
+**Majority vote is not padding.** Because reasoning is non-deterministic, single-shot
+verdicts are not reproducible. A bare 2-1 majority is flagged `inconclusive` (spec 005 Q5)
+rather than forced into a verdict — a coin flip recorded as a result silently poisons the
+calibration number.
+
+## Extending the fixture
+
+Keep it **balanced**. A fixture that is mostly `pass` can be gamed by a judge that always
+answers `pass`, and would report high agreement while being useless — `calibrate.py`
+prints the always-answer-the-same-way baseline and refuses to certify a judge that merely
+matches it.
+
+Prefer **real captured output** over invented examples. The judge has to agree with humans
+about messages the product actually emits.

--- a/ci/quality/error_quality/calibrate.py
+++ b/ci/quality/error_quality/calibrate.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Calibrate the error-quality judge against human verdicts (spec 005, P2).
+
+This is the go/no-go gate. Spec 005 Q4 requires a model change to pass calibration
+before taking effect; running it FIRST answers the prior question -- whether the pinned
+model can grade error-message quality at all -- before a harness is built around it.
+
+Agreement is measured on pass/fail, not on the exact score: two reasonable graders
+routinely differ by a point while agreeing on whether a message is acceptable.
+
+Usage:
+    LLM_GATEWAY_URL=... LLM_GATEWAY_KEY=... LLM_GATEWAY_MODEL=... \\
+        python3 ci/quality/error_quality/calibrate.py [--trials N] [--json OUT]
+
+Exit codes: 0 = calibrated, 1 = below threshold, 2 = could not run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from judge import gateway_from_env, judge_case  # noqa: E402
+
+CASES_PATH = pathlib.Path(__file__).resolve().parent / "cases.json"
+
+# Below this the judge is not trustworthy enough to report findings a human will act on.
+# Deliberately demanding: a judge that is wrong a third of the time generates review
+# work rather than saving it, and the fixture is small enough that each case matters.
+AGREEMENT_THRESHOLD = 0.80
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--trials", type=int, default=3, help="trials per case (majority vote)")
+    ap.add_argument("--json", type=str, default=None, help="write full results here")
+    args = ap.parse_args()
+
+    cases = json.loads(CASES_PATH.read_text())["cases"]
+    try:
+        gw = gateway_from_env()
+    except SystemExit as exc:
+        print(f"cannot run: {exc}")
+        return 2
+
+    # A fixture skewed to one verdict can be gamed by a judge that always answers the
+    # same way, so state the balance up front and make an always-X baseline visible.
+    expected_pass = sum(1 for c in cases if c["expected"]["pass"])
+    print(f"model     {gw.model}")
+    print(f"cases     {len(cases)} ({expected_pass} pass / {len(cases) - expected_pass} fail)")
+    print(f"trials    {args.trials} per case, majority vote")
+    baseline = max(expected_pass, len(cases) - expected_pass) / len(cases)
+    print(f"baseline  {baseline:.0%} (always answering the more common verdict)")
+    print("-" * 78)
+
+    agree = disagree = inconclusive = errored = 0
+    rows = []
+
+    for case in cases:
+        want = case["expected"]["pass"]
+        res = judge_case(gw, case, trials=args.trials)
+
+        if not res.verdicts:
+            status, errored = "ERROR", errored + 1
+        elif res.inconclusive and res.passed is None:
+            status, inconclusive = "SPLIT", inconclusive + 1
+        else:
+            matched = res.passed == want
+            if res.inconclusive:
+                # A bare majority counts toward agreement but is flagged: it is a weak
+                # signal, and a judge that is only ever barely right is not reliable.
+                status = "agree?" if matched else "DIFFER?"
+            else:
+                status = "agree" if matched else "DIFFER"
+            if matched:
+                agree += 1
+            else:
+                disagree += 1
+
+        got = "-" if res.passed is None else ("pass" if res.passed else "fail")
+        score = f"{res.score:.1f}" if res.score is not None else " - "
+        print(f"{status:<8} {case['id']:<34} want={'pass' if want else 'fail'} got={got:<4} score={score}")
+        if res.error:
+            print(f"         └─ {res.error}")
+        elif status.startswith(("DIFFER", "SPLIT")) and res.verdicts:
+            print(f"         └─ judge said: {res.verdicts[0].justification[:100]}")
+
+        rows.append(
+            {
+                "id": case["id"],
+                "expected_pass": want,
+                "got_pass": res.passed,
+                "mean_score": res.score,
+                "inconclusive": res.inconclusive,
+                "error": res.error,
+                "justifications": [v.justification for v in res.verdicts],
+            }
+        )
+
+    scored = agree + disagree
+    agreement = agree / scored if scored else 0.0
+    print("-" * 78)
+    print(f"agreement {agreement:.0%} ({agree}/{scored})   split={inconclusive} errored={errored}")
+    print(f"requests  {gw.requests_made}")
+
+    if args.json:
+        pathlib.Path(args.json).write_text(
+            json.dumps(
+                {
+                    "model": gw.model,
+                    "agreement": agreement,
+                    "agree": agree,
+                    "disagree": disagree,
+                    "inconclusive": inconclusive,
+                    "errored": errored,
+                    "baseline": baseline,
+                    "threshold": AGREEMENT_THRESHOLD,
+                    "cases": rows,
+                },
+                indent=2,
+            )
+        )
+
+    if errored == len(cases):
+        print("\nVERDICT: could not run — every case errored.")
+        return 2
+    if agreement >= AGREEMENT_THRESHOLD and agreement > baseline:
+        print(f"\nVERDICT: CALIBRATED (>= {AGREEMENT_THRESHOLD:.0%} and above baseline).")
+        return 0
+    if agreement <= baseline:
+        # Beating the threshold while merely matching the baseline means the judge has
+        # learned the fixture's skew, not the rubric.
+        print(f"\nVERDICT: NOT CALIBRATED — {agreement:.0%} is no better than always "
+              f"answering the same way ({baseline:.0%}).")
+    else:
+        print(f"\nVERDICT: NOT CALIBRATED — {agreement:.0%} < {AGREEMENT_THRESHOLD:.0%}.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/quality/error_quality/calibration-2026-08-18-gemma4.json
+++ b/ci/quality/error_quality/calibration-2026-08-18-gemma4.json
@@ -1,0 +1,142 @@
+{
+  "model": "claude-sonnet-4-6",
+  "agreement": 0.7,
+  "agree": 7,
+  "disagree": 3,
+  "inconclusive": 0,
+  "errored": 0,
+  "baseline": 0.5,
+  "threshold": 0.8,
+  "cases": [
+    {
+      "id": "read_not_found",
+      "expected_pass": true,
+      "got_pass": true,
+      "mean_score": 5.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "The message is highly specific, actionable, and clean, providing the missing skill name, search context, and clear next steps.",
+        "The message is highly specific, actionable, clean, and correctly handles the non-zero exit code.",
+        "The message is highly specific, actionable, clean, and correctly handles the failure with a non-zero exit code."
+      ]
+    },
+    {
+      "id": "add_nonexistent_path",
+      "expected_pass": true,
+      "got_pass": true,
+      "mean_score": 5.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "The message is highly specific, actionable, clean, and uses a non-zero exit code for a handled validation failure.",
+        "The message is highly specific, actionable, clean, and associated with a non-crash exit code.",
+        "The message is highly specific, actionable, clean, and associated with a non-crash exit code."
+      ]
+    },
+    {
+      "id": "remove_not_found",
+      "expected_pass": true,
+      "got_pass": true,
+      "mean_score": 5.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "The message is highly specific, actionable, clean, and correctly handles the non-zero exit code.",
+        "The message is highly specific, actionable, clean, and uses a non-crash exit code.",
+        "The message is highly specific, actionable, clean, and correctly handles the failure with a non-zero exit code."
+      ]
+    },
+    {
+      "id": "install_missing_dependencies_section",
+      "expected_pass": true,
+      "got_pass": true,
+      "mean_score": 5.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "The message is highly specific, actionable, clean, and indicates a handled error.",
+        "The message is highly specific, clearly identifies the missing configuration section, and provides actionable steps for resolution.",
+        "The message is highly specific, clearly identifies the missing configuration section, and provides actionable steps for resolution."
+      ]
+    },
+    {
+      "id": "search_invalid_limit",
+      "expected_pass": true,
+      "got_pass": true,
+      "mean_score": 5.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "The message is highly specific, clearly identifies the invalid value and the expected type, and is completely clean.",
+        "The message is highly specific, actionable, clean, and correctly indicates a handled error.",
+        "The message is highly specific, actionable, clean, and correctly indicates a handled error."
+      ]
+    },
+    {
+      "id": "repos_skills_unknown_argument",
+      "expected_pass": false,
+      "got_pass": true,
+      "mean_score": 4.666666666666667,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "The message is specific about the error type, highly actionable with a clear hint, and completely clean.",
+        "The message is specific, highly actionable, clean, and uses a non-crash exit code.",
+        "The message is specific about the type of error and provides a clear, actionable hint for the user."
+      ]
+    },
+    {
+      "id": "clap_duplicate_arg_panic",
+      "expected_pass": false,
+      "got_pass": false,
+      "mean_score": 1.3333333333333333,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "The message is a raw panic trace with a crash exit code, failing the cleanliness and exit code criteria.",
+        "The message identifies the specific argument conflict but is unusable due to the inclusion of a full stack trace and internal file paths.",
+        "The message is a raw panic trace containing internal file paths and stack information, failing the cleanliness requirement."
+      ]
+    },
+    {
+      "id": "unwrap_panic",
+      "expected_pass": false,
+      "got_pass": false,
+      "mean_score": 2.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "The message is a raw internal panic report that provides no actionable information for the end-user.",
+        "The message identifies the internal cause and location but is not clean, actionable for an end-user, and represents a crash.",
+        "The message is specific about the internal panic location but is not actionable for the user and contains excessive internal stack trace details."
+      ]
+    },
+    {
+      "id": "generic_invalid_input",
+      "expected_pass": false,
+      "got_pass": true,
+      "mean_score": 2.6666666666666665,
+      "inconclusive": true,
+      "error": null,
+      "justifications": [
+        "The message identifies a generic problem but does not provide specific details or actionable steps for the user.",
+        "The error message is vague and does not provide any context or guidance on how to fix the invalid input.",
+        "The message identifies a generic error type but does not provide specific details or guidance on how to correct the input."
+      ]
+    },
+    {
+      "id": "serde_error_leak",
+      "expected_pass": false,
+      "got_pass": true,
+      "mean_score": 3.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "The message identifies the type of data validation failure but lacks specific guidance on how the user should correct the input.",
+        "The message identifies the technical failure type but does not provide clear guidance on how the user should correct the input data.",
+        "The message identifies the type of data validation failure but does not provide any specific context or guidance on how the user should fix the issue."
+      ]
+    }
+  ]
+}

--- a/ci/quality/error_quality/calibration-2026-08-18-haiku.json
+++ b/ci/quality/error_quality/calibration-2026-08-18-haiku.json
@@ -1,0 +1,142 @@
+{
+  "model": "claude-haiku-4-5",
+  "agreement": 1.0,
+  "agree": 10,
+  "disagree": 0,
+  "inconclusive": 0,
+  "errored": 0,
+  "baseline": 0.5,
+  "threshold": 0.8,
+  "cases": [
+    {
+      "id": "read_not_found",
+      "expected_pass": true,
+      "got_pass": true,
+      "mean_score": 5.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "Identifies the specific missing skill by name, shows exactly where was searched, and provides two actionable next steps (install or list available skills).",
+        "Identifies the specific missing skill by name, shows exactly where was searched, and provides two actionable next steps (install or list available skills).",
+        "Identifies the specific missing skill by name, shows exactly where was searched, and provides two actionable next steps (install or list available skills)."
+      ]
+    },
+    {
+      "id": "add_nonexistent_path",
+      "expected_pass": true,
+      "got_pass": true,
+      "mean_score": 5.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "The error message is highly specific (names the exact missing file and directory), actionable (explains the requirement and suggests the --recursive flag as an alternative), clean (no stack traces or internal details), and uses a proper exit code.",
+        "The error message is highly specific (names the exact missing file and directory), actionable (explains the requirement and suggests the --recursive flag as an alternative), clean (no stack traces or internal details), and uses a proper non-zero exit code.",
+        "The error message is highly specific (names the exact missing file and directory), actionable (explains the requirement and suggests the --recursive flag as an alternative), clean (no stack traces or internal details), and uses a proper exit code."
+      ]
+    },
+    {
+      "id": "remove_not_found",
+      "expected_pass": true,
+      "got_pass": true,
+      "mean_score": 5.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "Identifies the specific missing skill ('ghost'), shows exactly where was searched, and provides actionable next steps (install or list available skills).",
+        "Identifies the specific missing skill ('ghost'), shows exactly where was searched, and provides actionable next steps (install or list available skills).",
+        "Identifies the specific missing skill ('ghost'), shows exactly where was searched, and provides actionable next steps (install or list available skills)."
+      ]
+    },
+    {
+      "id": "install_missing_dependencies_section",
+      "expected_pass": true,
+      "got_pass": true,
+      "mean_score": 5.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "Highly specific (names the exact file and missing section), actionable (explains what section is needed and provides a command to add skills), clean (no stack traces or internal details), and proper exit code.",
+        "The error message is highly specific (names the exact file and missing section), actionable (tells user to add '[dependencies]' section and provides the command to use), clean (no stack traces or internal details), and uses exit code 1 (proper error handling).",
+        "The error message is highly specific (names the exact file and missing section), actionable (tells user to add '[dependencies]' section and provides the command to use), clean (no stack traces or internal details), and uses exit code 1 (proper error handling)."
+      ]
+    },
+    {
+      "id": "search_invalid_limit",
+      "expected_pass": true,
+      "got_pass": true,
+      "mean_score": 4.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "Specific problem identified (which argument, which value, what was expected) with clear actionability; minor deduction for using error code notation (E004) which adds jargon but doesn't obscure the message.",
+        "Specific about the problem (which argument, which value, what was expected) and actionable (user knows to provide an integer), with clean formatting and proper exit code; minor deduction for not suggesting a valid example value.",
+        "Specific problem identified (invalid value for limit argument, expected integer), actionable fix is clear (provide an integer), clean output with no internal leaks, but could be slightly more explicit about the valid range or format."
+      ]
+    },
+    {
+      "id": "repos_skills_unknown_argument",
+      "expected_pass": false,
+      "got_pass": false,
+      "mean_score": 2.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "The error is vague and generic\u2014it doesn't specify which argument is unknown or what the valid options are, making it unclear whether 'nosuchrepo' is invalid or if the command structure itself is wrong.",
+        "The error is vague and generic\u2014it doesn't specify which argument is unknown, what the valid arguments are, or what the user should do beyond consulting --help, making it difficult to diagnose the actual problem.",
+        "The error is vague and generic\u2014it doesn't specify which argument is unknown or what the valid options are, making it unclear whether 'nosuchrepo' is invalid or if the command structure itself is wrong."
+      ]
+    },
+    {
+      "id": "clap_duplicate_arg_panic",
+      "expected_pass": false,
+      "got_pass": false,
+      "mean_score": 1.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "This is a raw panic with internal source paths and stack trace, indicating an unhandled crash rather than a graceful error message; while it identifies a duplicate 'version' argument problem, the exit code 101 confirms this is a crash that should have been caught during development.",
+        "This is a panic/crash (exit code 101) with internal source paths and stack trace, indicating a bug in the tool's argument definition rather than a handled user error.",
+        "This is a raw panic with internal source paths and stack trace, indicating an unhandled crash in the tool's argument parsing logic rather than a user-facing error message."
+      ]
+    },
+    {
+      "id": "unwrap_panic",
+      "expected_pass": false,
+      "got_pass": false,
+      "mean_score": 1.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "This is an unhandled panic with exit code 101 (crash), exposing internal source paths and unwrap failures rather than a user-facing error message; the user has no idea what went wrong or how to fix it.",
+        "This is an unhandled panic with exit code 101 (crash), exposing internal source paths and unwrap failures rather than a user-facing error message.",
+        "This is an unhandled panic with exit code 101 (crash), exposing internal source paths and unwrap failures rather than a user-facing error message."
+      ]
+    },
+    {
+      "id": "generic_invalid_input",
+      "expected_pass": false,
+      "got_pass": false,
+      "mean_score": 1.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "The message is completely generic, does not identify which input is invalid or why, provides no actionable guidance, and leaves the user unable to determine what to fix.",
+        "The message is completely generic, does not identify which input is invalid or why, provides no actionable guidance, and leaves the user unable to determine what to fix.",
+        "The message is completely generic, does not identify which input is invalid or why, provides no actionable guidance, and leaves the user unable to determine what to fix."
+      ]
+    },
+    {
+      "id": "serde_error_leak",
+      "expected_pass": false,
+      "got_pass": false,
+      "mean_score": 1.0,
+      "inconclusive": false,
+      "error": null,
+      "justifications": [
+        "The error message exposes internal Rust type information (untagged enum DependencySpec) rather than explaining what data format was expected or which file/field caused the problem, making it impossible for a user to know what to fix.",
+        "The error message exposes internal Rust type information (untagged enum DependencySpec) rather than explaining what the user did wrong or how to fix it, making it useless for end-user troubleshooting.",
+        "The error message exposes internal Rust type information (untagged enum DependencySpec) rather than explaining what the user did wrong or how to fix it, making it useless for end-user troubleshooting."
+      ]
+    }
+  ]
+}

--- a/ci/quality/error_quality/cases.json
+++ b/ci/quality/error_quality/cases.json
@@ -1,0 +1,137 @@
+{
+  "_comment": [
+    "Calibration fixture for the spec-005 error-message-quality judge.",
+    "",
+    "Every `good` case is REAL output captured from fastskill 0.9.179 by running the",
+    "command shown. Nothing here is an invented example of what a good message might",
+    "look like -- the judge has to agree with humans about messages the product",
+    "actually emits, not about idealised prose.",
+    "",
+    "The `bad` cases are messages fastskill could realistically regress into. Two are",
+    "historical: `clap_duplicate_arg_panic` is the panic that `fastskill init` really",
+    "produced before PR #225 (an arg named `version` collided with clap's generated",
+    "--version), and `unwrap_panic` is the shape any stray .unwrap() produces. They are",
+    "reconstructed rather than captured because the bugs are fixed -- which is the point:",
+    "the judge exists to catch a return to them.",
+    "",
+    "`expected.pass` is the human verdict and is what calibration scores against.",
+    "`expected.score_range` is advisory -- exact scores vary between reasonable judges,",
+    "so agreement is measured on pass/fail, with score used only to spot a judge that",
+    "gets the verdict right for visibly wrong reasons.",
+    "",
+    "Keep this set BALANCED. A fixture that is mostly `pass` can be gamed by a judge",
+    "that always answers `pass`, and would report ~80% agreement while being useless."
+  ],
+  "cases": [
+    {
+      "id": "read_not_found",
+      "command": "fastskill read no-such-skill",
+      "exit_code": 1,
+      "output": "Error: Skill 'no-such-skill' not found\n\nSearched locations:\n  ✓ /tmp/proj/skills (project)\n\nTry:\n  fastskill install owner/repo\n  fastskill list                    # See available skills",
+      "expected": {
+        "pass": true,
+        "score_range": [4, 5],
+        "why": "Names the specific missing skill, shows where it looked so the user can tell whether the path was wrong, and offers two concrete next commands. Clean, no internals. Exit 1 is right."
+      }
+    },
+    {
+      "id": "add_nonexistent_path",
+      "command": "fastskill add ./does-not-exist",
+      "exit_code": 1,
+      "output": "Error: Validation error: No SKILL.md found in ./does-not-exist. A skill directory must contain a SKILL.md file. If this folder has multiple skills in subdirectories, use --recursive.",
+      "expected": {
+        "pass": true,
+        "score_range": [4, 5],
+        "why": "Names the path, states the requirement that was violated, and anticipates the most likely cause with a specific flag to fix it."
+      }
+    },
+    {
+      "id": "remove_not_found",
+      "command": "fastskill remove ghost",
+      "exit_code": 1,
+      "output": "Error: Skill 'ghost' not found\n\nSearched locations:\n  ✓ /tmp/proj/skills (project)\n\nTry:\n  fastskill install owner/repo\n  fastskill list                    # See available skills",
+      "expected": {
+        "pass": true,
+        "score_range": [4, 5],
+        "why": "Same shape as read_not_found. Included deliberately: a judge that scores identical messages inconsistently is not usable, so this is a self-consistency probe."
+      }
+    },
+    {
+      "id": "install_missing_dependencies_section",
+      "command": "fastskill install",
+      "exit_code": 1,
+      "output": "Installing skills...\n\nError: Configuration error: skill-project.toml validation failed: Project-level skill-project.toml (at project root) requires [dependencies] section. Add '[dependencies]' section to manage skill dependencies. Use 'fastskill add <skill-id>' to add skills.",
+      "expected": {
+        "pass": true,
+        "score_range": [3, 5],
+        "why": "Says exactly which section is missing from which file and gives both a manual fix and a command. Slightly jargon-heavy ('validation failed') and the nested prefixes are clumsy, so a 3 is defensible -- but it is actionable, which is what pass turns on."
+      }
+    },
+    {
+      "id": "search_invalid_limit",
+      "command": "fastskill search --limit notanumber x",
+      "exit_code": 1,
+      "output": "error[E004]: invalid value 'notanumber' for 'limit'; expected integer",
+      "expected": {
+        "pass": true,
+        "score_range": [3, 5],
+        "why": "Names the offending value, the field, and the expected type. Terse and offers no next command, but a user knows precisely what to change."
+      }
+    },
+    {
+      "id": "repos_skills_unknown_argument",
+      "command": "fastskill repos skills nosuchrepo",
+      "exit_code": 1,
+      "output": "error[E002]: unknown argument\n  hint: Use --help to see available arguments\nError: unknown argument",
+      "expected": {
+        "pass": false,
+        "score_range": [1, 2],
+        "why": "REAL current output and genuinely poor. Never says WHICH argument was unknown, though the CLI plainly knows. The hint is generic boilerplate, and the message is printed twice. A user is left guessing."
+      }
+    },
+    {
+      "id": "clap_duplicate_arg_panic",
+      "command": "fastskill init --yes",
+      "exit_code": 101,
+      "output": "thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.23/src/builder/debug_asserts.rs:99:13:\nCommand init: Argument names must be unique, but 'version' is in use by more than one argument or group\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
+      "expected": {
+        "pass": false,
+        "score_range": [1, 1],
+        "why": "The panic `fastskill init` really produced before PR #225. Raw Rust panic with a vendored crate path and an internal invariant. Says nothing the user can act on -- it is not even their fault. Exit 101 signals a crash, not a usage error."
+      }
+    },
+    {
+      "id": "unwrap_panic",
+      "command": "fastskill list",
+      "exit_code": 101,
+      "output": "thread 'main' panicked at crates/fastskill-core/src/core/manifest.rs:412:38:\ncalled `Option::unwrap()` on a `None` value\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
+      "expected": {
+        "pass": false,
+        "score_range": [1, 1],
+        "why": "The shape any stray .unwrap() produces. Leaks a source path and line, names no user-facing problem, offers no action."
+      }
+    },
+    {
+      "id": "generic_invalid_input",
+      "command": "fastskill add some/skill",
+      "exit_code": 1,
+      "output": "Error: invalid input",
+      "expected": {
+        "pass": false,
+        "score_range": [1, 2],
+        "why": "The canonical useless error. Correct exit code and no internals leaked, so a judge weighing only cleanliness might wave it through -- which is exactly the failure mode this case exists to detect. Zero specificity, zero actionability."
+      }
+    },
+    {
+      "id": "serde_error_leak",
+      "command": "fastskill install",
+      "exit_code": 1,
+      "output": "Error: data did not match any variant of untagged enum DependencySpec",
+      "expected": {
+        "pass": false,
+        "score_range": [1, 2],
+        "why": "REAL historical output: what a pre-Origin manifest produced before the migration hint. Technically accurate and completely unactionable -- it names an internal Rust type, not the file, line, or field the user must change."
+      }
+    }
+  ]
+}

--- a/ci/quality/error_quality/judge.py
+++ b/ci/quality/error_quality/judge.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""LLM judge for fastskill error-message quality (spec 005, P2).
+
+Scores a captured (command, output, exit_code) against a fixed rubric and returns a
+structured verdict. The *capture* is deterministic; only the *scoring* is LLM.
+
+Stdlib only, so this runs before any dependency install.
+
+Two behaviours here exist because of things measured on the real gateway, not from
+theory -- see `strip_reasoning` and `judge_case`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from collections import Counter
+from dataclasses import dataclass, field
+
+TIMEOUT = 180
+
+RUBRIC = """\
+You are grading the quality of a command-line tool's ERROR MESSAGE.
+
+Grade ONLY the message shown. Do not speculate about the tool's internals, and do not
+reward or penalise wording you merely like or dislike.
+
+Four dimensions:
+
+1. Specificity  - does it name the SPECIFIC problem (which file, which value, which
+                  argument), rather than a generic "invalid input"?
+2. Actionability - does it tell the user what to do next, or make the fix obvious?
+3. Cleanliness  - free of stack traces, panics, source paths, and internal type names?
+4. Exit code    - non-zero for a real failure. A panic exit (101) is a CRASH, not a
+                  handled error, and should be penalised heavily.
+
+Score 1-5:
+  5 - specific, actionable, clean
+  4 - specific and actionable; minor wording or jargon issues
+  3 - identifies the problem but the next step is unclear
+  2 - vague, or the user must guess what to change
+  1 - useless, or a raw crash/panic/internal leak
+
+`pass` is true only for a score of 3 or higher AND no crash/panic/internal leak.
+
+Reply with ONLY a JSON object, no prose and no code fence:
+{"score": <1-5>, "pass": <true|false>, "justification": "<one sentence>"}
+"""
+
+
+@dataclass
+class Verdict:
+    score: int
+    passed: bool
+    justification: str
+
+
+@dataclass
+class CaseResult:
+    case_id: str
+    verdicts: list[Verdict] = field(default_factory=list)
+    passed: bool | None = None       # majority verdict; None when inconclusive
+    score: float | None = None       # mean score across trials
+    inconclusive: bool = False
+    error: str | None = None
+
+
+def strip_reasoning(text: str) -> str:
+    """Remove a reasoning preamble before JSON parsing.
+
+    Measured on the pinned gateway model: the SAME prompt produced a `<think>` block of
+    143 tokens in one call and a bare 2-token answer in another. Reasoning is emitted
+    non-deterministically, so this cannot be conditioned on the model name or assumed
+    away -- it has to be stripped defensively on every response.
+
+    Also unwraps a ```json fence, which models add despite being told not to.
+    """
+    text = re.sub(r"<think\b.*?</think\s*>", "", text, flags=re.DOTALL | re.IGNORECASE)
+    # An unterminated <think> means the token budget ran out mid-reasoning; everything
+    # after the opening tag is reasoning, so there is no JSON to recover.
+    text = re.sub(r"<think\b.*", "", text, flags=re.DOTALL | re.IGNORECASE)
+    fence = re.search(r"```(?:json)?\s*(.*?)```", text, flags=re.DOTALL)
+    if fence:
+        text = fence.group(1)
+    return text.strip()
+
+
+def extract_json(text: str) -> dict:
+    """Parse the verdict object, tolerating text around it."""
+    cleaned = strip_reasoning(text)
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError:
+        pass
+    # Fall back to the first {...} block; models sometimes prepend a sentence.
+    match = re.search(r"\{.*\}", cleaned, flags=re.DOTALL)
+    if not match:
+        raise ValueError(f"no JSON object in reply: {cleaned[:200]!r}")
+    return json.loads(match.group(0))
+
+
+class Gateway:
+    def __init__(self, base_url: str, api_key: str, model: str):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.model = model
+        self.requests_made = 0
+
+    def complete(self, prompt: str, max_tokens: int = 1200) -> str:
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            # Deterministic scoring (spec 005 rubric: temp=0). Note this does NOT make
+            # the pinned model deterministic in practice -- hence the majority vote.
+            "temperature": 0,
+            # Generous, because a reasoning model spends budget thinking before it
+            # answers; too small a budget yields an empty answer, not a short one.
+            "max_tokens": max_tokens,
+        }
+        req = urllib.request.Request(
+            f"{self.base_url}/v1/chat/completions",
+            data=json.dumps(payload).encode(),
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+                body = json.loads(resp.read().decode())
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(f"HTTP {exc.code}: {exc.read().decode(errors='replace')[:200]}")
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"cannot reach gateway: {exc.reason}")
+        self.requests_made += 1
+        return (body.get("choices") or [{}])[0].get("message", {}).get("content", "")
+
+
+def build_prompt(case: dict) -> str:
+    return (
+        f"{RUBRIC}\n"
+        f"Command: {case['command']}\n"
+        f"Exit code: {case['exit_code']}\n"
+        f"Output:\n---\n{case['output']}\n---\n"
+    )
+
+
+def judge_case(gw: Gateway, case: dict, trials: int = 3) -> CaseResult:
+    """Judge one case over N trials and take the majority verdict.
+
+    Majority vote is not defensive padding: the pinned model reasons
+    non-deterministically, so single-shot verdicts are not reproducible. A split where
+    the minority is a single dissent is reported as `inconclusive` rather than forced
+    into a verdict (spec 005, Q5) -- a coin-flip recorded as a result is worse than an
+    honest abstention, because it silently poisons the calibration number.
+    """
+    result = CaseResult(case_id=case["id"])
+    for _ in range(trials):
+        try:
+            raw = gw.complete(build_prompt(case))
+            data = extract_json(raw)
+            result.verdicts.append(
+                Verdict(
+                    score=int(data["score"]),
+                    passed=bool(data["pass"]),
+                    justification=str(data.get("justification", "")).strip(),
+                )
+            )
+        except (RuntimeError, ValueError, KeyError, TypeError) as exc:
+            result.error = f"{type(exc).__name__}: {exc}"
+
+    if not result.verdicts:
+        return result
+
+    votes = Counter(v.passed for v in result.verdicts)
+    top, count = votes.most_common(1)[0]
+    result.score = sum(v.score for v in result.verdicts) / len(result.verdicts)
+
+    if len(votes) > 1 and count == len(result.verdicts) - count:
+        result.inconclusive = True          # an even split has no majority
+    elif len(votes) > 1 and count - (len(result.verdicts) - count) <= 1:
+        result.inconclusive = True          # bare 2-1 majority: too weak to trust
+        result.passed = top
+    else:
+        result.passed = top
+    return result
+
+
+def gateway_from_env() -> Gateway:
+    missing = [
+        name
+        for name in ("LLM_GATEWAY_URL", "LLM_GATEWAY_KEY", "LLM_GATEWAY_MODEL")
+        if not os.environ.get(name, "").strip()
+    ]
+    if missing:
+        raise SystemExit(f"missing required environment: {', '.join(missing)}")
+    return Gateway(
+        os.environ["LLM_GATEWAY_URL"],
+        os.environ["LLM_GATEWAY_KEY"],
+        os.environ["LLM_GATEWAY_MODEL"],
+    )


### PR DESCRIPTION
Adds the LLM judge for fastskill error messages — and, first, the fixture that decides whether an LLM can do that job at all.

**Calibration was built and run before the harness, deliberately.** Whether the pinned model could grade error-message quality was an open question. Answering it costs an hour of fixture work; discovering it after building a harness costs the harness.

## Result

10 balanced cases (5 pass / 5 fail), 3 trials each, 50% baseline:

| Model | Backing | Agreement | Verdict |
|---|---|---|---|
| `claude-haiku-4-5` | real Anthropic | **100%** (10/10) | CALIBRATED |
| `claude-sonnet-4-6` | local gemma4 on gx10 | **70%** (7/10) | not calibrated |

### The local model fails on one specific class

It got every *good* message right and both *raw panics* right. It failed exactly the **clean but useless** messages — `repos_skills_unknown_argument`, `generic_invalid_input`, `serde_error_leak`. It conflates "no stack trace" with "good".

Sharpest symptom, on `Error: invalid input`: the model wrote *"does not provide specific details or actionable steps"* and then returned `pass: true`, at a mean score of **2.7** — contradicting both its own justification and the rubric rule that pass requires ≥ 3.

**No prompt tuning was attempted before switching models.** Tuning against the same fixture that measures success fits the judge to those ten cases and inflates the number without improving the judgement. 70% is the honest reading.

## Cost inverts the usual argument

From the gateway’s own spend log:

| Model | per call | per 30-call run |
|---|---|---|
| `claude-haiku-4-5` | $0.00070 | ~$0.02 |
| `claude-sonnet-4-6` | $0.00251 | ~$0.08 |

LiteLLM prices by **alias name**, so the gx10 route is billed at Sonnet rates. The local model is less accurate *and* 3.5× more expensive in the ledger. (Worth knowing beyond this PR: anything using that alias accrues Sonnet-priced spend.)

## Two details that are load-bearing, not incidental

**`<think>` stripping runs on every response.** The local model emits reasoning *non-deterministically* — the same prompt gave a 143-token `<think>` block in one call and a bare 2-token answer in another. This cannot be conditioned on model name or assumed away.

**Majority vote is not padding.** Because reasoning is non-deterministic, single-shot verdicts are not reproducible. A bare 2-1 majority is flagged `inconclusive` (spec 005 Q5) rather than forced — a coin flip recorded as a result poisons the calibration number silently.

## Fixture design

Deliberately **balanced**, and `calibrate.py` prints the always-answer-the-same-way baseline and refuses to certify a judge that merely matches it — otherwise a judge that always says `pass` would score 80% on a skewed fixture and look excellent.

Every `pass` case is **real output captured from fastskill 0.9.179**. The `fail` cases include two **real historical regressions**: the clap duplicate-arg panic `fastskill init` produced before #225, and the untagged-enum serde leak from before the manifest migration. The judge exists to catch a return to those.

## Ops consequence (not applied here)

`LLM_GATEWAY_MODEL` should become `claude-haiku-4-5` for the judge, which requires **re-minting the `fastskill-ci` virtual key** — scoping is by model name and it is currently `["claude-sonnet-4-6","kalm-embed"]`. Left to the repo owner, since it trades the "prefer local models" preference against a measured 30-point accuracy gap.

## Scope

Judge + calibration only. Wiring it over live captured commands is the remaining P2 work — the fixture carries captured output inline, which is exactly what made calibration possible before the runner exists. No product code touched; nothing runs in CI yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)