### PR TITLE
feat(quality): live error-message suite driven by real commands (spec 005 P2)

### DIFF
--- a/ci/quality/error_quality/README.md
+++ b/ci/quality/error_quality/README.md
@@ -17,9 +17,42 @@ assertion instead.
 
 | | |
 |---|---|
-| `cases.json` | Calibration fixture — human verdicts on real fastskill errors |
 | `judge.py` | Rubric, gateway client, majority vote |
+| `cases.json` | Calibration fixture — human verdicts on real fastskill errors |
 | `calibrate.py` | Scores the judge against the fixture. The go/no-go gate. |
+| `suite.json` | The live suite — **commands**, not captured output |
+| `run_suite.py` | Runs each command in a sandbox and judges what comes back |
+
+## Running the live suite
+
+```bash
+LLM_GATEWAY_URL=... LLM_GATEWAY_KEY=... LLM_GATEWAY_MODEL=... \
+    python3 ci/quality/error_quality/run_suite.py --json report.json
+```
+
+`--capture-only` runs the commands and prints what they emit **without calling the
+gateway** — use it to check the harness, add cases, or see what changed, for free.
+
+Each case runs in a disposable sandbox with a bare environment (`PATH` + `HOME` only), so
+a stray `OPENAI_API_KEY` or `FASTSKILL_*` on the machine cannot change which error path
+runs. Sandbox paths are rewritten to `<project>` so captures are stable across runs.
+
+**A case that exits 0 is reported as broken, not judged.** A command that succeeded did
+not produce the error the case exists to grade, and scoring its success output would
+quietly weaken the suite while still looking green.
+
+**This tier is soft.** A poor message exits 0 and appears in the report; only a broken
+harness (no binary, unreachable gateway) fails the run. Past `--max-requests` the
+remaining cases are skipped *and named* — silent truncation would read as full coverage.
+
+### First live run (2026-08-18, judge `claude-haiku-4-5`, 24 requests, ~$0.017)
+
+7 of 8 messages passed. The one flagged poor was `repos_skills_unknown_repo` —
+independently rediscovering the known K-class defect with no hard-coded knowledge of
+which case was bad:
+
+> The error is vague and generic — it doesn't specify which argument is unknown, what the
+> valid arguments are, or how to correct it.
 
 ## Running calibration
 

--- a/ci/quality/error_quality/run_suite.py
+++ b/ci/quality/error_quality/run_suite.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Run fastskill's error paths and judge the messages (spec 005, P2).
+
+The *capture* is deterministic: each case runs a real command against a real binary in a
+disposable sandbox. Only the *scoring* is LLM. That split is the whole design — an
+assertion-based test would have to hard-code wording and would fail on every harmless
+rephrase, which is why these steps were left to a human in the first place.
+
+This tier is **soft** (spec 005): it reports, it does not gate. A judge verdict is
+advisory, so a poor message exits 0 and shows up in the report. Only a broken *harness*
+(no binary, unreachable gateway) is a real failure.
+
+Usage:
+    LLM_GATEWAY_URL=... LLM_GATEWAY_KEY=... LLM_GATEWAY_MODEL=... \\
+        python3 ci/quality/error_quality/run_suite.py [--binary PATH] [--json OUT]
+                                                     [--summary FILE] [--max-requests N]
+                                                     [--capture-only]
+
+Exit codes: 0 = ran (regardless of verdicts), 2 = could not run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from judge import gateway_from_env, judge_case  # noqa: E402
+
+HERE = pathlib.Path(__file__).resolve().parent
+SUITE_PATH = HERE / "suite.json"
+COMMAND_TIMEOUT = 60
+
+MANIFESTS = {
+    # A valid project manifest: enough for commands to resolve a project root.
+    "default": (
+        '[metadata]\nid = "quality-sandbox"\nversion = "1.0.0"\n\n'
+        '[tool.fastskill]\nskills_directory = "skills"\n\n[dependencies]\n'
+    ),
+    # Deliberately missing [dependencies] — drives the config-validation error path.
+    "minimal_no_dependencies": (
+        '[metadata]\nid = "quality-sandbox"\nversion = "1.0.0"\n\n'
+        '[tool.fastskill]\nskills_directory = "skills"\n'
+    ),
+}
+
+
+def find_binary(explicit: str | None) -> str:
+    """Locate the binary under test.
+
+    Order matters: an explicit path wins, then the env var CI sets, then a local debug
+    build, then PATH. PATH is LAST on purpose — picking up an installed release while
+    believing you tested the build under review is exactly the mistake this tier exists
+    to avoid making about error messages.
+    """
+    for candidate in (explicit, os.environ.get("FASTSKILL_BIN")):
+        if candidate:
+            path = pathlib.Path(candidate)
+            if path.is_file():
+                return str(path.resolve())
+            raise SystemExit(f"binary not found: {candidate}")
+
+    for rel in ("target/debug/fastskill", "target/release/fastskill"):
+        path = pathlib.Path(rel)
+        if path.is_file():
+            return str(path.resolve())
+
+    found = shutil.which("fastskill")
+    if found:
+        print(f"warning: falling back to fastskill on PATH ({found}); "
+              f"this may not be the build under test")
+        return found
+    raise SystemExit("no fastskill binary; pass --binary or set FASTSKILL_BIN")
+
+
+def prepare_sandbox(root: pathlib.Path, setup: dict) -> None:
+    """Build a disposable project for one case. Never reuses state between cases."""
+    (root / "skills").mkdir(parents=True, exist_ok=True)
+    manifest = MANIFESTS[setup.get("manifest", "default")]
+    (root / "skill-project.toml").write_text(manifest)
+    for name in setup.get("mkdir", []):
+        (root / name).mkdir(parents=True, exist_ok=True)
+
+
+def run_case(binary: str, case: dict) -> dict:
+    """Execute one case and capture what a user would see."""
+    with tempfile.TemporaryDirectory(prefix="fs-quality-") as tmp:
+        root = pathlib.Path(tmp)
+        prepare_sandbox(root, case.get("setup", {}))
+        try:
+            proc = subprocess.run(
+                [binary, *case["command"]],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=COMMAND_TIMEOUT,
+                # A bare environment except PATH/HOME: a stray OPENAI_API_KEY or
+                # FASTSKILL_* in the ambient environment would change which error path
+                # runs, making the captured message depend on the machine.
+                env={"PATH": os.environ.get("PATH", ""), "HOME": str(root)},
+            )
+            out, err, code, timed_out = proc.stdout, proc.stderr, proc.returncode, False
+        except subprocess.TimeoutExpired:
+            out, err, code, timed_out = "", "", None, True
+
+    # Users see one stream. Judge what they see, not what the plumbing separated.
+    combined = "\n".join(part.strip() for part in (out, err) if part.strip())
+    # Sandbox paths are noise and differ per run; keep the message stable across runs.
+    combined = combined.replace(str(root), "<project>")
+    return {
+        "command": "fastskill " + " ".join(case["command"]),
+        "output": combined,
+        "exit_code": code,
+        "timed_out": timed_out,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--binary", default=None)
+    ap.add_argument("--json", default=None, help="write full results here")
+    ap.add_argument("--summary", default=os.environ.get("GITHUB_STEP_SUMMARY"))
+    ap.add_argument("--trials", type=int, default=3)
+    ap.add_argument("--max-requests", type=int, default=300,
+                    help="hard cap; past it remaining cases are skipped AND logged")
+    ap.add_argument("--capture-only", action="store_true",
+                    help="run commands and print captures without calling the gateway")
+    args = ap.parse_args()
+
+    cases = json.loads(SUITE_PATH.read_text())["cases"]
+    binary = find_binary(args.binary)
+    print(f"binary  {binary}")
+    print(f"cases   {len(cases)}")
+
+    gw = None
+    if not args.capture_only:
+        try:
+            gw = gateway_from_env()
+            print(f"model   {gw.model}")
+        except SystemExit as exc:
+            print(f"cannot run: {exc}")
+            return 2
+    print("-" * 78)
+
+    rows, skipped = [], []
+    for case in cases:
+        captured = run_case(binary, case)
+
+        # A case that succeeds did not produce the error it exists to grade. Judging the
+        # success output would score the wrong thing and quietly weaken the suite.
+        if captured["timed_out"]:
+            print(f"BROKEN   {case['id']:<34} command timed out after {COMMAND_TIMEOUT}s")
+            rows.append({"id": case["id"], "status": "timeout", **captured})
+            continue
+        if captured["exit_code"] == 0:
+            print(f"BROKEN   {case['id']:<34} exited 0 — expected an error to grade")
+            rows.append({"id": case["id"], "status": "unexpected_success", **captured})
+            continue
+
+        if args.capture_only:
+            first = captured["output"].splitlines()[0] if captured["output"] else "(no output)"
+            print(f"capture  {case['id']:<34} exit={captured['exit_code']} {first[:60]}")
+            rows.append({"id": case["id"], "status": "captured", **captured})
+            continue
+
+        if gw.requests_made + args.trials > args.max_requests:
+            skipped.append(case["id"])
+            continue
+
+        result = judge_case(gw, {"id": case["id"], **captured}, trials=args.trials)
+        if not result.verdicts:
+            status = "error"
+            print(f"ERROR    {case['id']:<34} {result.error}")
+        else:
+            status = "pass" if result.passed else "poor"
+            mark = "ok  " if result.passed else "POOR"
+            flag = " (inconclusive)" if result.inconclusive else ""
+            print(f"{mark:<8} {case['id']:<34} score={result.score:.1f}{flag}")
+            if not result.passed:
+                print(f"         └─ {result.verdicts[0].justification[:110]}")
+        rows.append({
+            "id": case["id"], "status": status, **captured,
+            "score": result.score, "passed": result.passed,
+            "inconclusive": result.inconclusive,
+            "justifications": [v.justification for v in result.verdicts],
+        })
+
+    # Silent truncation would read as "everything was covered". Name what was dropped.
+    if skipped:
+        print(f"\nSKIPPED {len(skipped)} case(s) at the {args.max_requests}-request cap: "
+              f"{', '.join(skipped)}")
+
+    poor = [r for r in rows if r.get("status") == "poor"]
+    broken = [r for r in rows if r.get("status") in ("timeout", "unexpected_success")]
+    print("-" * 78)
+    print(f"judged {len([r for r in rows if r.get('status') in ('pass', 'poor')])}  "
+          f"poor {len(poor)}  broken {len(broken)}  skipped {len(skipped)}"
+          + (f"  requests {gw.requests_made}" if gw else ""))
+
+    if args.json:
+        pathlib.Path(args.json).write_text(json.dumps(
+            {"binary": binary, "model": gw.model if gw else None,
+             "poor": len(poor), "broken": len(broken), "skipped": skipped,
+             "cases": rows}, indent=2))
+
+    if args.summary:
+        lines = ["## Error-message quality", ""]
+        if gw:
+            lines.append(f"Judge: `{gw.model}` · {gw.requests_made} requests")
+        lines += ["", "| Case | Verdict | Score |", "|---|---|---|"]
+        for r in rows:
+            verdict = {"pass": "ok", "poor": "**poor**"}.get(r.get("status"), r.get("status"))
+            score = f"{r['score']:.1f}" if r.get("score") is not None else "—"
+            lines.append(f"| `{r['id']}` | {verdict} | {score} |")
+        if poor:
+            lines += ["", "### Messages judged poor", ""]
+            for r in poor:
+                lines += [f"**`{r['id']}`** — `{r['command']}`", "",
+                          "```", r["output"][:600], "```", "",
+                          f"> {(r.get('justifications') or [''])[0][:300]}", ""]
+        if skipped:
+            lines += ["", f"_Skipped at the request cap: {', '.join(skipped)}_"]
+        with open(args.summary, "a") as fh:
+            fh.write("\n".join(lines) + "\n")
+
+    # Soft tier: verdicts never fail the run. Only a broken harness does.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/quality/error_quality/suite.json
+++ b/ci/quality/error_quality/suite.json
@@ -1,0 +1,73 @@
+{
+  "_comment": [
+    "Live error-message suite for the spec-005 nightly quality tier.",
+    "",
+    "Unlike cases.json (the calibration fixture, which carries captured output inline so",
+    "the judge could be calibrated before this runner existed), these cases carry only a",
+    "COMMAND. The runner executes each against the binary under test and judges whatever",
+    "comes back -- so a regression in an error message is caught even though no assertion",
+    "here mentions its wording.",
+    "",
+    "Seeded from the human-judgment error steps of docs/qa/smoke-test-plan.md, which is",
+    "where a person was previously asked 'is this message actually helpful?'.",
+    "",
+    "`setup` runs in the sandbox before the command. Keep it to file creation: the sandbox",
+    "is disposable but the tier must not need network to reach the point of judging.",
+    "",
+    "Every case must FAIL -- a zero exit means the command did not produce the error the",
+    "case exists to grade, and the runner reports that as a broken case rather than",
+    "quietly judging success output."
+  ],
+  "cases": [
+    {
+      "id": "read_not_found",
+      "plan_step": "1.4",
+      "command": ["read", "no-such-skill"],
+      "why": "The most common way a user meets an error: asking for something that isn't installed."
+    },
+    {
+      "id": "remove_not_found",
+      "plan_step": "3.x",
+      "command": ["remove", "ghost"],
+      "why": "Same class as read_not_found; catches the two paths drifting apart."
+    },
+    {
+      "id": "add_nonexistent_path",
+      "plan_step": "3.10",
+      "command": ["add", "./does-not-exist"],
+      "why": "A path typo — the message must name the path and the missing SKILL.md."
+    },
+    {
+      "id": "add_dir_without_skill_md",
+      "plan_step": "3.3",
+      "command": ["add", "./empty-dir"],
+      "setup": {"mkdir": ["empty-dir"]},
+      "why": "The directory exists but isn't a skill. Distinct from a missing path, and the message should say so."
+    },
+    {
+      "id": "add_by_id_without_repository",
+      "plan_step": "7.12",
+      "command": ["add", "someorg/someskill"],
+      "why": "Installing by skill id with no repository configured — must say what to configure, not just refuse."
+    },
+    {
+      "id": "repos_skills_unknown_repo",
+      "plan_step": "7.8",
+      "command": ["repos", "skills", "nosuchrepo"],
+      "why": "Known-poor today (K-class: says 'unknown argument' without naming it). Kept so the tier reports it until it is fixed, and notices if it regresses further."
+    },
+    {
+      "id": "search_invalid_limit",
+      "plan_step": "12.x",
+      "command": ["search", "--limit", "notanumber", "anything"],
+      "why": "Type error on a flag — the message should name the value, the flag, and the expected type."
+    },
+    {
+      "id": "install_without_dependencies_section",
+      "plan_step": "2.x",
+      "command": ["install"],
+      "setup": {"manifest": "minimal_no_dependencies"},
+      "why": "A manifest missing a required section. Exercises the config-validation path rather than the skill-lookup path."
+    }
+  ]
+}


### PR DESCRIPTION
Completes **P2**. The calibration fixture carried captured output inline so the judge could be calibrated before a runner existed; this runs the commands for real.

Each case executes against the binary under test in a disposable sandbox, and the judge scores whatever comes back. **Nothing here asserts on wording** — that is the point. An assertion-based test would hard-code the message and fail on every harmless rephrase, which is why these steps were left to a human in the first place.

## First live run

Judge `claude-haiku-4-5`, 24 requests, **~$0.017**:

```
ok       read_not_found                       score=5.0
ok       remove_not_found                     score=5.0
ok       add_nonexistent_path                 score=5.0
ok       add_dir_without_skill_md             score=5.0
ok       add_by_id_without_repository         score=4.0
POOR     repos_skills_unknown_repo            score=2.0
ok       search_invalid_limit                 score=4.3
ok       install_without_dependencies_section score=5.0
```

It flagged **exactly one** message, and it is the genuinely bad one — `repos skills`, which says "unknown argument" without naming the argument (filed as K9). **The runner has no knowledge of which case is bad.** It ran eight commands and independently reached the same conclusion a human did:

> The error is vague and generic — it doesn’t specify which argument is unknown, what the valid arguments are, or how to correct it.

That is the first evidence the judge works on live output rather than a curated fixture.

## Decisions worth reviewing

These are the difference between a real signal and a comfortable one:

- **Bare environment** (`PATH` + `HOME` only). A stray `OPENAI_API_KEY` or `FASTSKILL_*` on the machine would change which error path runs, making the captured message depend on who ran it.
- **stdout and stderr are judged together**, because that is what a user sees. Judging stderr alone would miss messages printed to stdout before failing (`install` does exactly this).
- **A case that exits 0 is reported BROKEN, not judged.** It did not produce the error it exists to grade, and scoring its success output would weaken the suite while still looking green.
- **PATH is last** in binary resolution, behind `--binary`, `FASTSKILL_BIN`, and a local debug build. Silently grading an installed release while believing you tested the build under review is exactly the mistake this tier exists to catch.
- **Skipped cases are named**, not silently dropped, when `--max-requests` is hit. Silent truncation reads as full coverage.
- Sandbox paths are rewritten to `<project>` so captures are stable and the judge is not scoring a temp directory name.

## Soft tier

Per spec 005, a poor message **exits 0** and lands in the report; only a broken harness (no binary, unreachable gateway) fails the run. Emits a GitHub job summary plus a JSON artifact — pull-based reporting until the tier earns trust (Q7).

`--capture-only` runs the commands and prints their output **without calling the gateway**, so the harness can be checked and cases added for free.

## Scope

No product code touched. Nothing is scheduled yet — P4 (`quality.yml`) is what makes this run on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)