### PR TITLE
ci(quality): nightly soft quality tier workflow (spec 005 P4)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -46,13 +46,12 @@ on:
     # nightly-agent-e2e slot (06:00 UTC) so the two don't contend for the same
     # shared gateway at the same moment.
     - cron: "17 3 * * *"
+  # Verified green on this branch before merge via a temporary push trigger, since
+  # workflow_dispatch requires the file to already be on the default branch. That
+  # trigger has been removed — run 32115238301 is the evidence: 8 cases judged over
+  # 24 gateway requests from inside the container, doc-walk correctly skipped as
+  # absent, job green with one poor finding (soft tier holding).
   workflow_dispatch: {}
-  # TEMPORARY: workflow_dispatch requires the workflow file to already be on
-  # the default branch, which this PR branch is not yet. Scoped to this exact
-  # branch only, purely so the run can be verified green before merge; removed
-  # before this PR is finished (same procedure quality-gateway-smoke.yml used).
-  push:
-    branches: [ci/nightly-quality-workflow]
 
 permissions:
   contents: read

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -47,6 +47,12 @@ on:
     # shared gateway at the same moment.
     - cron: "17 3 * * *"
   workflow_dispatch: {}
+  # TEMPORARY: workflow_dispatch requires the workflow file to already be on
+  # the default branch, which this PR branch is not yet. Scoped to this exact
+  # branch only, purely so the run can be verified green before merge; removed
+  # before this PR is finished (same procedure quality-gateway-smoke.yml used).
+  push:
+    branches: [ci/nightly-quality-workflow]
 
 permissions:
   contents: read

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,165 @@
+name: Nightly Quality
+
+# The nightly SOFT quality tier (spec 005, P4): the LLM-judge error-message-quality
+# suite and the blind doc-walk suite, run in an ephemeral container built from HEAD,
+# reached over the Tailnet to the shared LLM gateway.
+#
+# This tier must NEVER fail the branch on a finding — a poor error message or doc
+# drift is a report, not a failure (spec 005). Only the harness itself breaking (no
+# binary, an unreachable gateway) fails the job; see ci/quality/entrypoint.sh for
+# exactly how that distinction is enforced. It sits entirely beside the PR gate
+# (test.yml, `cargo fmt --check` + `cargo nextest`), which stays hard and
+# deterministic and is not touched by this workflow.
+#
+# P4 may land before P3 (spec 005 doc-walk, ci/quality/docwalk/run_docwalk.py does
+# not exist yet). The container tolerates that file being absent and skips the
+# doc-walk step with a clear note in the summary rather than failing — see
+# ci/quality/entrypoint.sh. Do not add a stub of that file here; it belongs to a
+# different PR landing in parallel.
+#
+# Ephemeral container for the whole tier is mandatory, not merely prudent (spec 005
+# Q8): the doc-walk suite runs commands verbatim out of the shipped docs, which
+# contain `curl | bash`, `sudo`, and `~/.claude*` writes (pre-filtered by the
+# extractor and never actually run, but the container is still the blast-radius
+# boundary). fastskill is built from HEAD *inside* the image every run (Q1), so the
+# tier always exercises the binary this branch actually produces.
+#
+# Required repo secrets (all five, else the job SKIPS with a warning rather than
+# fails, so forks and repos without the secrets stay green):
+#   TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET  — Tailscale OAuth client, tag:ci
+#   LLM_GATEWAY_URL                       — gateway base URL on the Tailnet
+#   LLM_GATEWAY_KEY                       — virtual key (sk-…), budget-scoped
+#   LLM_GATEWAY_MODEL                     — judge model pin (currently
+#                                            claude-haiku-4-5 — spec 005 P2 found it
+#                                            both cheaper and better-calibrated than
+#                                            the local-model alias)
+#
+# Cost guards (spec 005 Q6/Q12): 300 gateway requests total per run, split
+# explicitly 120 (error-quality) / 180 (doc-walk) rather than first-suite-wins — see
+# ci/quality/entrypoint.sh for the budget reasoning. timeout-minutes: 60 below is the
+# outer backstop for the 60-job-minute cap; the per-suite --max-requests caps inside
+# the container are the primary guard and log exactly what gets skipped if hit.
+
+on:
+  schedule:
+    # 03:17 UTC nightly — off the hour, and deliberately not aikit's
+    # nightly-agent-e2e slot (06:00 UTC) so the two don't contend for the same
+    # shared gateway at the same moment.
+    - cron: "17 3 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  # Required by tailscale/github-action to mint an OIDC token for OAuth.
+  id-token: write
+
+concurrency:
+  group: nightly-quality
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Nightly quality tier (error-message judge + doc-walk)
+    runs-on: ubuntu-latest
+    # Outer backstop for the 60-job-minute cost guard (spec 005 Q6/Q12).
+    timeout-minutes: 60
+    steps:
+      - name: Verify secrets are configured
+        id: guard
+        env:
+          TS_OAUTH_CLIENT_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          TS_OAUTH_SECRET: ${{ secrets.TS_OAUTH_SECRET }}
+          LLM_GATEWAY_URL: ${{ secrets.LLM_GATEWAY_URL }}
+          LLM_GATEWAY_KEY: ${{ secrets.LLM_GATEWAY_KEY }}
+          LLM_GATEWAY_MODEL: ${{ secrets.LLM_GATEWAY_MODEL }}
+        run: |
+          missing=""
+          for v in TS_OAUTH_CLIENT_ID TS_OAUTH_SECRET LLM_GATEWAY_URL \
+                   LLM_GATEWAY_KEY LLM_GATEWAY_MODEL; do
+            [ -z "${!v}" ] && missing="$missing $v"
+          done
+          if [ -n "$missing" ]; then
+            echo "::warning::gateway/Tailscale secrets not configured — skipping the nightly quality tier:$missing"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout code
+        if: steps.guard.outputs.run == 'true'
+        uses: actions/checkout@v6
+
+      - name: Connect to the Tailnet
+        if: steps.guard.outputs.run == 'true'
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          # Must be authorized in the Tailscale ACL `tagOwners`; the node is
+          # ephemeral and auto-removed when the job ends.
+          tags: tag:ci
+
+      - name: Set up Docker Buildx
+        if: steps.guard.outputs.run == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build the quality image (fastskill built from HEAD inside)
+        if: steps.guard.outputs.run == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ci/quality/Dockerfile
+          tags: fastskill-quality:ci
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Prepare output directory
+        if: steps.guard.outputs.run == 'true'
+        run: |
+          mkdir -p "${{ github.workspace }}/quality-out"
+          # 777: the container runs as a non-root user whose uid may not match
+          # the runner's; the bind mount needs to be writable regardless.
+          chmod 777 "${{ github.workspace }}/quality-out"
+
+      - name: Run the quality suites (ephemeral container, throwaway $HOME)
+        if: steps.guard.outputs.run == 'true'
+        env:
+          LLM_GATEWAY_URL: ${{ secrets.LLM_GATEWAY_URL }}
+          LLM_GATEWAY_KEY: ${{ secrets.LLM_GATEWAY_KEY }}
+          LLM_GATEWAY_MODEL: ${{ secrets.LLM_GATEWAY_MODEL }}
+        run: |
+          # --network host: the container reuses the runner's Tailnet join
+          # (established on the host above) to reach the internal gateway —
+          # same pattern as aikit's nightly-agent-e2e.yml.
+          docker run --rm --network host \
+            -e LLM_GATEWAY_URL \
+            -e LLM_GATEWAY_KEY \
+            -e LLM_GATEWAY_MODEL \
+            -v "${{ github.workspace }}/quality-out:/out" \
+            fastskill-quality:ci
+
+      - name: Append findings to the job summary
+        # always(): still show whatever the container produced even if the run
+        # step above exited non-zero (infra failure) — the report is diagnostic
+        # evidence, not proof of success.
+        if: steps.guard.outputs.run == 'true' && always()
+        run: |
+          if [ -f "${{ github.workspace }}/quality-out/summary.md" ]; then
+            cat "${{ github.workspace }}/quality-out/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Nightly quality tier"
+              echo ""
+              echo "_No summary was produced — the container likely failed before writing output; check the run logs._"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload quality reports
+        if: steps.guard.outputs.run == 'true' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-reports
+          path: quality-out/
+          if-no-files-found: warn
+          retention-days: 30

--- a/ci/quality/Dockerfile
+++ b/ci/quality/Dockerfile
@@ -1,0 +1,47 @@
+# Ephemeral image for the nightly quality tier (spec 005, P4).
+#
+# Mandatory per spec 005 Q8, not merely prudent: the doc-walk suite this image runs
+# executes commands *verbatim* out of the shipped docs, and the docs contain `curl |
+# bash`, `sudo`, and `~/.claude*` writes (those specific patterns are pre-filtered by
+# the extractor and never run — see specs/005, "Extractor rules" — but the container
+# is still the blast-radius boundary in case that filter is ever wrong). $HOME is
+# thrown away with the container on every run; nothing here is expected to persist.
+#
+# fastskill is built from HEAD *inside* this image every run (spec 005 Q1) so the
+# tier always tests the binary the branch under test actually produces, not a stale
+# release. rust-toolchain.toml pins the nightly channel; rustup (bundled in the base
+# image) resolves and installs it automatically from that file.
+
+# ---- build stage: compile the fastskill binary ----
+FROM rust:bookworm AS build
+WORKDIR /src
+COPY . .
+RUN cargo build --release --bin fastskill
+
+# ---- runtime stage: fastskill binary + Python quality harness ----
+# Stdlib-only Python (see ci/quality/error_quality/judge.py) so no pip install is
+# needed here; if a future suite needs third-party packages it must vendor or pip
+# install them explicitly in its own directory, not assume this image has network
+# access to PyPI at run time (it does, over the Tailnet's default route, but the
+# quality tier itself should not depend on that).
+FROM python:3.12-slim-bookworm AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /src/target/release/fastskill /usr/local/bin/fastskill
+COPY ci/quality /app/ci/quality
+RUN chmod +x /app/ci/quality/entrypoint.sh
+
+# Non-root, throwaway $HOME. Doc-walk cases that write to ~/.claude* land here and
+# vanish with the container; nothing under /app is meant to survive between runs
+# either, only what the entrypoint copies out to the bind-mounted /out.
+RUN useradd --create-home --home-dir /home/quality --shell /bin/bash quality
+ENV HOME=/home/quality
+USER quality
+WORKDIR /app
+
+# LLM_GATEWAY_URL / LLM_GATEWAY_KEY / LLM_GATEWAY_MODEL are injected at `docker run`
+# time from repo secrets (see .github/workflows/quality.yml) — never baked in here.
+ENTRYPOINT ["/app/ci/quality/entrypoint.sh"]

--- a/ci/quality/entrypoint.sh
+++ b/ci/quality/entrypoint.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Entrypoint for the nightly quality container (spec 005, P4).
+#
+# Runs both suites of the nightly soft tier and merges their output. This tier must
+# NEVER fail the branch on findings (spec 005: "a poor error message or doc drift is
+# a report, not a failure") — only genuine infrastructure breakage (no binary, an
+# unreachable gateway, a malformed harness) should surface as a failed job. Both
+# suites signal that distinction the same way: exit 0 means "ran" regardless of what
+# it found, exit 2 means "could not run at all". This script fails (non-zero exit,
+# which fails the docker run step and therefore the job) only on a 2 from either
+# suite; a "poor" or "drift" verdict inside a 0 exit never does.
+#
+# Budget split (spec 005 Q6/Q12 — 300 gateway requests total per run, shared across
+# both suites): 120 to error-quality, 180 to doc-walk, set explicitly here rather
+# than left to whichever suite runs first. Reasoning: error-quality's live suite is
+# currently 8 cases x 3 trials = 24 requests (see ci/quality/error_quality/README.md)
+# so 120 is 5x headroom for the case set to grow ("extend as new error paths land",
+# spec 005 §1) without a workflow edit. Doc-walk classifies every runnable block
+# across 4 docs (spec 005 Q10) — a larger, still-growing corpus — so it gets the
+# larger share. 120 + 180 = 300 exactly: the two caps together ARE the total cap,
+# not an independent limit layered on top of it.
+#
+# P4 may land before P3 (spec 005 doc-walk, ci/quality/docwalk/run_docwalk.py). A
+# sibling PR not having merged yet is not an infrastructure failure, so this script
+# checks for that file and skips the step with a clear note instead of erroring —
+# and it must NOT be stubbed out here (that file belongs to the other PR).
+
+set -uo pipefail
+
+OUT="${QUALITY_OUT:-/out}"
+mkdir -p "$OUT"
+SUMMARY="$OUT/summary.md"
+: > "$SUMMARY"
+
+ERROR_MAX="${ERROR_QUALITY_MAX_REQUESTS:-120}"
+DOCWALK_MAX="${DOCWALK_MAX_REQUESTS:-180}"
+BINARY="/usr/local/bin/fastskill"
+
+infra_broke=0
+
+echo "================================================================================"
+echo "error-message quality  (cap: ${ERROR_MAX} gateway requests)"
+echo "================================================================================"
+python3 ci/quality/error_quality/run_suite.py \
+    --binary "$BINARY" \
+    --json "$OUT/error_quality.json" \
+    --summary "$SUMMARY" \
+    --max-requests "$ERROR_MAX"
+error_rc=$?
+echo "error-quality exit code: $error_rc"
+if [ "$error_rc" -eq 2 ]; then
+    echo "INFRA FAILURE: error-quality suite could not run (exit 2)." >&2
+    infra_broke=1
+elif [ "$error_rc" -ne 0 ]; then
+    echo "INFRA FAILURE: error-quality suite exited $error_rc (expected 0 or 2)." >&2
+    infra_broke=1
+fi
+
+DOCWALK_SCRIPT="ci/quality/docwalk/run_docwalk.py"
+echo
+echo "================================================================================"
+if [ -f "$DOCWALK_SCRIPT" ]; then
+    echo "doc-walk drift  (cap: ${DOCWALK_MAX} gateway requests)"
+    echo "================================================================================"
+    python3 "$DOCWALK_SCRIPT" \
+        --binary "$BINARY" \
+        --json "$OUT/docwalk.json" \
+        --summary "$SUMMARY" \
+        --max-requests "$DOCWALK_MAX"
+    docwalk_rc=$?
+    echo "docwalk exit code: $docwalk_rc"
+    if [ "$docwalk_rc" -eq 2 ]; then
+        echo "INFRA FAILURE: doc-walk suite could not run (exit 2)." >&2
+        infra_broke=1
+    elif [ "$docwalk_rc" -ne 0 ]; then
+        echo "INFRA FAILURE: doc-walk suite exited $docwalk_rc (expected 0 or 2)." >&2
+        infra_broke=1
+    fi
+else
+    echo "doc-walk drift  SKIPPED"
+    echo "================================================================================"
+    echo "$DOCWALK_SCRIPT does not exist on this ref yet (spec 005 P3 not merged)."
+    echo "This is expected if P4 landed before P3 — not treated as an infra failure."
+    {
+        echo ""
+        echo "## Doc-walk drift"
+        echo ""
+        echo "_Skipped: \`$DOCWALK_SCRIPT\` does not exist on this ref yet (spec 005 P3)._"
+    } >> "$SUMMARY"
+fi
+
+echo
+if [ "$infra_broke" -eq 1 ]; then
+    echo "One or more suites could not run at all — failing the job." >&2
+    exit 1
+fi
+
+echo "Nightly quality tier ran to completion (soft tier: findings above never fail this job)."
+exit 0


### PR DESCRIPTION
Schedules the quality tier. Until now everything built in P1–P3 was runnable only by hand; this is what makes it run on its own.

## Verified by an actual run, not a green check

[Run 32115238301](https://github.com/gofastskill/fastskill/actions/runs/32115238301), from the log:

```
error-message quality  (cap: 120 gateway requests)
binary  /usr/local/bin/fastskill
cases   8
ok       read_not_found                       score=5.0
...
POOR     repos_skills_unknown_repo            score=2.0
ok       install_without_dependencies_section  score=5.0
judged 8  poor 1  broken 0  skipped 0  requests 24
error-quality exit code: 0

doc-walk drift  SKIPPED
ci/quality/docwalk/run_docwalk.py does not exist on this ref yet (spec 005 P3 not merged).
This is expected if P4 landed before P3 — not treated as an infra failure.

Nightly quality tier ran to completion (soft tier: findings above never fail this job).
```

This distinction matters: the secret guard **skips and still succeeds** by design, so a green check alone would not prove anything ran. The log confirms the guard passed, the container built fastskill from HEAD, the gateway was reached over the Tailnet, and 24 real requests were spent. It also reproduced the same single poor message found locally, from a completely different environment.

## Design

| | |
|---|---|
| Schedule | `17 3 * * *` — off the hour, and deliberately not aikit’s 06:00 slot, so the two don’t contend for the same shared gateway |
| Isolation | Ephemeral container (Q8), fastskill built from HEAD **inside** the image (Q1) |
| Budget | **120 error-quality / 180 doc-walk = 300 exactly** |
| Guards | `timeout-minutes: 60`, `concurrency: cancel-in-progress` |
| Reporting | Job summary + uploaded artifact only — pull-based (Q7) |
| Missing secrets | Skips with a warning, so forks stay green |

**On the budget split:** divided explicitly rather than first-suite-wins, which would let the error suite starve the doc-walk. The error suite uses 24 requests today (8 cases × 3 trials), so 120 is 5× headroom for the case set to grow; doc-walk gets the larger share as the block-count-driven consumer.

**On the container:** mandatory rather than prudent (Q8). The doc-walk suite runs commands verbatim out of the shipped docs, which contain `curl | bash`, `sudo`, and `~/.claude*` writes. Those are pre-filtered by P3’s extractor and never actually executed, but the container is the blast-radius boundary regardless.

**On P3:** this tolerates `ci/quality/docwalk/run_docwalk.py` being absent and skips that step with a clear note — proven by the run above, which executed before P3 merged. Either merge order works; merging #263 first just means the first nightly actually walks the docs. No stub of that file is created here, deliberately, to avoid a conflict with #263.

## Soft tier

One poor finding, job still green. A poor error message or doc drift is a report, not a failure. Only a broken harness — no binary, unreachable gateway — fails the job.

The temporary `push:` trigger used to verify the run pre-merge has been removed; leaving it would fire the whole tier, and spend gateway budget, on every push to a branch of that name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)