### PR TITLE
feat(quality): blind doc-walk harness (spec 005, P3)

### DIFF
--- a/ci/quality/docwalk/README.md
+++ b/ci/quality/docwalk/README.md
@@ -1,0 +1,179 @@
+# Blind doc-walk harness (spec 005, P3)
+
+Runs a webdoc's own code blocks **exactly as written** and checks whether the doc's
+claimed output still matches reality — without ever letting the thing doing the
+checking also decide what to run.
+
+```
+extract.py    deterministic  -- pull fenced code blocks out of the .mdx, in order,
+                                 verbatim; classify + pre-filter, never edit
+runner.py     deterministic  -- execute each runnable block exactly as written, one
+                                 sandbox per doc, capture output
+classify.py   LLM            -- ONLY compares doc-claimed output vs actual output and
+                                 labels the divergence (match/drift/broken)
+```
+
+## Why the split, specifically
+
+The value of "blind" is a reader who runs the doc verbatim and reports divergence
+**without self-correcting**. An LLM is the worst actor at that — it "knows" the right
+command and silently fixes the doc's mistake, hallucinating success. So the LLM here
+**never decides what runs**. `classify.py`'s prompt has no field for a corrected
+command; it can only emit a verdict and a quote. If you find yourself wiring a command
+suggestion into this pipeline, you have broken the design — see spec 005 section 2.
+
+Per spec 005 Q3, this — like `ci/quality/error_quality` — can never become a PR gate:
+anything with an LLM in the verdict path stays in the nightly soft tier, permanently.
+
+## Files
+
+| | |
+|---|---|
+| `extract.py` | Fence parser (handles 2-4 space indented fences), pre-filters, anchor detection |
+| `runner.py` | Executes runnable blocks in one persistent per-doc sandbox |
+| `classify.py` | Gateway prompt + majority vote over `judge.py`'s `Gateway` |
+| `docs.json` | The settled 4-doc set (spec 005 Q10) |
+| `run_docwalk.py` | CLI entry point tying the three stages together |
+
+`classify.py` reuses `error_quality/judge.py`'s `Gateway`, `strip_reasoning`, and
+`extract_json` rather than reimplementing the gateway client or the `<think>`-block
+handling — same gateway, same reasoning-model quirks.
+
+## Running it
+
+```bash
+LLM_GATEWAY_URL=... LLM_GATEWAY_KEY=... LLM_GATEWAY_MODEL=... \
+    python3 ci/quality/docwalk/run_docwalk.py --json report.json
+```
+
+`--capture-only` runs the extractor and the sandboxed commands and prints what came
+back, **without calling the gateway at all** — this is how you check the harness
+itself, or see what a doc's blocks actually do, for free. It needs no gateway
+credentials and no network beyond whatever the doc's own commands touch.
+
+Exit codes: **0** always, except a harness that genuinely cannot run — no binary, or a
+gateway that fails a one-request connectivity preflight — which exits **2**. A doc
+full of `broken` verdicts still exits 0: this tier reports, it never gates (spec 005
+Q3). `--max-requests` (default 300) caps gateway calls; classifications past the cap
+are skipped **and named** in both the console output and the summary, never silently
+dropped.
+
+## Extraction rules (what gets run, what gets flagged, and why)
+
+- Fences are found by scanning for opening/closing backtick runs at **any**
+  indentation, not just column 0 — a `^```` scanner misses blocks nested inside list
+  items (see `webdocs/quickstart.mdx`, "Add standard-compliant skills").
+- A ```bash/sh/shell/zsh/console``` block is a **command** candidate. It is
+  pre-filtered and flagged `human-review` — never run, never silently skipped — if it:
+  - contains a `$ `-prefixed line (illustrative prompt+output, e.g.
+    `webdocs/skill-management/reconciliation.mdx`'s status tables),
+  - contains a placeholder (`<...>`, `/path/to`, or the `your-*` family — `your-org`,
+    `your-token`, and the `your-key-here` / `your-gateway-key` shapes found in
+    `configuration/init-command.mdx` during this build),
+  - or is a network installer (`curl ... | bash`, `sudo`,
+    `brew`/`scoop`/`cargo install`) — banned even inside a sandboxed container.
+- ```toml/json/yaml/yml``` blocks are **file bodies**, never executed. If the fence's
+  info string names a file (```toml skill-project.toml```), the body is written
+  verbatim to the sandbox before later commands run; an untagged file body (an
+  illustrative fragment, e.g. `configuration/init-command.mdx`'s `schema_version`
+  snippets) is recorded but not written anywhere.
+- Everything else (untagged fences, `mermaid`, etc.) is **prose**: never executed. A
+  bare fence directly under a command block is treated as that command's claimed
+  output instead of an orphan (see anchors, below).
+- Heading sections with **zero** code blocks anywhere under them (e.g.
+  `validation.mdx`'s "Best Practices" essay) are flagged separately, at the section
+  level — this is the "prose-only step… still needs a human" limit from spec 005,
+  generalized from one named example to every such section, found mechanically. A
+  parent heading and a code-free child heading both get flagged independently, which
+  reads verbose but is honest: no code exists anywhere in either scope.
+
+## Sandboxing: one sandbox per *doc*, not per block
+
+Unlike `error_quality` (fresh sandbox per case), a doc-walk uses **one persistent
+sandbox per doc**, walked top to bottom. A real reader works in one directory; a doc
+that creates `skill-project.toml` in step 2 is *supposed* to have it still there in
+step 4. Isolating every block would make an internally consistent multi-step doc look
+broken for no reason.
+
+The sandbox starts **empty** — the runner never pre-seeds a skills directory or
+manifest fields a doc doesn't create itself. If a doc's own steps don't create
+something a later step needs, that's a real doc finding, not a harness bug to paper
+over.
+
+Commands run with `stdin=DEVNULL`: an interactive command (`fastskill init` with no
+`--yes`) hits EOF immediately, exactly as it would for anyone who actually piped the
+doc into a non-interactive shell. Blocks run without `set -e`, matching how a person
+pastes lines one at a time — one failed line doesn't stop the rest of the block, which
+matters for blocks that present several alternative examples in one fence (spec's
+"verbatim" is the fence's contents, not an implied `&&`-chain).
+
+## Expected-output anchors
+
+There is no clean command/output pairing in the corpus — that's exactly why the
+comparison step is LLM, not diff. Three anchor kinds, all attached automatically:
+
+- **`output-comment`** — the inline `` # Output: `` convention, single- or multi-line
+  (`webdocs/skill-management/reconciliation.mdx` is the densest: 6 of the corpus's
+  known ~14 occurrences).
+- **`next-block`** — a bare fence immediately following a command block
+  (`configuration/init-command.mdx`'s interactive-prompt example).
+- **`prose-hint`** — a "you'll see…" / "you should see…" sentence outside any fence,
+  attached to whichever block is nearest by line distance, in **either** direction
+  (validation.mdx's hint precedes its example; quickstart's follows it).
+
+A block that ran but has **no** anchor is reported as `no_anchor` and never sent to
+the gateway — nothing to compare, so no request is spent. A block that has an anchor
+but wasn't run (flagged `human-review`) still reports the anchor text, for a human.
+
+## Classification
+
+3 trials per block (spec 005 Q5), majority vote. With three verdict categories instead
+of `error_quality`'s pass/fail, "majority" is stricter here: only a **unanimous 3/3**
+counts as decisive. Any split — 2-1 or 1-1-1 — is `inconclusive`, but still reports the
+leading label so a human has a lead, not just a shrug.
+
+## First live run (2026-08-18, judge `claude-haiku-4-5`, 22 requests)
+
+7 of 45 blocks across the 4 docs had a claimed-output anchor and were actually run, so
+7 were sent to the judge: **0 match, 1 drift, 6 broken, 0 inconclusive.**
+
+Two independent, genuine doc bugs, not seeded or hand-picked:
+
+- **`webdocs/quickstart.mdx`** — the manifest the doc tells you to create in step 2
+  (`skill-project.toml` with only `[dependencies]`) has no `[tool.fastskill]` /
+  `skills_directory`. Every later command in the walkthrough (`install`, `search`)
+  fails with `Configuration error: project-level skill-project.toml requires
+  [tool.fastskill] with skills_directory`.
+- **`webdocs/skill-management/reconciliation.mdx`** — 4 of its `broken` verdicts share
+  one root cause, not four independent bugs: the doc is written as a *reference* (what
+  do the reconciliation states mean) rather than a self-contained walkthrough, so its
+  `fastskill list` examples assume a project that was never set up earlier **in this
+  file**. A blind, literal walk of just this doc correctly reports that as broken; a
+  human reading it in context understands it's describing an existing project. Worth
+  a decision (add a "assumes an existing project" note, or make it self-contained) but
+  not a crash.
+- `configuration/init-command.mdx`'s one `drift`: the doc's interactive-prompt
+  transcript vs. what a headless, EOF-on-stdin run of `fastskill init` (no `--yes`)
+  actually prints — expected, not a red flag; a genuinely blind non-interactive run of
+  that exact command can't reproduce a human's typed answers.
+
+Extraction/flag counts, per doc (`--capture-only`, no gateway calls, verified separately):
+
+| Doc | Blocks | Command blocks run | Flagged human-review (command) | File bodies | Prose sections flagged | Anchors found |
+|---|---|---|---|---|---|---|
+| `quickstart.mdx` | 8 | 7 | 0 | 1 | 2 | 1 |
+| `skill-management/validation.mdx` | 3 | 1 | 2 | 0 | 13 | 1 |
+| `configuration/init-command.mdx` | 12 | 2 | 2 | 6 | 10 | 1 |
+| `skill-management/reconciliation.mdx` | 22 | 13 | 5 | 3 | 9 | 6 |
+
+`validation.mdx` and `init-command.mdx` run far fewer of their command blocks than
+`quickstart.mdx`/`reconciliation.mdx` — most of their bash fences are either
+`$`-prefixed illustrative transcripts or contain a placeholder (`<skill-id>`,
+`your-key-here`), which the pre-filter is designed to catch, not a harness gap.
+
+## Extending the doc set
+
+The 4-doc set is deliberately settled (spec 005 Q10) — do not add docs here without
+re-opening that decision. `installation.mdx` (global installers), `manifest-system.mdx`
+(mostly illustrative TOML), and the registry/tool-calling docs (placeholder-dense) were
+excluded on purpose for v1.

--- a/ci/quality/docwalk/classify.py
+++ b/ci/quality/docwalk/classify.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""LLM classifier for the blind doc-walk harness (spec 005, P3).
+
+This is the ONLY place an LLM appears in the whole doc-walk pipeline, and its job is
+narrow on purpose: compare what a doc *claims* the output will be against what the
+sandboxed run actually produced, and label the divergence. It never sees a broken
+command and suggests a fix — there is no "corrected command" field anywhere in the
+schema below, and the prompt tells the model outright not to try.
+
+Reuses `judge.py`'s `Gateway`, `strip_reasoning`, and `extract_json` — the gateway
+client, `<think>`-block stripping, and tolerant JSON parsing are identical concerns to
+the error-quality judge (same gateway, same reasoning-model quirks) and are not
+reimplemented here.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+
+import sys
+import pathlib
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "error_quality"))
+from judge import Gateway, extract_json  # noqa: E402
+
+VERDICTS = ("match", "drift", "broken")
+
+RUBRIC = """\
+You are checking whether a documentation example's CLAIMED output matches what
+ACTUALLY happened when the exact commands from the doc were run verbatim in a fresh
+sandbox.
+
+You are NOT being asked whether the command is well-written, idiomatic, or how you
+would fix it. Do not propose a different command, a corrected command, or any kind of
+fix. Only compare the two texts you are given and classify the divergence between
+them.
+
+Classify as exactly one of:
+  match  - the actual output is consistent with what the doc claims. Minor
+           formatting, whitespace, ordering, or timestamp differences still count as
+           a match.
+  drift  - the command(s) ran, but the actual output differs in SUBSTANCE from what
+           the doc claims (different values, different fields, wording that changes
+           the meaning) — the workflow basically works but the doc's example is
+           stale.
+  broken - the actual output shows the documented command failing, erroring, or
+           crashing in a way the doc's claim does not anticipate — the doc's
+           instructions do not work as written.
+
+Reply with ONLY a JSON object, no prose and no code fence:
+{"verdict": "match"|"drift"|"broken", "quote": "<the exact actual-output text that diverges from the claim, or empty string if match>"}
+"""
+
+
+@dataclass
+class Trial:
+    verdict: str
+    quote: str
+
+
+@dataclass
+class ClassifyResult:
+    block_index: int
+    trials: list[Trial] = field(default_factory=list)
+    verdict: str | None = None      # majority verdict; None when no majority at all
+    inconclusive: bool = False
+    quote: str = ""
+    error: str | None = None
+
+
+def build_prompt(command_text: str, claimed: str, actual: str, exit_code: int | None) -> str:
+    return (
+        f"{RUBRIC}\n"
+        f"Command(s) exactly as written in the doc:\n---\n{command_text}\n---\n\n"
+        f"Doc's claimed output:\n---\n{claimed}\n---\n\n"
+        f"Actual output (exit code {exit_code}):\n---\n{actual}\n---\n"
+    )
+
+
+def classify_block(
+    gw: Gateway, block_index: int, command_text: str, claimed: str, actual: str,
+    exit_code: int | None, trials: int = 3,
+) -> ClassifyResult:
+    """Classify one block over N trials and take the majority verdict.
+
+    Same reasoning as `judge.judge_case`: the pinned model reasons
+    non-deterministically, so a single call is not reproducible. Unlike the binary
+    pass/fail judge, this is a 3-way classification, so "majority" is stricter here —
+    only a unanimous 3/3 counts as decisive. A 2-1 split is flagged `inconclusive`
+    (spec 005 Q5's "bare 2-1" rule, generalized from 2 categories to 3) but still
+    reports the leading label so a human has a lead to follow, not just a shrug.
+    """
+    result = ClassifyResult(block_index=block_index)
+    prompt = build_prompt(command_text, claimed, actual, exit_code)
+    for _ in range(trials):
+        try:
+            raw = gw.complete(prompt, max_tokens=1200)
+            data = extract_json(raw)
+            verdict = str(data["verdict"]).strip().lower()
+            if verdict not in VERDICTS:
+                raise ValueError(f"unexpected verdict {verdict!r}")
+            result.trials.append(Trial(verdict=verdict, quote=str(data.get("quote", "")).strip()))
+        except (RuntimeError, ValueError, KeyError, TypeError) as exc:
+            result.error = f"{type(exc).__name__}: {exc}"
+
+    if not result.trials:
+        return result
+
+    votes = Counter(t.verdict for t in result.trials)
+    top_verdict, top_count = votes.most_common(1)[0]
+    quotes = [t.quote for t in result.trials if t.verdict == top_verdict and t.quote]
+
+    if top_count == len(result.trials) and len(votes) == 1:
+        result.verdict = top_verdict
+        result.quote = quotes[0] if quotes else ""
+    else:
+        result.inconclusive = True
+        result.verdict = top_verdict  # leaning, not decisive — caller must check flag
+        result.quote = quotes[0] if quotes else ""
+    return result

--- a/ci/quality/docwalk/docs.json
+++ b/ci/quality/docwalk/docs.json
@@ -1,0 +1,8 @@
+{
+  "docs": [
+    "webdocs/quickstart.mdx",
+    "webdocs/skill-management/validation.mdx",
+    "webdocs/configuration/init-command.mdx",
+    "webdocs/skill-management/reconciliation.mdx"
+  ]
+}

--- a/ci/quality/docwalk/extract.py
+++ b/ci/quality/docwalk/extract.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Deterministic extractor for the blind doc-walk harness (spec 005, P3).
+
+Pulls fenced code blocks out of a webdocs `.mdx` file **in order, verbatim** — this
+module never decides what a block means beyond mechanical classification (command /
+file body / prose) and never edits a block's content. The LLM only shows up later, in
+`classify.py`, and only to compare a doc's claimed output against what actually ran.
+
+Stdlib only.
+
+Known, deliberate scope limits (see spec 005 section 2 and the module docstring in
+`run_docwalk.py` for the full design rationale):
+
+- Only blocks written as fenced code (``` ... ```) are considered "extractable". A
+  fence can be indented 2-4 spaces (list items) — a column-0-only scanner misses those
+  (see `webdocs/quickstart.mdx`, the "Add standard-compliant skills" bullet).
+- Three block kinds: "command" (bash/sh/shell/zsh/console — a runnable candidate),
+  "file" (toml/json/yaml/yml — an input written to disk, never executed), and "prose"
+  (anything else, including untagged fences — never executed, may serve as an
+  expected-output anchor for the preceding command).
+- A command block is pre-filtered and flagged "human-review" (never run) if it:
+  contains a `$ `-prefixed line (illustrative prompt+output), contains a placeholder
+  (`<...>`, `/path/to`, `your-*`), or contains a network installer
+  (`curl ... | bash`, `sudo`, `brew/scoop/cargo install`) — banned even in a sandbox.
+- Prose-only *sections* (a heading with zero code blocks anywhere under it) are
+  reported too, separately from block-level flags — see `find_prose_sections`. This is
+  what "no silent caps" means in practice: a doc step that never had code to extract
+  must still show up in the report, not vanish.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+COMMAND_LANGS = {"bash", "sh", "shell", "zsh", "console", "shell-session"}
+FILE_LANGS = {"toml", "json", "yaml", "yml"}
+
+# Placeholder shapes seen in the real webdocs census (spec 005): angle brackets
+# (`<skill-id>`), `/path/to/...`, and the `your-org` / `your-token` / `your-key`
+# family. The `your-[a-z-]+` half is intentionally broader than the two examples
+# named in the spec — `your-key-here` and `your-gateway-key` are the same shape and
+# were found in configuration/init-command.mdx during this build.
+PLACEHOLDER_RE = re.compile(r"<[a-zA-Z][\w.-]*>|/path/to\b|\byour-[a-z][a-z-]*\b")
+
+# Network installers stay banned even inside the sandbox container (spec 005, Q8):
+# a fresh container is still a real machine with real network egress.
+NETWORK_INSTALL_RE = re.compile(
+    r"curl[^\n]*\|\s*(bash|sh)\b|\bsudo\b|\b(brew|scoop|cargo)\s+install\b",
+    re.IGNORECASE,
+)
+
+DOLLAR_PREFIX_RE = re.compile(r"^\$ ")
+
+OUTPUT_COMMENT_RE = re.compile(r"^\s*#\s*output:?\s*(.*)$", re.IGNORECASE)
+
+# "you'll see...", "you should see...", "you should now see..." — prose claims about
+# output that live outside any fence (often inside a <Callout>).
+PROSE_HINT_RE = re.compile(
+    r"you(?:'ll| will| should)(?: now)? see[^.\n]{0,220}[.\n]", re.IGNORECASE
+)
+
+# A prose block is only worth pairing as an "expected output" anchor for the
+# preceding command if it isn't itself a command/file block in disguise.
+PROSE_ANCHOR_LANGS = {"", "text", "output", "console-output", "plaintext", "plain"}
+
+
+@dataclass
+class Anchor:
+    kind: str  # "output-comment" | "next-block" | "prose-hint"
+    text: str
+
+
+@dataclass
+class Block:
+    index: int
+    line_start: int
+    line_end: int
+    lang: str
+    filename: str | None
+    raw: str
+    kind: str  # "command" | "file" | "prose"
+    run: bool
+    skip_reason: str | None = None
+    notes: list[str] = field(default_factory=list)
+    anchors: list[Anchor] = field(default_factory=list)
+    consumed_as_anchor_for: int | None = None
+
+    # Populated by runner.py for blocks that were actually executed.
+    output: str | None = None
+    exit_code: int | None = None
+    timed_out: bool = False
+
+    @property
+    def command_text(self) -> str:
+        return self.raw
+
+
+@dataclass
+class ProseSection:
+    heading: str
+    line: int
+    reason: str
+
+
+@dataclass
+class ExtractedDoc:
+    path: str
+    blocks: list[Block]
+    prose_sections: list[ProseSection]
+
+
+@dataclass
+class _RawFence:
+    start_line: int
+    end_line: int
+    indent: str
+    info: str
+    raw: str
+
+
+def _parse_fences(text: str) -> list[_RawFence]:
+    """Pull every fenced block, in order, tolerating 2-4 space indentation.
+
+    CommonMark's actual closing-fence rule (>= as many backticks, indented no more
+    than the opener) is approximated here: we require the same-or-fewer indent and at
+    least as many backticks. That is sufficient for the fence shapes real webdocs
+    actually use and deliberately does not try to be a full Markdown parser.
+    """
+    lines = text.splitlines()
+    fence_open = re.compile(r"^(?P<indent>[ \t]*)(?P<fence>`{3,})(?P<info>.*)$")
+    fences: list[_RawFence] = []
+    i, n = 0, len(lines)
+    while i < n:
+        m = fence_open.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        indent, fence_chars, info = m.group("indent"), m.group("fence"), m.group("info").strip()
+        start_line = i + 1  # 1-based
+        i += 1
+        content: list[str] = []
+        closed = False
+        close_re = re.compile(rf"^[ \t]{{0,{len(indent)}}}`{{{len(fence_chars)},}}\s*$")
+        while i < n:
+            if close_re.match(lines[i]):
+                closed = True
+                break
+            content.append(lines[i])
+            i += 1
+        end_line = i + 1 if closed else i  # 1-based; unclosed fence ends at EOF
+        dedented = [
+            l[len(indent):] if l[: len(indent)] == indent else l.lstrip(" \t")
+            for l in content
+        ]
+        fences.append(_RawFence(start_line, end_line, indent, info, "\n".join(dedented)))
+        if closed:
+            i += 1  # step past the closing fence line
+    return fences
+
+
+def _classify_lang(info: str) -> tuple[str, str | None]:
+    parts = info.split(None, 1)
+    lang = parts[0].lower() if parts else ""
+    extra = parts[1].strip() if len(parts) > 1 else ""
+    return lang, (extra or None)
+
+
+def _prefilter_command(raw: str) -> str | None:
+    """Return a skip reason if this command block must never be run, else None."""
+    if any(DOLLAR_PREFIX_RE.match(line.lstrip()) for line in raw.splitlines()):
+        return "illustrative prompt+output ($-prefixed line)"
+    if PLACEHOLDER_RE.search(raw):
+        return "contains a placeholder (<...>, /path/to, or your-*)"
+    if NETWORK_INSTALL_RE.search(raw):
+        return "network installer / privileged install — banned even in a sandbox"
+    return None
+
+
+def _extract_output_comment_anchors(raw: str) -> list[Anchor]:
+    """Pull `# Output: ...` (single- or multi-line) annotations out of a block.
+
+    Both shapes are real (see webdocs/skill-management/reconciliation.mdx):
+    `# Output: <one line>` and `# Output:` followed by more `#`-prefixed lines.
+    The block still executes with these comments in it — bash ignores `#` lines on
+    its own, so nothing needs to be stripped before running.
+    """
+    lines = raw.splitlines()
+    anchors: list[Anchor] = []
+    i, n = 0, len(lines)
+    while i < n:
+        m = OUTPUT_COMMENT_RE.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        parts = [m.group(1)] if m.group(1) else []
+        i += 1
+        while i < n and lines[i].lstrip().startswith("#"):
+            parts.append(lines[i].lstrip().lstrip("#").strip())
+            i += 1
+        text = "\n".join(p for p in parts if p)
+        if text:
+            anchors.append(Anchor(kind="output-comment", text=text))
+    return anchors
+
+
+def _find_prose_hint_anchors(doc_text: str, blocks: list[Block]) -> None:
+    """Attach "you should see..." prose claims to the nearest block, either direction.
+
+    These live outside fences entirely (typically inside a `<Callout>`), so they are
+    found by scanning the raw document text, not the fence list. The claim can refer
+    either to the example just above it ("...ran fine:\\n```\\n...") or the one just
+    below it ("you'll see: ```\\n...```") — validation.mdx uses the latter shape
+    ("If validation fails, you'll see specific error messages:" immediately precedes
+    the example), so nearest-by-absolute-distance beats nearest-preceding-only.
+    """
+    for m in PROSE_HINT_RE.finditer(doc_text):
+        hint_line = doc_text.count("\n", 0, m.start()) + 1
+        best, best_dist = None, None
+        for b in blocks:
+            if b.line_start <= hint_line <= b.line_end:
+                dist = 0
+            else:
+                dist = min(abs(hint_line - b.line_start), abs(hint_line - b.line_end))
+            if best_dist is None or dist < best_dist:
+                best, best_dist = b, dist
+        if best is not None and best_dist <= 20:
+            best.anchors.append(Anchor(kind="prose-hint", text=m.group(0).strip()))
+
+
+def _find_prose_sections(doc_text: str, blocks: list[Block]) -> list[ProseSection]:
+    """Flag headings whose whole section (incl. subsections) has zero code blocks.
+
+    This is the "prose-only step" limit spec 005 calls out explicitly ("open the file
+    and check it looks reasonable" doesn't extract into a command and still needs a
+    human) — generalized from "one named example" to "every heading section with no
+    code at all", found mechanically rather than by hand-picking examples.
+    """
+    heading_re = re.compile(r"^(#{2,3})[ \t]+(.+?)\s*$", re.MULTILINE)
+    headings = [
+        (len(m.group(1)), m.group(2).strip(), doc_text.count("\n", 0, m.start()) + 1)
+        for m in heading_re.finditer(doc_text)
+    ]
+    flags: list[ProseSection] = []
+    for idx, (level, title, line) in enumerate(headings):
+        end_line = len(doc_text.splitlines()) + 1
+        for level2, _title2, line2 in headings[idx + 1 :]:
+            if level2 <= level:
+                end_line = line2
+                break
+        has_code = any(line < b.line_start < end_line for b in blocks)
+        if not has_code:
+            flags.append(
+                ProseSection(
+                    heading=title,
+                    line=line,
+                    reason="prose-only section, no code block to extract",
+                )
+            )
+    return flags
+
+
+def extract_doc(path: str) -> ExtractedDoc:
+    text = open(path, encoding="utf-8").read()
+    fences = _parse_fences(text)
+
+    blocks: list[Block] = []
+    for idx, fence in enumerate(fences):
+        lang, extra = _classify_lang(fence.info)
+        if lang in COMMAND_LANGS:
+            kind = "command"
+        elif lang in FILE_LANGS:
+            kind = "file"
+        else:
+            kind = "prose"
+
+        block = Block(
+            index=idx,
+            line_start=fence.start_line,
+            line_end=fence.end_line,
+            lang=lang,
+            filename=extra if kind == "file" else None,
+            raw=fence.raw,
+            kind=kind,
+            run=False,
+        )
+
+        if kind == "command":
+            reason = _prefilter_command(fence.raw)
+            if reason:
+                block.skip_reason = reason
+            else:
+                block.run = True
+            block.anchors.extend(_extract_output_comment_anchors(fence.raw))
+        elif kind == "file":
+            block.skip_reason = "file body (toml/json/yaml) — an input, not a command"
+            if NETWORK_INSTALL_RE.search(fence.raw):
+                block.notes.append(
+                    "contains network-installer text; not executed because it is a "
+                    "file body, flagged for visibility only"
+                )
+        else:  # prose
+            block.skip_reason = f"prose/non-command content (lang={lang!r}); needs human review"
+
+        blocks.append(block)
+
+    # Pair a bare prose fence immediately after a command block as its output anchor.
+    for i, block in enumerate(blocks):
+        if block.kind != "command":
+            continue
+        if i + 1 >= len(blocks):
+            continue
+        nxt = blocks[i + 1]
+        if (
+            nxt.kind == "prose"
+            and nxt.lang in PROSE_ANCHOR_LANGS
+            and nxt.raw.strip()
+            and (nxt.line_start - block.line_end) <= 6
+        ):
+            block.anchors.append(Anchor(kind="next-block", text=nxt.raw.strip()))
+            nxt.consumed_as_anchor_for = block.index
+            nxt.skip_reason = f"consumed as expected-output anchor for block #{block.index}"
+
+    _find_prose_hint_anchors(text, blocks)
+    prose_sections = _find_prose_sections(text, blocks)
+
+    return ExtractedDoc(path=path, blocks=blocks, prose_sections=prose_sections)

--- a/ci/quality/docwalk/run_docwalk.py
+++ b/ci/quality/docwalk/run_docwalk.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Blind doc-walk harness (spec 005, P3): does the doc still say what actually happens?
+
+Three deterministic-then-LLM stages, and the split is the entire point (spec 005
+section 2): a reader who "knows" the right command and silently fixes a doc's mistake
+is the worst possible judge of whether that doc is broken. So the stages are:
+
+    extract.py    deterministic  -- pull fenced code blocks out of the .mdx, in order,
+                                     verbatim; classify + pre-filter, never edit.
+    runner.py     deterministic  -- execute each runnable block exactly as written, in
+                                     one sandbox per doc, capture output.
+    classify.py   LLM            -- ONLY compares doc-claimed output vs actual output
+                                     and labels the divergence (match/drift/broken). It
+                                     never authors, repairs, or suggests a command.
+
+This tier is **soft** (spec 005 Q3): a poor doc, drifted output, or a "broken" verdict
+all exit 0 and show up in the report. Only a broken *harness* — no binary, or a gateway
+that cannot be reached at all — exits 2. That mirrors `ci/quality/error_quality/run_suite.py`
+exactly; see that module's docstring for the same design note in the sibling tier.
+
+Usage:
+    LLM_GATEWAY_URL=... LLM_GATEWAY_KEY=... LLM_GATEWAY_MODEL=... \\
+        python3 ci/quality/docwalk/run_docwalk.py [--binary PATH] [--json OUT]
+                                                  [--summary FILE] [--max-requests N]
+                                                  [--capture-only]
+
+Exit codes: 0 = ran (regardless of verdicts), 2 = could not run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import shutil
+import sys
+from collections import Counter
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent.parent
+DOCS_PATH = HERE / "docs.json"
+
+sys.path.insert(0, str(HERE))
+from extract import Block, extract_doc  # noqa: E402
+from runner import run_doc_blocks  # noqa: E402
+from classify import classify_block  # noqa: E402
+
+sys.path.insert(0, str(HERE.parent / "error_quality"))
+from judge import gateway_from_env  # noqa: E402
+
+ANCHOR_LABELS = {
+    "output-comment": "inline `# Output:` comment",
+    "next-block": "the output shown directly under this command",
+    "prose-hint": "prose claim elsewhere in the doc",
+}
+
+
+def find_binary(explicit: str | None) -> str | None:
+    """Locate the binary under test — same order-of-precedence as error_quality's:
+    explicit flag, then env, then a local debug/release build, then PATH last (PATH
+    picking up an installed release while you believe you're testing HEAD is exactly
+    the mistake a doc-walk exists to catch)."""
+    for candidate in (explicit, os.environ.get("FASTSKILL_BIN")):
+        if candidate:
+            path = pathlib.Path(candidate)
+            if path.is_file():
+                return str(path.resolve())
+            print(f"binary not found: {candidate}")
+            return None
+    for rel in ("target/debug/fastskill", "target/release/fastskill"):
+        path = REPO_ROOT / rel
+        if path.is_file():
+            return str(path.resolve())
+    found = shutil.which("fastskill")
+    if found:
+        print(f"warning: falling back to fastskill on PATH ({found}); "
+              f"this may not be the build under test")
+        return found
+    print("no fastskill binary; pass --binary or set FASTSKILL_BIN")
+    return None
+
+
+def _claimed_text(block: Block) -> str:
+    parts = []
+    for a in block.anchors:
+        label = ANCHOR_LABELS.get(a.kind, a.kind)
+        parts.append(f"[{label}]\n{a.text}")
+    return "\n\n".join(parts)
+
+
+def process_doc(doc_rel: str, binary: str, gw, capture_only: bool, max_requests: int, trials: int):
+    doc_path = REPO_ROOT / doc_rel
+    extracted = extract_doc(str(doc_path))
+    run_doc_blocks(binary, extracted.blocks)
+
+    rows = []
+    skipped_at_cap = []
+    for block in extracted.blocks:
+        row = {
+            "doc": doc_rel,
+            "index": block.index,
+            "line_start": block.line_start,
+            "line_end": block.line_end,
+            "lang": block.lang,
+            "kind": block.kind,
+            "filename": block.filename,
+            "run": block.run,
+            "skip_reason": block.skip_reason,
+            "notes": block.notes,
+            "anchors": [{"kind": a.kind, "text": a.text} for a in block.anchors],
+            "output": block.output,
+            "exit_code": block.exit_code,
+            "timed_out": block.timed_out,
+            "classify_status": "not_applicable",
+            "classify_verdict": None,
+            "classify_quote": "",
+            "classify_inconclusive": False,
+        }
+
+        if block.kind == "command" and block.run:
+            if not block.anchors:
+                row["classify_status"] = "no_anchor"
+            elif capture_only:
+                row["classify_status"] = "capture_only"
+            elif gw is None:
+                row["classify_status"] = "no_anchor"
+            elif gw.requests_made + trials > max_requests:
+                row["classify_status"] = "skipped_cap"
+                skipped_at_cap.append(f"{doc_rel}#{block.index}")
+            else:
+                result = classify_block(
+                    gw, block.index, block.command_text, _claimed_text(block),
+                    block.output or "", block.exit_code, trials=trials,
+                )
+                if not result.trials:
+                    row["classify_status"] = "classify_error"
+                    row["classify_error"] = result.error
+                elif result.inconclusive:
+                    row["classify_status"] = "inconclusive"
+                    row["classify_verdict"] = result.verdict
+                    row["classify_quote"] = result.quote
+                    row["classify_inconclusive"] = True
+                else:
+                    row["classify_status"] = result.verdict
+                    row["classify_verdict"] = result.verdict
+                    row["classify_quote"] = result.quote
+
+        rows.append(row)
+
+    prose_sections = [
+        {"heading": p.heading, "line": p.line, "reason": p.reason}
+        for p in extracted.prose_sections
+    ]
+
+    commands_total = sum(1 for b in extracted.blocks if b.kind == "command")
+    commands_run = sum(1 for b in extracted.blocks if b.kind == "command" and b.run)
+    commands_flagged = commands_total - commands_run
+    file_bodies = sum(1 for b in extracted.blocks if b.kind == "file")
+    prose_blocks = sum(
+        1 for b in extracted.blocks if b.kind == "prose" and b.consumed_as_anchor_for is None
+    )
+    prose_consumed = sum(
+        1 for b in extracted.blocks if b.kind == "prose" and b.consumed_as_anchor_for is not None
+    )
+    anchors_found = sum(len(b.anchors) for b in extracted.blocks)
+
+    counts = {
+        "blocks_total": len(extracted.blocks),
+        "commands_total": commands_total,
+        "commands_run": commands_run,
+        "commands_flagged_human_review": commands_flagged,
+        "file_bodies": file_bodies,
+        "prose_blocks_flagged": prose_blocks,
+        "prose_blocks_consumed_as_anchor": prose_consumed,
+        "prose_sections_flagged": len(prose_sections),
+        "anchors_found": anchors_found,
+    }
+
+    return {
+        "doc": doc_rel,
+        "counts": counts,
+        "prose_sections": prose_sections,
+        "blocks": rows,
+    }, skipped_at_cap
+
+
+def _print_doc_summary(doc_report: dict) -> None:
+    c = doc_report["counts"]
+    print(f"\n{doc_report['doc']}")
+    print(
+        f"  blocks={c['blocks_total']}  "
+        f"commands: run={c['commands_run']} flagged={c['commands_flagged_human_review']}  "
+        f"file-bodies={c['file_bodies']}  "
+        f"prose: flagged={c['prose_blocks_flagged']} consumed-as-anchor={c['prose_blocks_consumed_as_anchor']}  "
+        f"prose-sections-flagged={c['prose_sections_flagged']}  "
+        f"anchors={c['anchors_found']}"
+    )
+    for row in doc_report["blocks"]:
+        if row["kind"] == "command" and row["run"]:
+            status = row["classify_status"]
+            mark = {
+                "match": "MATCH ", "drift": "DRIFT ", "broken": "BROKEN",
+                "inconclusive": "UNSURE", "no_anchor": "ran   ", "capture_only": "capture",
+                "skipped_cap": "SKIP  ", "classify_error": "ERROR ",
+            }.get(status, status)
+            exit_repr = "timeout" if row["timed_out"] else row["exit_code"]
+            print(f"    [{block_tag(row)}] {mark:<8} exit={exit_repr} line={row['line_start']}")
+            if status in ("drift", "broken") and row["classify_quote"]:
+                print(f"             └─ {row['classify_quote'][:160]}")
+        elif row["kind"] == "command" and not row["run"]:
+            print(f"    [{block_tag(row)}] FLAGGED line={row['line_start']} — {row['skip_reason']}")
+        elif row["kind"] == "file":
+            print(f"    [{block_tag(row)}] FILE    line={row['line_start']} — {row['skip_reason']}")
+        elif row["kind"] == "prose":
+            if row["skip_reason"] and row["skip_reason"].startswith("consumed"):
+                continue  # not independently interesting; already shown as an anchor
+            print(f"    [{block_tag(row)}] PROSE   line={row['line_start']} — {row['skip_reason']}")
+    for p in doc_report["prose_sections"]:
+        print(f"    [section] line={p['line']} {p['heading']!r} — {p['reason']}")
+
+
+def block_tag(row: dict) -> str:
+    return f"#{row['index']:>2}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--binary", default=None)
+    ap.add_argument("--json", default=None, help="write full results here")
+    ap.add_argument("--summary", default=os.environ.get("GITHUB_STEP_SUMMARY"))
+    ap.add_argument("--trials", type=int, default=3)
+    ap.add_argument("--max-requests", type=int, default=300,
+                    help="hard cap; past it remaining classifications are skipped AND logged")
+    ap.add_argument("--capture-only", action="store_true",
+                    help="extract + run commands, print captures, make NO gateway calls")
+    args = ap.parse_args()
+
+    binary = find_binary(args.binary)
+    if binary is None:
+        return 2
+    docs = json.loads(DOCS_PATH.read_text())["docs"]
+    print(f"binary  {binary}")
+    print(f"docs    {len(docs)}")
+
+    gw = None
+    if not args.capture_only:
+        try:
+            gw = gateway_from_env()
+        except SystemExit as exc:
+            print(f"cannot run: {exc}")
+            return 2
+        print(f"model   {gw.model}")
+        # Preflight: prove the gateway is actually reachable before spending a whole
+        # run's worth of docs against it. Mirrors gateway_smoke.py's "fail loudly
+        # here is the point" — a broken harness (per the interface contract) means
+        # unreachable, not merely "misclassified one block".
+        try:
+            gw.complete("Reply with the single word OK.", max_tokens=512)
+        except RuntimeError as exc:
+            print(f"cannot run: gateway unreachable — {exc}")
+            return 2
+    print("-" * 78)
+
+    doc_reports = []
+    all_skipped = []
+    for doc_rel in docs:
+        report, skipped = process_doc(doc_rel, binary, gw, args.capture_only, args.max_requests, args.trials)
+        doc_reports.append(report)
+        all_skipped.extend(skipped)
+        _print_doc_summary(report)
+
+    print("-" * 78)
+    totals = Counter()
+    verdicts = Counter()
+    for r in doc_reports:
+        for k, v in r["counts"].items():
+            totals[k] += v
+        for row in r["blocks"]:
+            if row["classify_status"] in ("match", "drift", "broken", "inconclusive"):
+                verdicts[row["classify_status"]] += 1
+    print(
+        f"totals  blocks={totals['blocks_total']}  "
+        f"commands run={totals['commands_run']} flagged={totals['commands_flagged_human_review']}  "
+        f"file-bodies={totals['file_bodies']}  "
+        f"prose flagged={totals['prose_blocks_flagged']}+sections={totals['prose_sections_flagged']}  "
+        f"anchors={totals['anchors_found']}"
+    )
+    if gw:
+        print(
+            f"judge   requests={gw.requests_made}  "
+            f"match={verdicts['match']} drift={verdicts['drift']} broken={verdicts['broken']} "
+            f"inconclusive={verdicts['inconclusive']}"
+        )
+    if all_skipped:
+        print(f"\nSKIPPED {len(all_skipped)} classification(s) at the {args.max_requests}-request "
+              f"cap: {', '.join(all_skipped)}")
+
+    if args.json:
+        pathlib.Path(args.json).write_text(json.dumps(
+            {
+                "binary": binary,
+                "model": gw.model if gw else None,
+                "capture_only": args.capture_only,
+                "requests_made": gw.requests_made if gw else 0,
+                "totals": dict(totals),
+                "verdicts": dict(verdicts),
+                "skipped_at_cap": all_skipped,
+                "docs": doc_reports,
+            },
+            indent=2,
+        ))
+
+    if args.summary:
+        lines = ["## Blind doc-walk", ""]
+        lines.append(
+            f"Binary: `{binary}` · {len(docs)} doc(s) · "
+            + (f"judge `{gw.model}` · {gw.requests_made} requests" if gw else "capture-only (no gateway calls)")
+        )
+        lines += ["", "| Doc | Blocks | Run | Flagged (human-review) | File bodies | Anchors |",
+                  "|---|---|---|---|---|---|"]
+        for r in doc_reports:
+            c = r["counts"]
+            lines.append(
+                f"| `{r['doc']}` | {c['blocks_total']} | {c['commands_run']} | "
+                f"{c['commands_flagged_human_review'] + c['prose_blocks_flagged'] + c['prose_sections_flagged']} | "
+                f"{c['file_bodies']} | {c['anchors_found']} |"
+            )
+        if gw:
+            lines += ["", f"Verdicts: match={verdicts['match']} · drift={verdicts['drift']} · "
+                          f"broken={verdicts['broken']} · inconclusive={verdicts['inconclusive']}"]
+            drifted = [
+                (r["doc"], row) for r in doc_reports for row in r["blocks"]
+                if row["classify_status"] in ("drift", "broken")
+            ]
+            if drifted:
+                lines += ["", "### Divergence found", ""]
+                for doc_rel, row in drifted:
+                    lines += [
+                        f"**`{doc_rel}` block #{row['index']}** (line {row['line_start']}, "
+                        f"`{row['classify_status']}`)",
+                        "", "```", row["output"][:600] if row["output"] else "(no output)", "```",
+                        "", f"> {row['classify_quote'][:300]}", "",
+                    ]
+        if all_skipped:
+            lines += ["", f"_Skipped at the request cap: {', '.join(all_skipped)}_"]
+        with open(args.summary, "a") as fh:
+            fh.write("\n".join(lines) + "\n")
+
+    # Soft tier: divergence verdicts never fail the run. Only a broken harness does,
+    # and that already returned 2 above.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/quality/docwalk/runner.py
+++ b/ci/quality/docwalk/runner.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Deterministic runner for the blind doc-walk harness (spec 005, P3).
+
+Executes exactly what `extract.py` pulled out of the doc — no repair, no
+substitution, no "obviously they meant". One sandbox **per doc**, not per block: a
+real reader walks a doc top to bottom in one working directory, so a manifest a doc
+creates in step 2 has to still be there for step 4. Isolating every block into its own
+throwaway sandbox (the way `ci/quality/error_quality` does per case) would make an
+internally-consistent multi-step doc look broken for no reason.
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import tempfile
+
+from extract import Block
+
+COMMAND_TIMEOUT = 60
+
+
+def run_doc_blocks(binary: str, blocks: list[Block]) -> None:
+    """Walk a doc's blocks in order in one persistent sandbox, mutating them in place.
+
+    Sets on each executed/staged block:
+        - block.output / block.exit_code / block.timed_out   (kind == "command", run)
+        - nothing on blocks that are never run — their `skip_reason` already explains
+          why, set by the extractor.
+
+    Deliberately does **not** pre-seed the sandbox with anything beyond an empty
+    directory. Extending the setup on the harness's own initiative (e.g. `mkdir
+    skills/` because a later `add` will need it) would be exactly the kind of silent
+    self-correction the whole design exists to avoid — if a doc's own steps do not
+    create a directory it later depends on, that is a real finding, not a harness bug.
+    """
+    with tempfile.TemporaryDirectory(prefix="fs-docwalk-") as tmp:
+        root = pathlib.Path(tmp)
+        env = {"PATH": os.environ.get("PATH", ""), "HOME": str(root), "TERM": "dumb"}
+
+        for block in blocks:
+            if block.kind == "file":
+                if block.filename:
+                    target = root / block.filename
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.write_text(block.raw)
+                    block.notes.append(f"written to sandbox as {block.filename!r}")
+                continue
+
+            if block.kind != "command" or not block.run:
+                continue
+
+            script = root / f"_docwalk_block_{block.index}.sh"
+            script.write_text(block.raw)
+            try:
+                proc = subprocess.run(
+                    ["bash", str(script)],
+                    cwd=root,
+                    capture_output=True,
+                    text=True,
+                    timeout=COMMAND_TIMEOUT,
+                    env=env,
+                    # Verbatim execution of a doc means no human is present to answer
+                    # a prompt. An interactive command (e.g. `fastskill init` with no
+                    # `--yes`) hits EOF immediately, exactly as it would for anyone
+                    # who actually piped this doc into a shell non-interactively.
+                    stdin=subprocess.DEVNULL,
+                )
+                out, err, code, timed_out = proc.stdout, proc.stderr, proc.returncode, False
+            except subprocess.TimeoutExpired:
+                out, err, code, timed_out = "", "", None, True
+
+            combined = "\n".join(part.strip() for part in (out, err) if part.strip())
+            combined = combined.replace(str(root), "<sandbox>")
+            block.output = combined
+            block.exit_code = code
+            block.timed_out = timed_out


### PR DESCRIPTION
## Summary

Implements P3 of spec 005 (`specs/005-llm-backed-qa-quality-tier.md` section "2. Blind
doc-walk — the split harness"): a three-stage harness over the 4 settled webdocs
(`quickstart.mdx`, `skill-management/validation.mdx`, `configuration/init-command.mdx`,
`skill-management/reconciliation.mdx`) that never lets the LLM decide what runs:

- **`extract.py`** (deterministic) — pulls fenced code blocks out of the `.mdx`, in
  order, verbatim, handling indented (2-4 space) fences. Classifies each as
  command / file-body / prose, pre-filters and **flags** (never silently drops)
  `$`-prefixed illustrative blocks, placeholder-containing blocks, and network
  installers. Also finds expected-output anchors: the inline `# Output:` comment
  convention, a bare fence immediately after a command, and "you should see…" prose
  claims.
- **`runner.py`** (deterministic) — executes runnable blocks exactly as written, one
  sandbox **per doc** (not per block, so a manifest a doc creates in step 2 is still
  there in step 4), `stdin=DEVNULL` so an interactive command hits EOF instead of
  hanging.
- **`classify.py`** (LLM, reuses `error_quality/judge.py`'s `Gateway` /
  `strip_reasoning` / `extract_json`) — the *only* place an LLM appears; it compares
  doc-claimed output to actual output and labels `match`/`drift`/`broken`. There is no
  "corrected command" field anywhere in its schema.
- **`run_docwalk.py`** — entry point matching the interface contract another agent's
  workflow depends on: `--json`/`--summary`/`--max-requests`/`--capture-only`/`--binary`,
  same `LLM_GATEWAY_*` env as P2, exit 0 for any verdict (soft tier), exit 2 only for a
  broken harness (no binary, or a gateway that fails a connectivity preflight).

## Verified

- `--capture-only` runs end-to-end with **zero** gateway credentials: 45 blocks across
  the 4 docs, 23 commands run, 9 flagged human-review, 10 file bodies, 34 prose-section
  flags, 9 expected-output anchors found.
- A live run against `claude-haiku-4-5` (22 gateway requests, well under the 300 cap)
  classified the 7 blocks that had both a captured run and an anchor: 0 match, 1 drift,
  6 broken, 0 inconclusive. It independently surfaced two real doc bugs:
  - `quickstart.mdx`'s own manifest example is missing `[tool.fastskill]` /
    `skills_directory`, breaking every later step in that walkthrough.
  - `reconciliation.mdx`'s `fastskill list` examples assume a project that this
    reference-style doc never sets up within itself (4 of the 6 `broken` verdicts
    share this one root cause).
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets
  --all-features` both pass; pre-commit and pre-push hooks (fmt, clippy, full nextest
  suite, doc build) ran clean.
- Test key `fastskill-p3-test` was minted, used, and deleted from the gateway; no key
  material was printed at any point.

See `ci/quality/docwalk/README.md` for full extraction rules, sandboxing rationale,
and the first-live-run writeup.

## Test plan

- [x] `--capture-only` runs with no gateway env vars set, exits 0
- [x] Missing `--binary` exits 2
- [x] Missing gateway env vars (non-`--capture-only`) exits 2
- [x] Live run against the gateway produces real classifications and exits 0
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features`
- [x] Pre-commit and pre-push hooks passed (fmt, clippy, nextest, doc build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPWdJZDbVTzy3rBcgbP1E8